### PR TITLE
Added new SQLAlchemy and Django checks

### DIFF
--- a/python/django/performance-improvements.yaml
+++ b/python/django/performance-improvements.yaml
@@ -1,0 +1,6 @@
+rules:
+  - id: access-foreign-keys
+    pattern: $X.user.id
+    message: "You should use ITEM.user_id rather than ITEM.user.id to prevent running an extra query."
+    languages: [python]
+    severity: WARNING

--- a/python/sqlalchemy/delete-where.yaml
+++ b/python/sqlalchemy/delete-where.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: delete-where-no-execute
+    patterns: 
+      - pattern-not: $X.delete().where(...).execute()
+      - pattern-not: $X.delete().where(...).$Y.execute()
+      - pattern: $X.delete().where(...)
+    message: ".delete().where(...) results in a no-op in SQLAlchemy unless the command is executed, use .filter(...).delete() instead."
+    languages: [python]
+    severity: ERROR

--- a/python/sqlalchemy/performance-improvements.yaml
+++ b/python/sqlalchemy/performance-improvements.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: len-all-count
+    pattern: len($X.all())
+    message: "Using QUERY.count() instead of len(QUERY.all()) sends less data to the client since the SQLAlchemy method is performed server-side."
+    languages: [python]
+    severity: WARNING
+  - id: batch-import
+    pattern: |
+      for $X in $Y:
+        db.session.add($Z)
+    message: "Rather than adding one element at a time, consider batch loading to improve performance."
+    languages: [python]
+    severity: WARNING


### PR DESCRIPTION
### Overview

- `delete-where-no-execute`: Running `delete().where(...)` without execution in Sqlachemy results in a no-op. An alternative is to run `filter(...).delete()` instead.
- `access-foreign-keys`: Instead of using `.user.id`, which calls an extra query, you can run `.user_id` for most databases 
- `len-all-count`: Running `.count()` rather than `len(...all())` sends less data to the client since the method is performed server side, so this results in a performance improvement.
- `batch-import`: Rather than adding elements one at a time from Sqlalchemy, batch imports can be performed such as 

```
batch = []
insert_stmt = Object.__table__.insert()
for $X in $Y:
    if len(batch) > 1000:
       db.session.execute(insert_stmt, batch)
       batch.clear()
    batch.append($X)
if batch:
    db.session.execute(insert_stmt, batch)
```

### Test Plan

- Scrape GitHub repositories
- Use r2c-isg to create inputset
- Add to platform via r2c CLI
- Verify that the check is relevant/not noisy on platform 

### Resources
[Sqlachemy fixes](https://dev.to/zchtodd/sqlalchemy-performance-anti-patterns-and-their-fixes-4bmm)