### PR TITLE
Add send_file warning

### DIFF
--- a/python/flask/secure-static-file-serve.yaml
+++ b/python/flask/secure-static-file-serve.yaml
@@ -3,9 +3,12 @@
 # https://stackoverflow.com/questions/20646822/how-to-serve-static-files-in-flask
 rules:
   - id: avoid_send_file_without_path_sanitization
-    pattern: |
-      def $X():
-        ...
+    patterns:
+      - pattern-inside: |
+          def $X(filename):
+            ...
+      - pattern-either:
+        - pattern: flask.send_file(filename, ...)
     message: Looks like `filename` could flow to `flask.send_file()` function. Make sure to properly sanitize filename or use `flask.send_from_directory`
     languages: [python]
     severity: WARNING

--- a/python/flask/secure-static-file-serve.yaml
+++ b/python/flask/secure-static-file-serve.yaml
@@ -4,8 +4,8 @@
 rules:
   - id: avoid_send_file_without_path_sanitization
     pattern: |
-      def $X(filename: $Y, ...):
-        flask.send_file(...)
+      def $X():
+        ...
     message: Looks like `filename` could flow to `flask.send_file()` function. Make sure to properly sanitize filename or use `flask.send_from_directory`
     languages: [python]
     severity: WARNING

--- a/python/flask/secure-static-file-serve.yaml
+++ b/python/flask/secure-static-file-serve.yaml
@@ -1,0 +1,11 @@
+# For Flask app to serve file securely, it should use `send_from_directory` method
+# The other methods like `send_file` or `send_static_file` are not recommended per
+# https://stackoverflow.com/questions/20646822/how-to-serve-static-files-in-flask
+rules:
+  - id: avoid_send_file_without_path_sanitization
+    pattern: |
+      def $X(filename: $Y, ...):
+        flask.send_file(...)
+    message: Looks like `filename` could flow to `flask.send_file()` function. Make sure to properly sanitize filename or use `flask.send_from_directory`
+    languages: [python]
+    severity: WARNING

--- a/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py
+++ b/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py
@@ -1,0 +1,7 @@
+import flask
+
+app = Flask(__name__)
+
+@app.route('/uploads/<path:filename>')
+def download_file(filename):
+  return send_file(filename)

--- a/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py
+++ b/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py
@@ -1,7 +1,6 @@
-import flask
+from flask import send_file
 
 app = Flask(__name__)
 
-@app.route('/uploads/<path:filename>')
-def download_file(filename):
-  return send_file(filename)
+def download_file():
+  return send_file()

--- a/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py
+++ b/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py
@@ -2,5 +2,6 @@ from flask import send_file
 
 app = Flask(__name__)
 
-def download_file():
-  return send_file()
+@app.route("/<path:filename>")
+def download_file(filename):
+  return send_file(filename)


### PR DESCRIPTION
Adds a check when there might be a dataflow from user input to a sink.
"How to serve static files in Flask" is the most asked question in Stackoverflow for Flask. Hence, this will be a popular check if we do it right.

Pending `def $X(filename: $Y, ...):` support integration in https://github.com/returntocorp/sgrep. 

Testing: 
1) Run rule 
```
sgrep-lint ~/Workspace/sgrep-rules/python/flask/secure-static-file-serve.yaml ~/Workspace/sgrep-rules/tests/python/flask/send_static_file/test_send_file_without_path_sanitization.py| jq
```
2) See it fire on 
```
@app.route("/<path:filename>")
def download_file(filename):
  return send_file(filename) .  ## CATCHES THIS
```