### PR TITLE
find variables used in strings that should probably be fstrings

### DIFF
--- a/python/deadcode/missing-fstring.yaml
+++ b/python/deadcode/missing-fstring.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: should-be-fstring
+    patterns:
+      - pattern: |
+          $X = $Y
+          ...
+          print('...{$X}...')
+    message: "possibly missing an f-string specifier for string containing variable $X"
+    languages: [python]
+    severity: WARNING

--- a/tests/python/deadcode/missing-fstring.py
+++ b/tests/python/deadcode/missing-fstring.py
@@ -1,0 +1,3 @@
+x = y
+print('hi')
+print('now {x} is {y}')


### PR DESCRIPTION
not currently working; cc @aryx ; I'm not sure on the right syntax to use inside the print(...) specifier:

`print('...{$X}...')`