### PR TITLE
Fixed Sqlachemy check and added new tests

### DIFF
--- a/java/basic-rules.yaml
+++ b/java/basic-rules.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: assignment-comparison
+    patterns: 
+      - pattern: if($X=true) {}
+      - pattern: if($X=false) {}
+    message: "This exception is being ignored. The best practice is to handle exceptions, throw them and show an error dialogue, or add a message to the log."
+    languages: [java]
+    severity: ERROR

--- a/python/sqlalchemy/delete-where.yaml
+++ b/python/sqlalchemy/delete-where.yaml
@@ -1,9 +1,8 @@
 rules:
   - id: delete-where-no-execute
     patterns: 
-      - pattern-not: $X.delete().where(...).execute()
-      - pattern-not: $X.delete().where(...).$Y.execute()
       - pattern: $X.delete().where(...)
+      - pattern-not-inside: $X.delete().where(...).execute()
     message: ".delete().where(...) results in a no-op in SQLAlchemy unless the command is executed, use .filter(...).delete() instead."
     languages: [python]
     severity: ERROR

--- a/tests/java/assignment-comparison.java
+++ b/tests/java/assignment-comparison.java
@@ -1,0 +1,10 @@
+class Bar {
+    void main() {
+        boolean myBoolean; 
+
+        if (myBoolean = true) {
+            continue;
+        }
+
+    } 
+} 

--- a/tests/python/django/sensitive-variables.py
+++ b/tests/python/django/sensitive-variables.py
@@ -1,0 +1,7 @@
+import sensitive_variables
+
+@sensitive_variables('user', 'pw', 'cc')
+def process_info(user):
+    pw = user.pass_word
+    cc = user.credit_card_number
+    name = user.name

--- a/tests/python/sqlalchemy/delete-where.py
+++ b/tests/python/sqlalchemy/delete-where.py
@@ -1,0 +1,3 @@
+delete = table.delete().where(table.post_id == post_id).execute()
+
+delete = table.delete().where(table.post_id == post_id)

--- a/tests/python/sqlalchemy/performance-test.py
+++ b/tests/python/sqlalchemy/performance-test.py
@@ -1,0 +1,4 @@
+for song in songs:
+    db.session.add(song)
+
+len(persons.all())


### PR DESCRIPTION
The conditions were incorrect for the initial Sqlachemy check, so I fixed the pattern matching. I also added tests to start the process of verifying the Django, Sqlachemy, and Java checks. 

### Test plan
- In pfff: 
`./configure && make depend && make && make opt`
- In sgrep: 
```
dune build
cp ./_build/default/bin/main_sgrep.exe /usr/local/bin/sgrep
cp ./sgrep.py /usr/local/bin/sgrep-lint
sgrep-lint <YAML_FILE_OR_DIRECTORY> <code to check>
```

Alternatively
```
./_build/default/bin/main_sgrep.exe -lang <java/python/javascript/etc> -e '<pattern>' /path/to/java/dir/
```