### PR TITLE
Reimplements jsonify check in sgrep

### DIFF
--- a/python/flask/use-jsonify/use-jsonify.py
+++ b/python/flask/use-jsonify/use-jsonify.py
@@ -1,0 +1,24 @@
+## Normal import
+import flask
+import json
+app = flask.Flask(__name__)
+
+@app.route("/user")
+def user():
+    user_dict = get_user(request.args.get("id"))
+    # ruleid:use-jsonify
+    return json.dumps(user_dict)
+
+from json import dumps
+
+@app.route("/user")
+def user():
+    user_dict = get_user(request.args.get("id"))
+    # ruleid:use-jsonify
+    return dumps(user_dict)
+
+# should not catch the following
+def dumps():
+  pass
+def test_empty_dumps():
+    dumps()

--- a/python/flask/use-jsonify/use-jsonify.yaml
+++ b/python/flask/use-jsonify/use-jsonify.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: use-jsonify
+    patterns:
+      - pattern-inside: |
+          @app.route(...)
+          def $X():
+            ...
+      - pattern-either:
+        - pattern: json.dumps(...)
+        - pattern: return json.dumps(...)
+    message: "flask.jsonify() is a Flask helper method which handles the correct settings for returning JSON from Flask routes"
+    languages: [python]
+    severity: ERROR


### PR DESCRIPTION
We have https://checks.bento.dev/en/latest/flake8-flask/use-jsonify/
this re-does it in sgrep in 1/10 the time it took.

Addresses https://github.com/returntocorp/sgrep-rules/issues/123