### PR TITLE
Initial set of django 2.0 compatibility rules

### DIFF
--- a/python/django/django-2_0-compat.py
+++ b/python/django/django-2_0-compat.py
@@ -1,0 +1,56 @@
+class SignalsWeak:
+    from django.dispatch.signals.Signal import disconnect
+    # ruleid: django-compat-2_0-signals-weak
+    disconnect(weak=True)
+    # ok
+    disconnect()
+
+class CheckAggregateSupport:
+    from django.db.backends.base.BaseDatabaseOperations import check_aggregate_support
+    # ruleid: django-compat-2_0-check-aggregate-support
+    check_aggregate_support()
+
+class FormsExtras:
+    # ruleid: django-compat-2_0-extra-forms
+    from django.forms import extras
+
+    # ruleid: django-compat-2_0-extra-forms
+    from django.forms.extras import a
+
+    # ruleid: django-compat-2_0-extra-forms
+    from django.forms import extras as a
+
+    # ruleid: django-compat-2_0-extra-forms
+    from django.forms.extras import a as b
+
+    # ruleid: django-compat-2_0-extra-forms
+    import django.forms.extras
+
+    # ruleid: django-compat-2_0-extra-forms
+    import django.forms.extras as extras
+
+    # ruleid: django-compat-2_0-extra-forms
+    import django.forms.extras.a
+
+    # ruleid: django-compat-2_0-extra-forms
+    import django.forms.extras.a as b
+
+class AssertRedirects:
+    # ruleid: django-compat-2_0-assert-redirects-helper
+    self.assertRedirects(expected_url="https://my.host/foo/bar", host="my.host")
+
+    # ok
+    self.assertRedirects(expected_url="https://my.host/foo/bar")
+
+    # ruleid: django-compat-2_0-assert-redirects-helper
+    assertRedirects(expected_url="https://my.host/foo/bar", host="my.host")
+
+    # ok
+    assertRedirects(expected_url="https://my.host/foo/bar")
+
+class AssignmentHelper:
+    # ruleid: django-compat-2_0-assignment-tag
+    Library().assignment_tag(settings)
+
+    # ruleid: django-compat-2_0-assignment-tag
+    assignment_tag(settings)

--- a/python/django/django-2_0-compat.yaml
+++ b/python/django/django-2_0-compat.yaml
@@ -1,0 +1,42 @@
+rules:
+  - id: django-compat-2_0-signals-weak
+    pattern: django.dispatch.signals.Signal.disconnect(..., weak=$X, ...)
+    message: The weak argument to django.dispatch.signals.Signal.disconnect() is removed in Django 2.0.
+    languages: [python]
+    severity: WARNING
+  - id: django-compat-2_0-check-aggregate-support
+    pattern: django.db.backends.base.BaseDatabaseOperations.check_aggregate_support(...)
+    message: django.db.backends.base.BaseDatabaseOperations.check_aggregate_support() is removed in Django 2.0.
+    languages: [python]
+    severity: WARNING
+  - id: django-compat_2_0-extra-forms
+    patterns:
+      - pattern-either:
+        - pattern: from django.forms import extras
+        - pattern: from django.forms.extras import $X
+        - pattern: from django.forms import extras as $Y
+        - pattern: from django.forms.extras import $X as $Y
+        - pattern: import django.forms.extras
+        - pattern: import django.forms.extras.$X
+        - pattern: import django.forms.extras as $Y
+        - pattern: import django.forms.extras.$X as $Y
+    message: The django.forms.extras package is removed in Django 2.0.
+    languages: [python]
+    severity: WARNING
+  - id: django-compat_2_0-assignment-tag
+    patterns:
+      - pattern-either:
+          - pattern: $X.assignment_tag(...)
+          - pattern: assignment_tag(...)
+    message: The assignment_tag helper is removed in Django 2.0.
+    languages: [python]
+    severity: WARNING
+  - id: django-compat_2_0-assert-redirects-helper
+    patterns:
+      - pattern-either:
+          - pattern: $X.assertRedirects(..., host=$Y, ...)
+          - pattern: assertRedirects(..., host=$Y, ...)
+    message: The host argument to assertRedirects is removed in Django 2.0.
+    languages: [python]
+    severity: WARNING
+

--- a/python/django/django-2_0-compat.yaml
+++ b/python/django/django-2_0-compat.yaml
@@ -9,7 +9,7 @@ rules:
     message: django.db.backends.base.BaseDatabaseOperations.check_aggregate_support() is removed in Django 2.0.
     languages: [python]
     severity: WARNING
-  - id: django-compat_2_0-extra-forms
+  - id: django-compat-2_0-extra-forms
     patterns:
       - pattern-either:
         - pattern: from django.forms import extras
@@ -23,7 +23,7 @@ rules:
     message: The django.forms.extras package is removed in Django 2.0.
     languages: [python]
     severity: WARNING
-  - id: django-compat_2_0-assignment-tag
+  - id: django-compat-2_0-assignment-tag
     patterns:
       - pattern-either:
           - pattern: $X.assignment_tag(...)
@@ -31,7 +31,7 @@ rules:
     message: The assignment_tag helper is removed in Django 2.0.
     languages: [python]
     severity: WARNING
-  - id: django-compat_2_0-assert-redirects-helper
+  - id: django-compat-2_0-assert-redirects-helper
     patterns:
       - pattern-either:
           - pattern: $X.assertRedirects(..., host=$Y, ...)


### PR DESCRIPTION
This commit implements five Django 2.0 compatibility rules for sgrep.
I'm pushing these as an initial set to see what our fire frequency is on
Django projects. If the enterprise seems worthwhile, I'll continue
implementing compatibility checks.

These checks are sourced from
https://docs.djangoproject.com/en/3.0/internals/deprecation/.