### PR TITLE
Clean up smells/list-modify-iterating check

### DIFF
--- a/python/smells/list-modify-iterating.py
+++ b/python/smells/list-modify-iterating.py
@@ -1,18 +1,19 @@
 l  = list(range(100))
-# ruleid:list-pop-while-iterate
 for i in l:
     print(i),
+    # ruleid:list-pop-while-iterate
     print(l.pop(0))
+    # ruleid:list-pop-while-iterate
     x = l.pop(0)
     print(x)
 
 a = [1, 2, 3, 4]
-# ruleid:list-pop-while-iterate
 for i in a:
     print(i)
+    # ruleid:list-pop-while-iterate
     a.pop(0)
 
-# ruleid:list-pop-while-iterate
 for i in a:
     print(i)
+    # ruleid:list-pop-while-iterate
     a.append(0)

--- a/python/smells/list-modify-iterating.yaml
+++ b/python/smells/list-modify-iterating.yaml
@@ -1,55 +1,14 @@
 rules:
   - id: list-pop-while-iterate
     patterns:
+      - pattern-inside: |
+          for $ELEMENT in $LIST:
+              ...
       - pattern-either:
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $LIST.pop(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $LIST.push(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $LIST.append(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $LIST.extend(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X = $LIST.pop(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X = $LIST.push(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X = $LIST.append(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X = $LIST.extend(...)
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X($LIST.pop(...))
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X($LIST.push(...))
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X($LIST.append(...))
-          - pattern: |
-              for $ELEMENT in $LIST:
-                  ...
-                  $X($LIST.extend(...))
+          - pattern: $LIST.pop(...)
+          - pattern: $LIST.push(...)
+          - pattern: $LIST.append(...)
+          - pattern: $LIST.extend(...)
     message: "It appears that `$LIST` is a list that is being modified while in a for loop. This is usually a bad idea"
     languages: [python]
     severity: WARNING


### PR DESCRIPTION
The existing implementation of this check had to use a large number of
patterns, as matching class inclusion in a pattern means only
a statement can be matched.

Instead, use the pattern-inside helper to determine class inclusion, in
which case a pattern can match any expression.

As a bonus, the check now reports the smell line, as opposed to the line
at which the enclosing class is defined.