### PR TITLE
Add rule for detecting manual reimplementation of 'collections' funtionality

### DIFF
--- a/python/smells/manual-collections-create.py
+++ b/python/smells/manual-collections-create.py
@@ -2,43 +2,60 @@ foo = {}
 
 # ruleid:manual-defaultdict-dict-create
 dict_d = {}
-for k, v in foo:
+for k, v in foo.items():
     if k not in dict_d:
         dict_d[k] = {}
     dict_d[k].update(v)
 
 # ruleid:manual-defaultdict-set-create
 set_d = {}
-for k, v in foo:
+for k, v in foo.items():
     if k not in set_d:
         set_d[k] = set()
     set_d[k].add(v)
 
 # ruleid:manual-defaultdict-list-create
 list_d = {}
-for k, v in foo:
+for k, v in foo.items():
     if k not in list_d:
         list_d[k] = []
     list_d[k].append(v)
 
 # ruleid:manual-defaultdict-dict-create
 setdefault_dict_d = {}
-for k, v in foo:
+for k, v in foo.items():
     setdefault_dict_d.setdefault(k, {}).update(v)
 
 # ruleid:manual-defaultdict-set-create
 setdefault_set_d = {}
-for k, v in foo:
+for k, v in foo.items():
     setdefault_set_d.setdefault(k, set()).add(v)
 
 # ruleid:manual-defaultdict-list-create
 setdefault_list_d = {}
-for k, v in foo:
+for k, v in foo.items():
     setdefault_list_d.setdefault(k, []).append(v)
 
 # ruleid:manual-counter-create
 counter_d = {}
-for k, v in foo:
+for k, v in foo.items():
     if k not in counter_d:
         counter_d[k] = 0
     counter_d[k] += 1
+
+# okay
+for k in foo:
+    pass
+
+for k, v in foo.items():
+    pass
+
+for k, v in foo.items():
+    if k not in [1, 2, 3]:
+        pass
+
+result = []
+for k, v in foo.items():
+    if k not in [1, 2, 3]:
+        pass
+    result.append(v)

--- a/python/smells/manual-collections-create.py
+++ b/python/smells/manual-collections-create.py
@@ -1,0 +1,44 @@
+foo = {}
+
+# ruleid:manual-defaultdict-dict-create
+dict_d = {}
+for k, v in foo:
+    if k not in dict_d:
+        dict_d[k] = {}
+    dict_d[k].update(v)
+
+# ruleid:manual-defaultdict-set-create
+set_d = {}
+for k, v in foo:
+    if k not in set_d:
+        set_d[k] = set()
+    set_d[k].add(v)
+
+# ruleid:manual-defaultdict-list-create
+list_d = {}
+for k, v in foo:
+    if k not in list_d:
+        list_d[k] = []
+    list_d[k].append(v)
+
+# ruleid:manual-defaultdict-dict-create
+setdefault_dict_d = {}
+for k, v in foo:
+    setdefault_dict_d.setdefault(k, {}).update(v)
+
+# ruleid:manual-defaultdict-set-create
+setdefault_set_d = {}
+for k, v in foo:
+    setdefault_set_d.setdefault(k, set()).add(v)
+
+# ruleid:manual-defaultdict-list-create
+setdefault_list_d = {}
+for k, v in foo:
+    setdefault_list_d.setdefault(k, []).append(v)
+
+# ruleid:manual-counter-create
+counter_d = {}
+for k, v in foo:
+    if k not in counter_d:
+        counter_d[k] = 0
+    counter_d[k] += 1

--- a/python/smells/manual-collections-create.yaml
+++ b/python/smells/manual-collections-create.yaml
@@ -5,7 +5,7 @@ rules:
             - pattern: |
                 $DICT = {}
                 ...
-                for $KEY, $VALUE in $OTHERDICT:
+                for $KEY, $VALUE in $OTHERDICT.items():
                     ...
                     if $KEY not in $DICT:
                         ...
@@ -15,7 +15,7 @@ rules:
             - pattern: |
                 $DICT = {}
                 ...
-                for $KEY, $VALUE in $OTHERDICT:
+                for $KEY, $VALUE in $OTHERDICT.items():
                     ...
                     $DICT.setdefault($KEY, {}).update(...)
     message: "manually creating a defaultdict - use collections.defaultdict(dict)"
@@ -27,7 +27,7 @@ rules:
             - pattern: |
                 $DICT = {}
                 ...
-                for $KEY, $VALUE in $OTHERDICT:
+                for $KEY, $VALUE in $OTHERDICT.items():
                     ...
                     if $KEY not in $DICT:
                         ...
@@ -37,7 +37,7 @@ rules:
             - pattern: |
                 $DICT = {}
                 ...
-                for $KEY, $VALUE in $OTHERDICT:
+                for $KEY, $VALUE in $OTHERDICT.items():
                     ...
                     $DICT.setdefault($KEY, set()).add(...)
     message: "manually creating a defaultdict - use collections.defaultdict(set)"
@@ -49,7 +49,7 @@ rules:
             - pattern: |
                 $DICT = {}
                 ...
-                for $KEY, $VALUE in $OTHERDICT:
+                for $KEY, $VALUE in $OTHERDICT.items():
                     ...
                     if $KEY not in $DICT:
                         ...
@@ -59,7 +59,7 @@ rules:
             - pattern: |
                 $DICT = {}
                 ...
-                for $KEY, $VALUE in $OTHERDICT:
+                for $KEY, $VALUE in $OTHERDICT.items():
                     ...
                     $DICT.setdefault($KEY, []).append(...)
     message: "manually creating a defaultdict - use collections.defaultdict(list)"
@@ -69,7 +69,7 @@ rules:
     pattern: |
         $DICT = {}
         ...
-        for $KEY, $VALUE in $OTHERDICT:
+        for $KEY, $VALUE in $OTHERDICT.items():
             ...
             if $KEY not in $DICT:
                 ...

--- a/python/smells/manual-collections-create.yaml
+++ b/python/smells/manual-collections-create.yaml
@@ -1,0 +1,81 @@
+rules:
+  - id: manual-defaultdict-dict-create
+    patterns:
+        - pattern-either:
+            - pattern: |
+                $DICT = {}
+                ...
+                for $KEY, $VALUE in $OTHERDICT:
+                    ...
+                    if $KEY not in $DICT:
+                        ...
+                        $DICT[$KEY] = {}
+                        ...
+                    $DICT[$KEY].update(...)
+            - pattern: |
+                $DICT = {}
+                ...
+                for $KEY, $VALUE in $OTHERDICT:
+                    ...
+                    $DICT.setdefault($KEY, {}).update(...)
+    message: "manually creating a defaultdict - use collections.defaultdict(dict)"
+    languages: [python]
+    severity: WARNING
+  - id: manual-defaultdict-set-create
+    patterns:
+        - pattern-either:
+            - pattern: |
+                $DICT = {}
+                ...
+                for $KEY, $VALUE in $OTHERDICT:
+                    ...
+                    if $KEY not in $DICT:
+                        ...
+                        $DICT[$KEY] = set()
+                        ...
+                    $DICT[$KEY].add(...)
+            - pattern: |
+                $DICT = {}
+                ...
+                for $KEY, $VALUE in $OTHERDICT:
+                    ...
+                    $DICT.setdefault($KEY, set()).add(...)
+    message: "manually creating a defaultdict - use collections.defaultdict(set)"
+    languages: [python]
+    severity: WARNING
+  - id: manual-defaultdict-list-create
+    patterns:
+        - pattern-either:
+            - pattern: |
+                $DICT = {}
+                ...
+                for $KEY, $VALUE in $OTHERDICT:
+                    ...
+                    if $KEY not in $DICT:
+                        ...
+                        $DICT[$KEY] = []
+                        ...
+                    $DICT[$KEY].append(...)
+            - pattern: |
+                $DICT = {}
+                ...
+                for $KEY, $VALUE in $OTHERDICT:
+                    ...
+                    $DICT.setdefault($KEY, []).append(...)
+    message: "manually creating a defaultdict - use collections.defaultdict(list)"
+    languages: [python]
+    severity: WARNING
+  - id: manual-counter-create
+    pattern: |
+        $DICT = {}
+        ...
+        for $KEY, $VALUE in $OTHERDICT:
+            ...
+            if $KEY not in $DICT:
+                ...
+                $DICT[$KEY] = 0
+                ...
+            $DICT[$KEY] += 1
+    message: "manually creating a counter - use collections.Counter"
+    languages: [python]
+    severity: WARNING


### PR DESCRIPTION
Detects manual implementation of [`collections.Counter`](https://docs.python.org/3.8/library/collections.html#collections.Counter) and [`collections.defaultdict`](https://docs.python.org/3.8/library/collections.html#collections.defaultdict).

Tested with:

```
$ docker run --rm -v $(pwd):/home/repo returntocorp/sgrep:develop -f /home/repo/python/smells/manual-collections-create.yaml /home/repo/python/smells/manual-collections-create.py | grep "manually creating a"
running 4 rules from 1 yaml files (0 yaml files were invalid)
rule:python.smells.manual-counter-create: manually creating a counter - use collections.Counter
rule:python.smells.manual-defaultdict-dict-create: manually creating a defaultdict - use collections.defaultdict(dict)
rule:python.smells.manual-defaultdict-dict-create: manually creating a defaultdict - use collections.defaultdict(dict)
rule:python.smells.manual-defaultdict-list-create: manually creating a defaultdict - use collections.defaultdict(list)
rule:python.smells.manual-defaultdict-list-create: manually creating a defaultdict - use collections.defaultdict(list)
rule:python.smells.manual-defaultdict-set-create: manually creating a defaultdict - use collections.defaultdict(set)
rule:python.smells.manual-defaultdict-set-create: manually creating a defaultdict - use collections.defaultdict(set)
```