### PR TITLE
remove strict parsing flag

### DIFF
--- a/test.py
+++ b/test.py
@@ -158,7 +158,7 @@ def generate_file_pairs(
             cmd = (
                 ["sgrep-lint"]
                 + extra_args
-                + ["--strict", "--strict-parsing", "--json", "--no-rewrite-rule-ids", "-f", str(filename)]
+                + ["--strict", "--json", "--no-rewrite-rule-ids", "-f", str(filename)]
                 + [str(t) for t in test_files]
             )
             print_debug(' '.join(cmd))


### PR DESCRIPTION
It's not implemented in sgrep.py any more