### PR TITLE
Copy secure-set-cookie to django

### DIFF
--- a/python/django/security/secure-cookies.py
+++ b/python/django/security/secure-cookies.py
@@ -1,0 +1,57 @@
+from django.shortcuts import render
+
+from django.conf import settings
+from django.contrib.messages.storage.base import BaseStorage, Message
+
+class CookieStorage(BaseStorage):
+    def _update_cookie(self, encoded_data, response):
+        """
+        Either sets the cookie with the encoded data if there is any data to
+        store, or deletes the cookie.
+        """
+        if encoded_data:
+            # ok
+            response.set_cookie(
+                self.cookie_name, encoded_data,
+                domain=settings.SESSION_COOKIE_DOMAIN,
+                secure=settings.SESSION_COOKIE_SECURE or None,
+                httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+            )
+        else:
+            response.delete_cookie(self.cookie_name, domain=settings.SESSION_COOKIE_DOMAIN)
+
+
+def index(request, template):
+    response = render(request, template)
+
+    # ok
+    response.set_cookie("hello", "world", secure=True, httponly=True, samesite="Lax")
+
+    # ok
+    response.set_cookie("hello", "world", **kwargs)
+
+    # ok
+    response.set_cookie(
+        settings.SESSION_COOKIE_NAME,
+        request.session.session_key, max_age=max_age,
+        expires=expires, domain=settings.SESSION_COOKIE_DOMAIN,
+        path=settings.SESSION_COOKIE_PATH,
+        secure=settings.SESSION_COOKIE_SECURE or None,
+        httponly=settings.SESSION_COOKIE_HTTPONLY or None,
+    )
+
+    # ok
+    response.set_cookie(
+        settings.CSRF_COOKIE_NAME,
+        request.META['CSRF_COOKIE'],
+        max_age=settings.CSRF_COOKIE_AGE,
+        domain=settings.CSRF_COOKIE_DOMAIN,
+        path=settings.CSRF_COOKIE_PATH,
+        secure=settings.CSRF_COOKIE_SECURE,
+        httponly=settings.CSRF_COOKIE_HTTPONLY,
+    )
+
+    # ruleid: django-secure-set-cookie
+    response.set_cookie("hello", "again", httponly=False)
+
+    return response

--- a/python/django/security/secure-cookies.yml
+++ b/python/django/security/secure-cookies.yml
@@ -1,0 +1,29 @@
+rules:
+  - id: django-secure-set-cookie
+    patterns:
+      # Exclude vendored i18n code
+      - pattern-not-inside: |
+          LANGUAGE_QUERY_PARAMETER = 'language'
+          ...
+          def set_language(request):
+              ...
+      # Exclude vendored contrib/messages/storage/cookie.py
+      - pattern-not-inside: |
+          class CookieStorage(django.contrib.messages.storage.base.BaseStorage):
+              ...
+      # Exclude cookies handled by vendored middleware
+      - pattern-not: response.set_cookie(django.conf.settings.SESSION_COOKIE_NAME, ...)
+      - pattern-not: response.set_cookie(django.conf.settings.CSRF_COOKIE_NAME, ...)
+      - pattern-not: response.set_cookie(django.conf.settings.LANGUAGE_COOKIE_NAME, ...)
+      - pattern-not: response.set_cookie(rest_framework_jwt.settings.api_settings.JWT_AUTH_COOKIE, ...)
+      - pattern-not: response.set_cookie(..., secure=$A, httponly=$B, samesite=$C, ...)
+      - pattern-not: response.set_cookie(..., **$A)
+      - pattern: response.set_cookie(...)
+    message: |
+      Django cookies should be handled securely by setting secure=True, httponly=True, and samesite='Lax' in
+      response.set_cookie(...). If your situation calls for different settings, explicitly disable the setting.
+      If you want to send the cookie over http, set secure=False.  If you want to let client-side JavaScript
+      read the cookie, set httponly=False. If you want to attach cookies to requests for external sites,
+      set samesite=None.
+    languages: [python]
+    severity: WARNING


### PR DESCRIPTION
This was a relatively successful check in our flask corpus. I've ported
it to Django here.

Interestingly, there's not a good way to identify that the set_cookie
method is being called on an HttpResponse object without some
rudimentary typing or dataflow. So I just use the common identifier
"response" as the invocation target. Note that this means that this
check fires on Flask projects.

In order to have this not fire on random Django middleware vendored
code, I excluded expressions from common Django middlewares.

After doing this, the fire frequency on non-test, non-vendored code is
1 finding in the entire Django-500 corpus. It's a true positive.

For details, see:
https://dev.massive.ret2.co/jobs/618?page=1&sort_on=repo_url&sort_by=asc