### PR TITLE
Fix #159, add rule for deprecated Flask APIs

### DIFF
--- a/python/flask/deprecated-apis.py
+++ b/python/flask/deprecated-apis.py
@@ -1,0 +1,46 @@
+from flask import Flask, json_available, request, testing
+
+app = Flask(__name__)
+
+# ruleid: flask-deprecated-apis
+if json_available:
+    pass
+
+# ruleid: flask-deprecated-apis
+blueprint = request.module
+
+# ruleid: flask-deprecated-apis
+builder = testing.make_test_environ_builder(app)
+
+# ruleid: flask-deprecated-apis
+app.open_session(...)
+
+# ruleid: flask-deprecated-apis
+app.save_session(...)
+
+# ruleid: flask-deprecated-apis
+app.make_null_session(...)
+
+# ruleid: flask-deprecated-apis
+app.init_jinja_globals(...)
+
+# ruleid: flask-deprecated-apis
+app.request_globals_class(...)
+
+# ruleid: flask-deprecated-apis
+app.static_path(...)
+
+# ruleid: flask-deprecated-apis
+app.config.from_json(...)
+
+
+@app.route("/foo")
+def foo():
+    pass
+
+
+if request.method == "POST":
+    pass
+
+app.config["BAR"] = "BAZ"
+app.register_blueprint(blueprint=object())

--- a/python/flask/deprecated-apis.yaml
+++ b/python/flask/deprecated-apis.yaml
@@ -1,0 +1,41 @@
+rules:
+  - id: flask-deprecated-apis
+    patterns:
+      - pattern-either:
+        - pattern: |
+              $F = Flask(...)
+              ...
+              $F.open_session(...)
+        - pattern: |
+              $F = Flask(...)
+              ...
+              $F.save_session(...)
+        - pattern: |
+              $F = Flask(...)
+              ...
+              $F.make_null_session(...)
+        - pattern: |
+              $F = Flask(...)
+              ...
+              $F.init_jinja_globals(...)
+        - pattern: |
+              $F = Flask(...)
+              ...
+              $F.request_globals_class(...)
+        - pattern: |
+              $F = Flask(...)
+              ...
+              $F.static_path(...)
+        - pattern: app.open_session(...)
+        - pattern: app.save_session(...)
+        - pattern: app.make_null_session(...)
+        - pattern: app.init_jinja_globals(...)
+        - pattern: app.request_globals_class(...)
+        - pattern: app.static_path(...)
+        - pattern: app.config.from_json(...)
+        - pattern: flask.json_available
+        - pattern: flask.request.module
+        - pattern: flask.testing.make_test_environ_builder(...)
+    message: "deprecated Flask API"
+    languages: [python]
+    severity: WARNING


### PR DESCRIPTION
This information was mostly gleaned by searching [Flask's CHANGELOG](https://github.com/pallets/flask/blob/master/CHANGES.rst) for "deprecated." There were a few more, but it's probably not necessary to search for things deprecated/removed in 2011. Once https://github.com/returntocorp/sgrep/issues/197 is in we'll be able to search for `flask.ext` use as well.

Fixes https://github.com/returntocorp/sgrep-rules/issues/159