### PR TITLE
Avoid calling people out over their bugs

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 rules:
   - id: eqeq-is-bad
     pattern: $X == $X
-    message: "$X == $X is stupid"
+    message: "$X == $X is always true"
     languages: [python]
     severity: ERROR

--- a/template.yaml
+++ b/template.yaml
@@ -1,6 +1,6 @@
 rules:
   - id: eqeq-is-bad
     pattern: $X == $X
-    message: "$X == $X is always true"
+    message: "$X == $X is a useless equality check"
     languages: [python]
     severity: ERROR


### PR DESCRIPTION
`template.yaml` is likely the first place new users will look when writing their own rules. These rules are probably firing on their code, or someone they knows code - let's avoid calling them out. 