### PR TITLE
Fix: Split out java tests

### DIFF
--- a/java/basic-rules.yaml
+++ b/java/basic-rules.yaml
@@ -19,11 +19,3 @@ rules:
     message: "useless comparison operation `$X == $X` or `$X != $X`"
     languages: [java]
     severity: ERROR
-  - id: hardcoded-eq-true-or-false
-    patterns:
-      - pattern-either:
-          - pattern: if (true) { ... }
-          - pattern: if (false) { ... }
-    message: "useless if statement, always the same behavior"
-    languages: [java]
-    severity: ERROR

--- a/java/hardcoded-conditional.py
+++ b/java/hardcoded-conditional.py
@@ -2,10 +2,18 @@ class Bar {
     void main() {
         boolean myBoolean;
 
-        //myBoolean == myBoolean;
-
-        // ruleid:assignment-comparison
+        // ok
         if (myBoolean = true) {
+            continue;
+        }
+
+        // ruleid:hardcoded-conditional
+        if (true) {
+            continue;
+        }
+
+        // ruleid:hardcoded-conditional
+        if (true && false) {
             continue;
         }
 
@@ -14,12 +22,12 @@ class Bar {
 
         }
 
-        // ruleid:eqeq-is-bad
+        // ok
         if (myBoolean == myBoolean) {
             continue;
         }
 
-        // ruleid:eqeq-is-bad
+        // ok
         if (myBoolean != myBoolean) {
             continue;
         }

--- a/java/hardcoded-conditional.yaml
+++ b/java/hardcoded-conditional.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: hardcoded-conditional
+    patterns:
+      - pattern-either:
+          - pattern: if (true) { ... }
+          - pattern: if (false) { ... }
+    message: "useless if statement, always the same behavior"
+    languages: [java]
+    severity: ERROR


### PR DESCRIPTION
Move hardcoded-conditional tests and rules to their own file so they
do not interfear with the other tests and cause tests to fail.