### PR TITLE
add jwt-hardcode rule for javascript

### DIFF
--- a/javascript/jwt-hardcode/example1.js
+++ b/javascript/jwt-hardcode/example1.js
@@ -1,0 +1,25 @@
+'use strict';
+const config = require('./app.config');
+const privateMethods = {
+    initialize(USER) {
+        const router = require('express').Router(),
+        jwt = require('jsonwebtoken');
+        if (config) {
+            router.route('/register').post((req, res) => {
+                USER.findOne({}).exec((error, user) => {
+                    if (error)
+                        return res.status(400).send({error: error});
+                    user.save((error, user) => {
+                        if (error) {
+                            return res.status(400).send({error: error});
+                        } else {
+                            const token = jwt.sign({id: user._id}, 'hardcoded-secret');
+                            return res.status(201).json({token: token});
+                        }
+                    });
+                });
+            });
+        }
+    }
+};
+module.exports = privateMethods;

--- a/javascript/jwt-hardcode/example2.js
+++ b/javascript/jwt-hardcode/example2.js
@@ -1,0 +1,21 @@
+(()=> {
+
+  'use strict';
+
+  let User = require('./user'),
+  jwt      = require('jsonwebtoken');
+
+  const express = require('express');
+  let router = express.Router();
+
+  router.post('/signup', (req, res) => {
+    let user = new User({
+      name:req.body.name,
+      password:req.body.password
+    });
+    var token = jwt.sign(user, "hardcoded-secret", {expiresIn: 60*60*10});
+    res.send({success:true, token: token});
+  });
+
+  module.exports = router;
+})();

--- a/javascript/jwt-hardcode/example3.js
+++ b/javascript/jwt-hardcode/example3.js
@@ -1,0 +1,19 @@
+const jwt = require('jsonwebtoken')
+
+const jwtSign = (payload = { id: 1 }) =>
+  jwt.sign(payload, 'hardcoded-secret')
+
+const jwtVerify = req => () => new Promise((resolve, reject) => {
+  const token = req.headers['x-access-token']
+  if (!token) {
+    resolve(false)
+  }
+  jwt.verify(token, 'hardcoded-secret', (err, decoded) => {
+    if (err) {
+      resolve(false)
+    }
+    resolve(decoded)
+  })
+})
+
+export default {jwtSign, jwtVerify}

--- a/javascript/jwt-hardcode/example4.js
+++ b/javascript/jwt-hardcode/example4.js
@@ -1,0 +1,15 @@
+const $jwt = require('jsonwebtoken');
+
+const cert = 'hardcoded-secret';
+
+module.exports = (app) => {
+  app.post('/api/login', (req, res) => {
+    app.login(req.body.username, req.body.password).then((out) => {
+      out.token = $jwt.sign(out, cert, {expiresIn: '1d'});
+      res.send(out);
+    }, (err) => {
+      console.error(err);
+      res.status(400).send(err);
+    });
+  });
+};

--- a/javascript/jwt-hardcode/example5.js
+++ b/javascript/jwt-hardcode/example5.js
@@ -1,0 +1,31 @@
+"use strict";
+const jwt = require('jsonwebtoken');
+const Promise = require("bluebird");
+const secret = "hardcoded-secret"
+class Authentication {
+	static sign(obj){
+		return jwt.sign(obj, secret, {});
+	}
+
+	static authenticate(payload) {
+		var token = payload.token;
+		let promise = new Promise((resolve, reject) => {
+			if (token) {
+				jwt.verify(token, secret, function (err, decoded) {
+					if (err) {
+						reject(err);
+					} else {
+						 resolve(decoded);
+					}
+				});
+			} else {
+				reject(new Error("No token provided"));
+			}
+		});
+
+		return promise;
+
+	}
+}
+
+module.exports = Authentication;

--- a/javascript/jwt-hardcode/jwt-hardcode.yaml
+++ b/javascript/jwt-hardcode/jwt-hardcode.yaml
@@ -1,0 +1,68 @@
+# module imports used as described in https://github.com/returntocorp/sgrep/issues/285
+rules:
+  - id: hardcoded-jwt-secret
+    patterns:
+      - pattern-either:
+          - pattern: |
+              $JWT = require("jsonwebtoken");
+              ...
+              $JWT.sign($P, "...", ...);
+          - pattern: |
+              $JWT = require("jsonwebtoken");
+              ...
+              $JWT.verify($P, "...", ...);
+          - pattern: |
+              $JWT = require("jsonwebtoken");
+              ...
+              $SECRET = "...";
+              ...
+              $JWT.sign($P, $SECRET, ...);
+          - pattern: |
+              $JWT = require("jsonwebtoken");
+              ...
+              $SECRET = "...";
+              ...
+              $JWT.verify($P, $SECRET, ...);
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $JOSE.JWT.sign($P, "...", ...);
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $JOSE.JWT.verify($P, "...", ...)
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $JOSE.JWT.sign($P, $JOSE.JWK.asKey("..."), ...);
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $JOSE.JWT.verify($P, $JOSE.JWK.asKey("..."), ...)
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $SECRET = "...";
+              ...
+              $JOSE.JWT.sign($P, $SECRET, ...);
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $SECRET = "...";
+              ...
+              $JOSE.JWT.verify($P, $SECRET, ...);
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $SECRET = "...";
+              ...
+              $JOSE.JWT.sign($P, $JOSE.JWK.asKey($SECRET), ...);
+          - pattern: |
+              $JOSE = require("jose");
+              ...
+              $SECRET = "...";
+              ...
+              $JOSE.JWT.verify($P, $JOSE.JWK.asKey($SECRET), ...);
+    message: "hardcoded jwt secret"
+    languages: [javascript]
+    severity: ERROR

--- a/javascript/jwt-hardcode/simple-examples.js
+++ b/javascript/jwt-hardcode/simple-examples.js
@@ -1,0 +1,36 @@
+const jsonwt = require('jsonwebtoken')
+const jose = require('jose')
+const { JWK, JWT } = jose
+const config = require('./config')
+
+const payload = {foo: 'bar'}
+const secret = 'shhhhh'
+
+const secret2 = config.secret
+const secret3 = process.env.SECRET || 'fallback-secret'
+
+//jsonwebtoken
+//true
+const token1 = jsonwt.sign(payload, secret)
+//true
+const token2 = jsonwt.sign(payload, 'some-secret')
+//false
+const token3 = jsonwt.sign(payload, config.secret)
+//false
+const token4 = jsonwt.sign(payload, secret2)
+//??
+const token5 = jsonwt.sign(payload, secret3)
+
+//jose
+//true
+const token6 = JWT.sign(payload, JWK.asKey(secret))
+//true
+const token7 = JWT.sign(payload, JWK.asKey('raz-dva-tri'))
+//true
+const token8 = JWT.sign(payload, secret)
+//true
+const token9 = JWT.sign(payload, 'secret-again')
+//false
+const token11 = JWT.sign(payload, JWK.asKey(secret2))
+//false
+const token12 = JWT.sign(payload, secret2)


### PR DESCRIPTION
**Description:**

the rule is intended to find hardcoded secret values while generating or verifying JWTs
it covers 2 most popular modules: [`jsonwebtoken`](https://www.npmjs.com/package/jsonwebtoken) and [`jose`](https://www.npmjs.com/package/jose)

examples:

```javascript
const jsonwt = require('jsonwebtoken')

const secret = 'hardcoded-secret'
const token1 = jsonwt.sign({foo: 'bar'}, secret)

const token2 = jsonwt.verify({foo: 'bar'}, 'hardcoded-secret')
```

```javascript
const jose = require('jose')
const { JWK, JWT } = jose

const token3 = JWT.sign(payload, 'hardcoded-secret')
const token4 = JWT.verify(payload, JWK.asKey('hardcoded-secret'))

```

**AST rules:**
to back my research on this one I created a `stadt` rule
https://github.com/inkz/typed-ast-rules-example/blob/2acada8e3f1958becfe16b99c6f08bcab7127fb4/src/src/rules/jwt-hardcode.ts

there are results of running AST rule towards inpuset of `jsonwebtoken` dependents (inputset is kinda outdated, as it was created in 2019, but still has some good examples)
https://app.r2c.dev/triager/filter/211

I used results from the job to bootstrap test examples based on "real life" scenarios

**Blocking tasks:**
https://github.com/returntocorp/sgrep/issues/229
possibility to find deep into multiple curly braces or subexpressions is important for discovering the usage of `jsonwebtoken` and `jose` modules and secrets across the code

**Nice to have features:**
https://github.com/returntocorp/sgrep/issues/285
this will increase the coverage as `import` statements become more popular, but using `$X = require("module-name")` is good enough for now