### PR TITLE
Airflow/bash operator

### DIFF
--- a/python/airflow/formatted-string-bashoperator.py
+++ b/python/airflow/formatted-string-bashoperator.py
@@ -1,0 +1,98 @@
+import requests
+from datetime import timedelta
+from airflow import DAG
+from airflow.operators.bash_operator import BashOperator
+from airflow.utils.dates import days_ago
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": days_ago(2),
+    "email": ["airflow@example.com"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5)
+}
+
+dag = DAG(
+    "tutorialex2",
+    default_args=default_args,
+    description="Tutorial DAG",
+    schedule_interval=timedelta(days=1)
+)
+
+message = requests.get("https://fakeurl.asdf/message").text
+# ruleid: formatted-string-bashoperator
+t1 = BashOperator(
+    task_id="print_date",
+    bash_command="echo " + message,
+    dag=dag
+)
+
+howlong = requests.get("https://fakeurl.asdf/howlong").text
+# ruleid: formatted-string-bashoperator
+command = "sleep {}".format(howlong)
+t2 = BashOperator(
+    task_id="sleep",
+    depends_on_past=False,
+    bash_command=command,
+    retries=3,
+    dag=dag
+)
+
+# ruleid: formatted-string-bashoperator
+unsafe_templated_command = """
+{% for i in range(5) %}
+    echo "{{ ds }}"
+    echo "{{ macros.ds_add(ds, 7)}}"
+    echo "{{ params.my_param }}"
+    echo "{{ %s }}"
+{% endfor %}
+""" % (message,)
+
+t3 = BashOperator(
+    task_id="templated",
+    depends_on_past=False,
+    bash_command=unsafe_templated_command,
+    params={
+        "my_param": "Parameter I passed in"
+    },
+    dag=dag
+)
+
+# ok
+templated_command = """
+{% for i in range(5) %}
+    echo "{{ ds }}"
+    echo "{{ macros.ds_add(ds, 7)}}"
+    echo "{{ params.my_param }}"
+{% endfor %}
+"""
+
+t4 = BashOperator(
+    task_id="safe_templated",
+    depends_on_past=False,
+    bash_command=templated_command,
+    params={
+        "my_param": "Parameter I passed in"
+    },
+    dag=dag
+)
+
+# ok
+t5 = BashOperator(
+    task_id="safe",
+    bash_command="echo hello world!",
+    dag=dag
+)
+
+# todoruleid: formatted-string-bashoperator
+echo_message = f"echo {message}"
+t5 = BashOperator(
+    task_id="safe",
+    bash_command=echo_message,
+    dag=dag
+)
+
+t1 >> [t2, t3, t4, t5, t6]

--- a/python/airflow/formatted-string-bashoperator.yaml
+++ b/python/airflow/formatted-string-bashoperator.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: formatted-string-bashoperator
+    patterns:
+      - pattern-either:
+          - pattern: |
+              airflow.operators.bash_operator.BashOperator(..., bash_command="..." + $CONCAT, ...)
+          - pattern: |
+              airflow.operators.bash_operator.BashOperator(..., bash_command="...".format(...), ...)
+          - pattern: |
+              airflow.operators.bash_operator.BashOperator(..., bash_command=f"...", ...)
+          - pattern: |
+              airflow.operators.bash_operator.BashOperator(..., bash_command="..." % $PARAMS, ...)
+          - pattern: |
+              $CMD = "..." % $PARAMS
+              ...
+              airflow.operators.bash_operator.BashOperator(..., bash_command=$CMD, ...)
+          - pattern: |
+              $CMD = $STR.format(...)
+              ...
+              airflow.operators.bash_operator.BashOperator(..., bash_command=$CMD, ...)
+          - pattern: |
+              $CMD = f"..."
+              ...
+              airflow.operators.bash_operator.BashOperator(..., bash_command=$CMD, ...)
+          - pattern: |
+              $CMD = "..." + $CONCAT
+              ...
+              airflow.operators.bash_operator.BashOperator(..., bash_command=$CMD, ...)
+          - pattern: |
+              $CMD = "..."
+              ...
+              $CMD += $CONCAT
+              ...
+              airflow.operators.bash_operator.BashOperator(..., bash_command=$CMD, ...)
+    message: |
+      Found a formatted string in BashOperator: $CMD.
+      This could be vulnerable to injection.
+      Be extra sure your variables are not controllable by external sources.
+    languages: [py]
+    severity: WARNING


### PR DESCRIPTION
This is a new check for the Apache Airflow BashOperator class.

As the name implies, BashOperator will run a bash command on an airflow instance. The same principles apply here as with any command string: formatted or concatenated strings are dangerous.

This check will look for these cases, alerting when formatted or concatenated strings are passed into BashOperator.

https://airflow.apache.org/docs/stable/_api/airflow/operators/bash_operator/index.html

This was inspired by a review of Etsy's `boundary-layer` tool, which transforms YAML files into Apache Airflow Python code. This code is autogenerated, and in looking for invariants to express about Airflow, this one for BashOperator seemed obvious.

I tested doing command injection via this method and was successful.