### PR TITLE
go/channel-guarded-with-mutex

### DIFF
--- a/go/antipatterns/channel-guarded-with-mutex.go
+++ b/go/antipatterns/channel-guarded-with-mutex.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+    "fmt"
+    "sync"
+)
+
+func ReadMessage() {
+    messages := make(chan string)
+
+    go func() {
+        messages <- "ping"
+    }()
+
+    // ok
+    msg := <-messages
+    fmt.Println(msg)
+}
+
+func ReadMessageMutex() {
+    var mutex = &sync.Mutex{}
+    messages := make(chan string)
+
+    go func() {
+        messages <- "ping"
+    }()
+
+    // ruleid: channel-guarded-with-mutex
+    mutex.Lock()
+    msg := <-messages
+    mutex.Unlock()
+    fmt.Println(msg)
+}

--- a/go/antipatterns/channel-guarded-with-mutex.yaml
+++ b/go/antipatterns/channel-guarded-with-mutex.yaml
@@ -1,0 +1,18 @@
+rules:
+  - id: channel-guarded-with-mutex
+    pattern-either:
+      - pattern: |
+          $MUX.Lock()
+          $VALUE <- $CHANNEL
+          $MUX.Unlock()
+      - pattern: |
+          $MUX.Lock()
+          $VALUE = <- $CHANNEL
+          $MUX.Unlock()
+    message: |
+      Detected a channel guarded with a mutex. Channels already have
+      an internal mutex, so this is unnecessary. Remove the mutex.
+      See https://hackmongo.com/page/golang-antipatterns/#guarded-channel
+      for more information.
+    languages: [go]
+    severity: WARNING


### PR DESCRIPTION
Add new golang check for guarded channels based on https://hackmongo.com/page/golang-antipatterns/#guarded-channel. The check makes sure that channels are not guarded by mutexes, since channels already have their own mutexes.