### PR TITLE
Fix FP in python/smells/open-never-closed

### DIFF
--- a/python/smells/open-never-closed.py
+++ b/python/smells/open-never-closed.py
@@ -5,5 +5,14 @@ def func1():
 
 
 def func2():
+    # ok
     fd = open('bar')
     fd.close()
+
+def func3():
+    # ok
+    fd = open('baz')
+    try:
+        pass
+    finally:
+        fd.close()

--- a/python/smells/open-never-closed.yml
+++ b/python/smells/open-never-closed.yml
@@ -29,6 +29,55 @@ rules:
             $F = tempfile.SpooledTemporaryFile(...)
             ...
             $F.close()
+        - pattern-not-inside: |
+            $F = open(...)
+            ...
+            try:
+                ...
+            finally:
+                $F.close()
+        - pattern-not-inside: |
+            $F = io.open(...)
+            ...
+            try:
+                ...
+            finally:
+                $F.close()
+        - pattern-not-inside: |
+            $F = tarfile.open(...)
+            ...
+            try:
+                ...
+            finally:
+                $F.close()
+        - pattern-not-inside: |
+            $F = ZipFile.open(...)
+            ...
+            try:
+                ...
+            finally:
+                $F.close()
+        - pattern-not-inside: |
+            $F = tempfile.TemporaryFile(...)
+            ...
+            try:
+                ...
+            finally:
+                $F.close()
+        - pattern-not-inside: |
+            $F = tempfile.NamedTemporaryFile(...)
+            ...
+            try:
+                ...
+            finally:
+                $F.close()
+        - pattern-not-inside: |
+            $F = tempfile.SpooledTemporaryFile(...)
+            ...
+            try:
+                ...
+            finally:
+                $F.close()
         - pattern-either:
             - pattern: $F = open(...)
             - pattern: $F = io.open(...)


### PR DESCRIPTION
In many cases, this pattern is a true positive:

  fd = open(...)
  do_something()
  fd.close()

As do_something() can raise an exception.

However, this pattern is correct:

  fd = open(...)
  try:
      do_something()
  finally:
      fd.close()

In this commit I merely remove the false positive, rather than
broadening the scope of the check to include these true positives.