### PR TITLE
Fix two false positives in flask-view-func-match-route-params

### DIFF
--- a/python/flask/different-route-names.py
+++ b/python/flask/different-route-names.py
@@ -4,6 +4,18 @@
 def get_snippet(snippit_id):
     db_id = hashids.decode(snippit_id)
 
+# ok
+@app.route("/api/snippet/<int:snippit_id>")
+@cache.cached(timeout=None)  # cache until restart or manual invalidation b/c immutable
+def get_snippet(snippit_id):
+    db_id = hashids.decode(snippit_id)
+
+# From segmentio/envoy
+# ok
+@app.route('/trace/<service_number>')
+def trace(service_number):
+    x = service_number
+
 # ruleid:flask-view-func-match-route-params
 @app.route("/api/snippet/<snippit_id>/<bar>")
 def get_snippet(snippit, baz):

--- a/python/flask/different-route-names.yaml
+++ b/python/flask/different-route-names.yaml
@@ -29,11 +29,11 @@ rules:
       - pattern-where-python: |
           set(
               [
-                  part.lstrip("<").rstrip(">")
-                  for part in vars["$PATH"].replace('"', "").split("/")
+                  part.split(":")[-1].lstrip("<").rstrip(">")
+                  for part in vars["$PATH"].replace('"', "").replace("'", "").split("/")
                   if part.startswith("<") and part.endswith(">")
               ]
           ) != set([v for k, v in vars.items() if k.startswith("$A")])
-    message: The view function arguments to `$R` don't match the path defined in @app.route($PATH)
+    message: The view function arguments `$PATH` to `$R` don't match the path defined in @app.route($PATH)
     languages: [python]
     severity: WARNING


### PR DESCRIPTION
1. Using single instead of double quotes in string literals (IMO sgrep
   should deal with this for you)
2. Defining converters in the route (see
   https://flask.palletsprojects.com/en/1.1.x/quickstart/#variable-rules)