### PR TITLE
Remove FP in python/smells/list-modify-iterating

### DIFF
--- a/python/smells/list-modify-iterating.py
+++ b/python/smells/list-modify-iterating.py
@@ -6,27 +6,27 @@ for i in l:
     x = l.pop(0)
     print(x)
 
-# ruleid:list-pop-while-iterate
 a = [1, 2, 3, 4]
+# ruleid:list-pop-while-iterate
 for i in a:
     print(i)
     a.pop(0)
 
-# ruleid:list-pop-while-iterate
 b = [1, 2, 3, 4]
+# ruleid:list-pop-while-iterate
 for i in b:
     print(i)
     b.append(0)
 
 c = []
+# ok
 for i in range(5):
     print(i)
-    # ok
     c.append(i)
 
 d = []
 e = [1, 2, 3, 4]
+# ok
 for i in e:
     print(i)
-    # ok
     d.append(i)

--- a/python/smells/list-modify-iterating.py
+++ b/python/smells/list-modify-iterating.py
@@ -1,19 +1,32 @@
 l  = list(range(100))
+# ruleid:list-pop-while-iterate
 for i in l:
     print(i),
-    # ruleid:list-pop-while-iterate
     print(l.pop(0))
-    # ruleid:list-pop-while-iterate
     x = l.pop(0)
     print(x)
 
+# ruleid:list-pop-while-iterate
 a = [1, 2, 3, 4]
 for i in a:
     print(i)
-    # ruleid:list-pop-while-iterate
     a.pop(0)
 
-for i in a:
+# ruleid:list-pop-while-iterate
+b = [1, 2, 3, 4]
+for i in b:
     print(i)
-    # ruleid:list-pop-while-iterate
-    a.append(0)
+    b.append(0)
+
+c = []
+for i in range(5):
+    print(i)
+    # ok
+    c.append(i)
+
+d = []
+e = [1, 2, 3, 4]
+for i in e:
+    print(i)
+    # ok
+    d.append(i)

--- a/python/smells/list-modify-iterating.yaml
+++ b/python/smells/list-modify-iterating.yaml
@@ -1,14 +1,23 @@
 rules:
   - id: list-pop-while-iterate
     patterns:
-      - pattern-inside: |
-          for $ELEMENT in $LIST:
-              ...
       - pattern-either:
-          - pattern: $LIST.pop(...)
-          - pattern: $LIST.push(...)
-          - pattern: $LIST.append(...)
-          - pattern: $LIST.extend(...)
+          - pattern: |
+              for $ELEMENT in $LIST:
+                ...
+                $LIST.pop(...)
+          - pattern: |
+              for $ELEMENT in $LIST:
+                ...
+                $LIST.push(...)
+          - pattern: |
+              for $ELEMENT in $LIST:
+                ...
+                $LIST.append(...)
+          - pattern: |
+              for $ELEMENT in $LIST:
+                ...
+                $LIST.extend(...)
     message: "It appears that `$LIST` is a list that is being modified while in a for loop. This is usually a bad idea"
     languages: [python]
     severity: WARNING


### PR DESCRIPTION
Leverages deep-expression matching to remove a false positive where this
would fire on _any_ list modification in a for loop, even if it was not
the list under iteration.

A downside of this change is that the rule now fires on the enclosing
iteration, instead of the offending list modification.