### PR TITLE
Django: scope secure cookie check to Django

### DIFF
--- a/python/django/security/secure-cookies.yml
+++ b/python/django/security/secure-cookies.yml
@@ -1,6 +1,13 @@
 rules:
   - id: django-secure-set-cookie
     patterns:
+      - pattern-either:
+        - pattern-inside: |
+            import django.http.HttpResponse
+            ...
+        - pattern-inside: |
+            import django.shortcuts.render
+            ...
       # Exclude vendored i18n code
       - pattern-not-inside: |
           LANGUAGE_QUERY_PARAMETER = 'language'


### PR DESCRIPTION
Previously, this check fired on Flask as well.

To validate, just run on
python/flask/secure-cookies/response-set-cookie.py.