### PR TITLE
Updated test for csrf-exempt

### DIFF
--- a/python/django/security/csrf-exempt.py
+++ b/python/django/security/csrf-exempt.py
@@ -1,14 +1,15 @@
 from django.http import HttpResponse
-# ruleid: django-csrf_exempt
+# ruleid: no-csrf-exempt
 from django.views.decorators.csrf import csrf_exempt
 
+# ruleid: no-csrf-exempt
 @csrf_exempt
 def my_view(request):
     return HttpResponse('Hello world')
 
 import django
 
-# ruleid: django-csrf_exempt
+# ruleid: no-csrf-exempt
 @django.views.decorators.csrf.csrf_exempt
 def my_view2(request):
     return HttpResponse('Hello world')

--- a/python/django/security/csrf-exempt.yaml
+++ b/python/django/security/csrf-exempt.yaml
@@ -1,5 +1,5 @@
 rules:
-  - id: django-csrf_exempt
+  - id: no-csrf-exempt
     patterns:
       - pattern-either:
           - pattern: |


### PR DESCRIPTION
Updated test for no-csrf-exempt now that https://github.com/returntocorp/sgrep/issues/294 is working. Renamed check_id to 'no-csrf-exempt' and renamed files to 'csrf-exempt'.