### PR TITLE
Add python/django/security/ssrf-injection-requests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+jinja2 ~= "2.11.1"
 
 [packages]
 

--- a/python/django/security/README.md
+++ b/python/django/security/README.md
@@ -1,0 +1,10 @@
+To generate rules with the injection template:
+
+1. Run pipenv shell from the repo root.
+1. In this directory, run:
+```
+./generate-injection.py --id YOUR_ID --sink YOUR_SINK --message YOUR_MESSAGE > RULE_FILE
+```
+1. Profit
+
+A todo item is to automate rule generation :)

--- a/python/django/security/README.md
+++ b/python/django/security/README.md
@@ -1,6 +1,7 @@
 To generate rules with the injection template:
 
-1. Run pipenv shell from the repo root.
+1. Run `pipenv install --dev` from the repo root.
+1. Run `pipenv shell` from the repo root.
 1. In this directory, run:
 ```
 ./generate-injection.py --id YOUR_ID --sink YOUR_SINK --message YOUR_MESSAGE > RULE_FILE

--- a/python/django/security/generate-injection.py
+++ b/python/django/security/generate-injection.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+from jinja2 import Environment, FileSystemLoader
+
+
+def main():
+    parser = argparse.ArgumentParser("CLI for injection templates")
+    parser.add_argument("--id", type=str, help="Check ID")
+    parser.add_argument("--message", type=str, help="Check message")
+    parser.add_argument("--sink", type=str, help="Sink")
+
+    options = parser.parse_args(sys.argv[1:])
+
+    env = Environment(
+        loader=FileSystemLoader(os.path.join(os.getcwd(), "templates/"))
+    )
+    injection_template = env.get_template("injection-template.yaml.j2")
+    print(injection_template.render(
+        id=options.id,
+        message=options.message,
+        sink=options.sink,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/django/security/ssrf-injection-requests.py
+++ b/python/django/security/ssrf-injection-requests.py
@@ -4,7 +4,7 @@ def test_bad_1():
 
     def send_to_redis(request):
         # ruleid: ssrf-injection-requests
-        bucket = request.get("bucket")
+        bucket = request.GET.get("bucket")
         inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
         return render({"response_code": inner_response.status_code})
 
@@ -14,7 +14,7 @@ def test_bad_2():
 
     def send_to_redis(request):
         # ruleid: ssrf-injection-requests
-        bucket = request.get("bucket")
+        bucket = request.GET.get("bucket")
         inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
         return HttpResponse(body = {"response_code": inner_response.status_code})
 
@@ -24,7 +24,7 @@ def test_bad_3():
 
     def send_to_redis(request):
         # todoruleid: ssrf-injection-requests
-        bucket = request.get("bucket")
+        bucket = request.GET.get("bucket")
         inner_response = get(f"http://my.redis.foo/{bucket}", data=3)
         return render({"response_code": inner_response.status_code})
 
@@ -44,7 +44,7 @@ def test_bad_5():
 
     def send_to_redis(request):
         # ruleid: ssrf-injection-requests
-        bucket = request["bucket"]
+        bucket = request.GET["bucket"]
         inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
         return render({"response_code": inner_response.status_code})
 

--- a/python/django/security/ssrf-injection-requests.py
+++ b/python/django/security/ssrf-injection-requests.py
@@ -1,0 +1,60 @@
+def test_bad_1():
+    from requests import get
+    from django.shortcuts import render
+
+    def send_to_redis(request):
+        # ruleid: ssrf-injection-requests
+        bucket = request.get("bucket")
+        inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
+        return render({"response_code": inner_response.status_code})
+
+def test_bad_2():
+    from requests import get
+    from django.http import HttpResponse
+
+    def send_to_redis(request):
+        # ruleid: ssrf-injection-requests
+        bucket = request.get("bucket")
+        inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
+        return HttpResponse(body = {"response_code": inner_response.status_code})
+
+def test_bad_3():
+    from requests import get
+    from django.shortcuts import render
+
+    def send_to_redis(request):
+        # todoruleid: ssrf-injection-requests
+        bucket = request.get("bucket")
+        inner_response = get(f"http://my.redis.foo/{bucket}", data=3)
+        return render({"response_code": inner_response.status_code})
+
+def test_bad_4():
+    from requests import get
+    from django.shortcuts import render
+
+    def send_to_redis(request):
+        # ruleid: ssrf-injection-requests
+        bucket = request.headers.get("bucket")
+        inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
+        return render({"response_code": inner_response.status_code})
+
+def test_bad_5():
+    from requests import get
+    from django.shortcuts import render
+
+    def send_to_redis(request):
+        # ruleid: ssrf-injection-requests
+        bucket = request["bucket"]
+        inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
+        return render({"response_code": inner_response.status_code})
+
+def test_bad_6():
+    from requests import get
+    from django.shortcuts import render
+
+    def send_to_redis(request):
+        # ruleid: ssrf-injection-requests
+        bucket = request.headers["bucket"]
+        inner_response = get("http://my.redis.foo/{}".format(bucket), data=3)
+        return render({"response_code": inner_response.status_code})
+

--- a/python/django/security/ssrf-injection-requests.yaml
+++ b/python/django/security/ssrf-injection-requests.yaml
@@ -1,0 +1,217 @@
+rules:
+  - id: ssrf-injection-requests
+    patterns:
+      - pattern-inside: |
+          import django.http.HttpResponse
+          ...
+          def $F(...):
+             ...
+      - pattern-either:
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            $RES = requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            $RES = requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            $RES = requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            $RES = requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            return requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            return requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            return requests.$METHOD(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            return requests.$METHOD(f"...{$DATA}...", ...)
+    message: |
+      Data from request object is passed to a new server-side request. This could lead to a server-side request forgery (SSRF). To mitigate, ensure that schemes and hosts are validated against a whitelist, do not forward the response to the user, and ensure proper authentication and transport-layer security in the proxied request. See https://owasp.org/www-community/attacks/Server_Side_Request_Forgery to learn more about SSRF vulnerabilities.
+    languages: [python]
+    severity: ERROR
+  - id: ssrf-injection-requests
+    patterns:
+      - pattern-inside: |
+          import django.shortcuts.render
+          ...
+          def $F(...):
+             ...
+      - pattern-either:
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              $RES = requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              return requests.$METHOD($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              $RES = requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              $RES = requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              $RES = requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              $RES = requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              return requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              return requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              return requests.$METHOD(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              return requests.$METHOD(f"...{$DATA}...", ...)
+    message: |
+      Data from request object is passed to a new server-side request. This could lead to a server-side request forgery (SSRF). To mitigate, ensure that schemes and hosts are validated against a whitelist, do not forward the response to the user, and ensure proper authentication and transport-layer security in the proxied request. See https://owasp.org/www-community/attacks/Server_Side_Request_Forgery to learn more about SSRF vulnerabilities.
+    languages: [python]
+    severity: ERROR

--- a/python/django/security/ssrf-injection-urllib.py
+++ b/python/django/security/ssrf-injection-urllib.py
@@ -13,7 +13,7 @@ def test2():
     from django.http import HttpResponse
 
     def send_to_redis(request):
-        # ruleid: ssrf-injection-requests
+        # ruleid: ssrf-injection-urllib
         bucket = request.GET.get("bucket")
         inner_response = urlopen("http://my.redis.foo/{}".format(bucket), data=3)
         return HttpResponse(body = {"response_code": inner_response.status_code})

--- a/python/django/security/ssrf-injection-urllib.py
+++ b/python/django/security/ssrf-injection-urllib.py
@@ -1,0 +1,19 @@
+def test1():
+    from urllib.request import urlopen
+    from django.shortcuts import render
+
+    def send_to_redis(request):
+        # ruleid: ssrf-injection-urllib
+        bucket = request.get("bucket")
+        inner_response = urlopen("http://my.redis.foo/{}".format(bucket), data=3)
+        return render({"response_code": inner_response.status_code})
+
+def test2():
+    from urllib.request import urlopen
+    from django.http import HttpResponse
+
+    def send_to_redis(request):
+        # ruleid: ssrf-injection-requests
+        bucket = request.get("bucket")
+        inner_response = urlopen("http://my.redis.foo/{}".format(bucket), data=3)
+        return HttpResponse(body = {"response_code": inner_response.status_code})

--- a/python/django/security/ssrf-injection-urllib.py
+++ b/python/django/security/ssrf-injection-urllib.py
@@ -4,7 +4,7 @@ def test1():
 
     def send_to_redis(request):
         # ruleid: ssrf-injection-urllib
-        bucket = request.get("bucket")
+        bucket = request.GET.get("bucket")
         inner_response = urlopen("http://my.redis.foo/{}".format(bucket), data=3)
         return render({"response_code": inner_response.status_code})
 
@@ -14,6 +14,6 @@ def test2():
 
     def send_to_redis(request):
         # ruleid: ssrf-injection-requests
-        bucket = request.get("bucket")
+        bucket = request.GET.get("bucket")
         inner_response = urlopen("http://my.redis.foo/{}".format(bucket), data=3)
         return HttpResponse(body = {"response_code": inner_response.status_code})

--- a/python/django/security/ssrf-injection-urllib.yaml
+++ b/python/django/security/ssrf-injection-urllib.yaml
@@ -1,0 +1,217 @@
+rules:
+  - id: ssrf-injection-urllib
+    patterns:
+      - pattern-inside: |
+          import django.http.HttpResponse
+          ...
+          def $F(...):
+             ...
+      - pattern-either:
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            return urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            return urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            return urllib.request.urlopen(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            return urllib.request.urlopen(f"...{$DATA}...", ...)
+    message: |
+      Data from request object is passed to a new server-side request. This could lead to a server-side request forgery (SSRF). To mitigate, ensure that schemes and hosts are validated against a whitelist, do not forward the response to the user, and ensure proper authentication and transport-layer security in the proxied request. See https://owasp.org/www-community/attacks/Server_Side_Request_Forgery to learn more about SSRF vulnerabilities.
+    languages: [python]
+    severity: ERROR
+  - id: ssrf-injection-urllib
+    patterns:
+      - pattern-inside: |
+          import django.shortcuts.render
+          ...
+          def $F(...):
+             ...
+      - pattern-either:
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              $RES = urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              return urllib.request.urlopen($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              $RES = urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              return urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              return urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              return urllib.request.urlopen(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              return urllib.request.urlopen(f"...{$DATA}...", ...)
+    message: |
+      Data from request object is passed to a new server-side request. This could lead to a server-side request forgery (SSRF). To mitigate, ensure that schemes and hosts are validated against a whitelist, do not forward the response to the user, and ensure proper authentication and transport-layer security in the proxied request. See https://owasp.org/www-community/attacks/Server_Side_Request_Forgery to learn more about SSRF vulnerabilities.
+    languages: [python]
+    severity: ERROR

--- a/python/django/security/templates/injection-template.yaml.j2
+++ b/python/django/security/templates/injection-template.yaml.j2
@@ -104,7 +104,7 @@ rules:
             ...
             return {{ sink }}(f"...{$DATA}...", ...)
     message: |
-      {{ message }}
+      {{ message | indent(width=8) }}
     languages: [python]
     severity: ERROR
   - id: {{ id }}
@@ -212,6 +212,6 @@ rules:
               ...
               return {{ sink }}(f"...{$DATA}...", ...)
     message: |
-      {{ message }}
+      {{ message | indent(width=8)  }}
     languages: [python]
     severity: ERROR

--- a/python/django/security/templates/injection-template.yaml.j2
+++ b/python/django/security/templates/injection-template.yaml.j2
@@ -1,0 +1,217 @@
+rules:
+  - id: {{ id }}
+    patterns:
+      - pattern-inside: |
+          import django.http.HttpResponse
+          ...
+          def $F(...):
+             ...
+      - pattern-either:
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            return {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            return {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            return {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            return {{ sink }}($A.$C(..., $DATA, ...), ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            $RES = {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            $RES = {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            $RES = {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            $RES = {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W.get($X)
+            ...
+            return {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W[$X]
+            ...
+            return {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W($X)
+            ...
+            return {{ sink }}(f"...{$DATA}...", ...)
+        - pattern: |
+            $DATA = request.$W
+            ...
+            return {{ sink }}(f"...{$DATA}...", ...)
+    message: |
+      {{ message }}
+    languages: [python]
+    severity: ERROR
+  - id: {{ id }}
+    patterns:
+      - pattern-inside: |
+          import django.shortcuts.render
+          ...
+          def $F(...):
+             ...
+      - pattern-either:
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              $RES = {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              return {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              return {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              return {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              return {{ sink }}($A.$C(..., $DATA, ...), ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              $RES = {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              $RES = {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              $RES = {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              $RES = {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W.get($X)
+              ...
+              return {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W[$X]
+              ...
+              return {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W($X)
+              ...
+              return {{ sink }}(f"...{$DATA}...", ...)
+          - pattern: |
+              $DATA = request.$W
+              ...
+              return {{ sink }}(f"...{$DATA}...", ...)
+    message: |
+      {{ message }}
+    languages: [python]
+    severity: ERROR


### PR DESCRIPTION
Detects SSRF injection attacks into the requests API.

Neither of these checks actually fire on anything in platform, so
they're pretty speculative.

For completeness, I had to write 48 different patterns for each sink. :(

This cardinality is the product space of
- Django import identification (import HttpResponse and import render)
- Request-object data extraction (request[], request.get,
  request.body[], request.body.get)
- Possible ways of embedding the injection expression (bare, assignment, return) -- note that this is incomplete, as there is also call site
- Injection methods (method call, e.g. by string format, and f-strint)

In order to streamline this generation in the future, I add jinja
templating.

For instance, to generate ssrf-injection-requests.yaml, I ran:

```bash
./generate-injection.py \
  --id ssrf-injection-requests \
  --sink 'requests.$METHOD' \
  --message 'Data from request object is passed to a new server-side request. This could lead to a server-side request forgery (SSRF). To mitigate, ensure that schemes and hosts are validated against a whitelist, do not forward the response to the user, and ensure proper authentication and transport-layer security in the proxied request. See https://owasp.org/www-community/attacks/Server_Side_Request_Forgery to learn more about SSRF vulnerabilities.' \ 
  > ssrf-injection-requests.yaml
```