### PR TITLE
Add pprof check (G108) to sgrep

### DIFF
--- a/go/gosec/pprof/pprof.yaml
+++ b/go/gosec/pprof/pprof.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: pprof-debug-exposure
-    message: 
-      Profiling endpoint is automatically exposed on /debug/pprof. 
+    message:
+      Profiling endpoint is automatically exposed on /debug/pprof.
       Just use `import "net/http/pprof"` instead.
       See https://www.farsightsecurity.com/blog/txt-record/go-remote-profiling-20161028/
       for more information and mitigation.

--- a/go/gosec/pprof/pprof.yaml
+++ b/go/gosec/pprof/pprof.yaml
@@ -1,0 +1,20 @@
+rules:
+  - id: pprof-debug-exposure
+    message: 
+      Profiling endpoint is automatically exposed on /debug/pprof. 
+      Just use `import "net/http/pprof"` instead.
+      See https://www.farsightsecurity.com/blog/txt-record/go-remote-profiling-20161028/
+      for more information and mitigation.
+    languages: [go]
+    severity: WARNING
+    patterns:
+      - pattern: |
+          import _ "net/http/pprof"
+          ...
+          func $FOO(...) {
+              ...
+              http.ListenAndServe($HOST, ...)
+              ...
+          }
+      - pattern-where-python: |
+          "localhost" not in vars['$HOST']

--- a/go/gosec/pprof/pprof_1.go
+++ b/go/gosec/pprof/pprof_1.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	// ruleid: pprof-debug-exposure
+	_ "net/http/pprof"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello World!")
+	})
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/go/gosec/pprof/pprof_2.go
+++ b/go/gosec/pprof/pprof_2.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	// ok
+	"net/http/pprof"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello World!")
+	})
+	pprof.StartCPUProfile()
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/go/gosec/pprof/pprof_3.go
+++ b/go/gosec/pprof/pprof_3.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	// OK
+	_ "net/http/pprof"
+)
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello World!")
+	})
+	log.Fatal(http.ListenAndServe("localhost:8080", nil))
+}


### PR DESCRIPTION
This is a one of 4 high severity checks in gosec.

The check detects import "_ net/http/pprof" with non-local http server. Blank imports assumes the side-effect of the package which in this case opens a /debug route.
This furthers [the check G108](https://github.com/securego/gosec/blob/master/rules/pprof.go
)  by adding a filter for localhost.

More on the problem in https://www.farsightsecurity.com/blog/txt-record/go-remote-profiling-20161028/