### PR TITLE
Add integer overflow (G109) check for overflow

### DIFF
--- a/go/gosec/overflow/overflow.yaml
+++ b/go/gosec/overflow/overflow.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: interter-overflow-int16
+    message:
+      Potential Integer overflow made by strconv.Atoi result conversion to int16
+    languages: [go]
+    severity: WARNING
+    patterns:
+      - pattern-either:
+        - pattern: |
+            $F, $ERR := strconv.Atoi($NUM)
+            ...
+            int16($F)
+        - pattern-where-python:
+            int(vars['$NUM'].replace('"', '')) > 32767 or int(vars['$NUM'].replace('"', '')) < -32768
+  - id: interter-overflow-int32
+    message:
+      Potential Integer overflow made by strconv.Atoi result conversion to int32
+    languages: [go]
+    severity: WARNING
+    patterns:
+      - pattern-either:
+        - pattern: |
+            $F, $ERR := strconv.Atoi($NUM)
+            ...
+            int32($F)
+        - pattern-where-python:
+            int(vars['$NUM'].replace('"', '')) > 2147483647 or int(vars['$NUM'].replace('"', '')) < -2147483648

--- a/go/gosec/overflow/overflow_int16.go
+++ b/go/gosec/overflow/overflow_int16.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main() {
+	mainInt16Ex1()
+	mainInt16Ex2()
+}
+
+func mainInt16Ex1() {
+	// ruleid: interter-overflow-int16
+	bigValue, err := strconv.Atoi("2147483648")
+	if err != nil {
+		panic(err)
+	}
+	value := int16(bigValue)
+	fmt.Println(value)
+}
+
+func mainInt16Ex2() {
+	// ok
+	bigValue, err := strconv.Atoi("10")
+	if err != nil {
+		panic(err)
+	}
+	value := int16(bigValue)
+	fmt.Println(value)
+}

--- a/go/gosec/overflow/overflow_int32.go
+++ b/go/gosec/overflow/overflow_int32.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func main1() {
+	mainInt32Ex1()
+	mainInt32Ex2()
+}
+
+func mainInt32Ex1() {
+	// ruleid: interter-overflow-int32
+	bigValue, err := strconv.Atoi("2147483648")
+	if err != nil {
+		panic(err)
+	}
+	value := int32(bigValue)
+	fmt.Println(value)
+}
+
+func mainInt32Ex2() {
+	// ok
+	bigValue, err := strconv.Atoi("10")
+	if err != nil {
+		panic(err)
+	}
+	value := int32(bigValue)
+	fmt.Println(value)
+}


### PR DESCRIPTION
Adds integer overflow detection for int16/int32 calls with
data flowing from strconv.Atoi.
It furthers [G109](https://github.com/securego/gosec/blob/master/rules/integer_overflow.go
) by actually validating the data flow and validating the string literal against against https://golang.org/pkg/builtin/#int32