### PR TITLE
Add math.rand (G404) checks

### DIFF
--- a/go/gosec/bad_imports/math_random.go
+++ b/go/gosec/bad_imports/math_random.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"crypto/rand"
+	mrand "math/rand"
+)
+
+func main() {
+	main0()
+	main1()
+	main2()
+	main3()
+}
+
+func main0() {
+	// pending https://github.com/returntocorp/sgrep/issues/411
+	// todoruleid: math-random-used
+	bad, _ := mrand.Read(nil)
+	println(bad)
+}
+
+func main1() {
+	// ok
+	good, _ := rand.Read(nil)
+	println(good)
+}
+
+func main2() {
+	// pending https://github.com/returntocorp/sgrep/issues/411
+	// todoruleid: math-random-used
+	bad := mrand.Int()
+	println(bad)
+}
+
+func main3() {
+	// ok because we only care about Read or Int
+	good, _ := rand.Read(nil)
+	println(good)
+	i := mrand.Int31()
+	println(i)
+}

--- a/go/gosec/bad_imports/math_random.yaml
+++ b/go/gosec/bad_imports/math_random.yaml
@@ -3,7 +3,7 @@ rules:
     message: Do not use math.rand. Use `crypto/rand` instead.
     languages: [go]
     severity: WARNING
-    patterns: 
+    patterns:
       - pattern-either:
           - pattern: math.rand.Int()
           - pattern: math.rand.Read(...)

--- a/go/gosec/bad_imports/math_random.yaml
+++ b/go/gosec/bad_imports/math_random.yaml
@@ -5,5 +5,11 @@ rules:
     severity: WARNING
     patterns:
       - pattern-either:
-          - pattern: math.rand.Int()
-          - pattern: math.rand.Read(...)
+          - pattern: |
+              import "math/rand"
+              ...
+              math.rand.Int()
+          - pattern: |
+              import "math/rand"
+              ...
+              math.rand.Read(...)

--- a/go/gosec/bad_imports/math_random.yaml
+++ b/go/gosec/bad_imports/math_random.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: math-random-used
+    message: Do not use math.rand. Use `crypto/rand` instead.
+    languages: [go]
+    severity: WARNING
+    patterns: 
+      - pattern-either:
+          - pattern: math.rand.Int()
+          - pattern: math.rand.Read(...)


### PR DESCRIPTION
This alerts on usage of Int() and Read() functions of math.rand module.
It acts the same as [G404](https://github.com/securego/gosec/blob/master/rules/rand.go)
~BLOCKED on Sgrep engine improvement in https://github.com/returntocorp/sgrep/issues/411~

