### PR TITLE
Hardcoded credential check without entrophy (G101)

### DIFF
--- a/go/gosec/hardcoded_credentials/hardcoded_credentials.go
+++ b/go/gosec/hardcoded_credentials/hardcoded_credentials.go
@@ -1,0 +1,37 @@
+package main
+
+import "fmt"
+
+func main1() {
+	username := "admin"
+	password := "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
+	fmt.Println("Doing something with: ", username, password)
+}
+
+func main2() {
+	username := "admin"
+	password := "secret"
+	fmt.Println("Doing something with: ", username, password)
+}
+
+var password = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
+
+func main3() {
+	username := "admin"
+	fmt.Println("Doing something with: ", username, password)
+}
+
+const cpassword = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
+
+func main4() {
+	username := "admin"
+	fmt.Println("Doing something with: ", username, cpassword)
+}
+
+const (
+	ATNStateTokenStart = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
+)
+
+func main5() {
+	println(ATNStateTokenStart)
+}

--- a/go/gosec/hardcoded_credentials/hardcoded_credentials.go
+++ b/go/gosec/hardcoded_credentials/hardcoded_credentials.go
@@ -4,16 +4,19 @@ import "fmt"
 
 func main1() {
 	username := "admin"
+	// ruleid: hardcoded-credentials
 	password := "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 	fmt.Println("Doing something with: ", username, password)
 }
 
 func main2() {
 	username := "admin"
+	// ruleid: hardcoded-credentials
 	password := "secret"
 	fmt.Println("Doing something with: ", username, password)
 }
 
+// ruleid: hardcoded-credentials
 var password = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 
 func main3() {
@@ -21,6 +24,7 @@ func main3() {
 	fmt.Println("Doing something with: ", username, password)
 }
 
+// ruleid: hardcoded-credentials
 const cpassword = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 
 func main4() {
@@ -28,6 +32,7 @@ func main4() {
 	fmt.Println("Doing something with: ", username, cpassword)
 }
 
+// ruleid: hardcoded-credentials
 const (
 	ATNStateTokenStart = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 )

--- a/go/gosec/hardcoded_credentials/hardcoded_credentials.go
+++ b/go/gosec/hardcoded_credentials/hardcoded_credentials.go
@@ -32,8 +32,8 @@ func main4() {
 	fmt.Println("Doing something with: ", username, cpassword)
 }
 
-// ruleid: hardcoded-credentials
 const (
+	// ruleid: hardcoded-credentials
 	ATNStateTokenStart = "f62e5bcda4fae4f82370da0c6f20697b8f8447ef"
 )
 

--- a/go/gosec/hardcoded_credentials/hardcoded_credentials.yaml
+++ b/go/gosec/hardcoded_credentials/hardcoded_credentials.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: hardcoded-credentials
+    message: Potential hardcoded credentials
+    severity: WARNING
+    languages: [go]
+    patterns:
+      # len([cred_name == vars['$VALUE'] for cred_name in ['"secret"', 'passwd','pass','password','pwd', 'secret', 'token']]) > 1
+      - pattern-either: 
+          - pattern: $VAR = "..."
+          - pattern: $VAR := "..."
+          - pattern: var $VAR = "..."
+          - pattern: const $VAR = "..."
+      - pattern-where-python: |
+            "password" in vars['$VAR'].lower() or "passwd" in vars['$VAR'].lower() or\
+            "pass" in  vars['$VAR'].lower() or "pwd" in vars['$VAR'].lower()  or \
+            "secret" in vars['$VAR'].lower() or "token" in vars['$VAR'].lower()

--- a/go/gosec/hardcoded_credentials/hardcoded_credentials.yaml
+++ b/go/gosec/hardcoded_credentials/hardcoded_credentials.yaml
@@ -5,7 +5,7 @@ rules:
     languages: [go]
     patterns:
       # len([cred_name == vars['$VALUE'] for cred_name in ['"secret"', 'passwd','pass','password','pwd', 'secret', 'token']]) > 1
-      - pattern-either: 
+      - pattern-either:
           - pattern: $VAR = "..."
           - pattern: $VAR := "..."
           - pattern: var $VAR = "..."


### PR DESCRIPTION
Tries to mimic [G101](https://github.com/securego/gosec/blob/master/rules/hardcoded_credentials.go) without
the entropy check on the value of the string literals. Blocked on https://github.com/returntocorp/sgrep/issues/412