### PR TITLE
* javascript/jwt-hardcode/jwt-hardcode.js: Fix todoruleid

### DIFF
--- a/javascript/jwt-hardcode/jwt-hardcode.js
+++ b/javascript/jwt-hardcode/jwt-hardcode.js
@@ -1,5 +1,4 @@
 "use strict";
-
 // ruleid: hardcoded-jwt-secret
 const jwt = require('jsonwebtoken');
 const Promise = require("bluebird");

--- a/javascript/jwt-hardcode/jwt-hardcode.js
+++ b/javascript/jwt-hardcode/jwt-hardcode.js
@@ -1,4 +1,5 @@
 "use strict";
+
 // ruleid: hardcoded-jwt-secret
 const jwt = require('jsonwebtoken');
 const Promise = require("bluebird");

--- a/javascript/jwt-hardcode/jwt-hardcode.js
+++ b/javascript/jwt-hardcode/jwt-hardcode.js
@@ -1,5 +1,5 @@
 "use strict";
-// todoruleid: hardcoded-jwt-secret
+// ruleid: hardcoded-jwt-secret
 const jwt = require('jsonwebtoken');
 const Promise = require("bluebird");
 const secret = "hardcoded-secret"


### PR DESCRIPTION
Really deep stmt matching probably allows to report this new error

test plan:
~/github/sgrep/sgrep_lint/sgrep.py --dangerously-allow-arbitrary-code-execution-from-rules --strict --test --test-ignore-todo .