### PR TITLE
PyYAML check

### DIFF
--- a/python/lang/security/deserialization/PyYAML.py
+++ b/python/lang/security/deserialization/PyYAML.py
@@ -1,0 +1,4 @@
+import yaml
+
+#ruleid:avoid-pyyaml-load
+yaml.load("!!python/object/new:os.system [echo EXPLOIT!]")

--- a/python/lang/security/deserialization/PyYAML.yaml
+++ b/python/lang/security/deserialization/PyYAML.yaml
@@ -11,7 +11,6 @@ rules:
     message:
       Avoid using `load()` as `PyYAML.load` could be easily exploited.
     fix: 
-      yaml.safe_load(...)
+      yaml.safe_load($FOO)
     severity: WARNING
-    pattern-either:
-      - pattern: yaml.load(...)
+    pattern: yaml.load($FOO)

--- a/python/lang/security/deserialization/PyYAML.yaml
+++ b/python/lang/security/deserialization/PyYAML.yaml
@@ -1,0 +1,17 @@
+rules:
+  - id: avoid-pyyaml-load
+    metadata:
+      owasp: "A8: Insecure Deserialization"
+      cwe: "CWE-502: Deserialization of Untrusted Data"
+      references: 
+      - https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
+      - https://nvd.nist.gov/vuln/detail/CVE-2017-18342
+    languages:
+    - python
+    message:
+      Avoid using `load()` as `PyYAML.load` could be easily exploited.
+    fix: 
+      yaml.safe_load(...)
+    severity: WARNING
+    pattern-either:
+      - pattern: yaml.load(...)


### PR DESCRIPTION
Add warning against yaml.load and recommend safe_load instead.

Addresses part of https://github.com/returntocorp/semgrep-rules/issues/511