### PR TITLE
add sax-xxe rule

### DIFF
--- a/javascript/sax/sax-xxe.js
+++ b/javascript/sax/sax-xxe.js
@@ -1,0 +1,49 @@
+function test1() {
+// ruleid: sax-xxe
+    var sax = require("sax"),
+    strict = false,
+    parser = sax.parser(strict);
+
+    parser.onattribute = function (attr) {
+        doSmth(attr)
+    };
+
+    parser.ondoctype = function(dt) {
+        processDocType(dt)
+    }
+    
+    const xml = `<?xml version="1.0" encoding="ISO-8859-1"?>
+    <!DOCTYPE foo [
+    <!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
+    <username>&xxe;</username>`;
+
+    parser.write(xml).close();
+}
+
+function test2() {
+// ruleid: sax-xxe
+    var saxStream = require("sax").createStream(strict, options)
+
+    saxStream.on("opentag", function (node) {
+        // same object as above
+    })
+
+    saxStream.on("doctype", function (node) {
+        processType(node)
+    })
+
+    fs.createReadStream("file.xml")
+        .pipe(saxStream)
+        .pipe(fs.createWriteStream("file-copy.xml"))
+}
+
+function okTest1() {
+// ok
+    var saxStream = require("sax").createStream(strict, options)
+
+    saxStream.on("ontext", function (node) {
+        // same object as above
+    })
+
+    fs.createReadStream("file.xml").pipe(saxStream).pipe(fs.createWriteStream("file-copy.xml"))
+}

--- a/javascript/sax/sax-xxe.yaml
+++ b/javascript/sax/sax-xxe.yaml
@@ -1,0 +1,18 @@
+rules:
+- id: sax-xxe
+  message: |
+    'ondoctype' detected. Be sure that entities received from a trusted source while processing XML.
+  metadata:
+    owasp: 'A4: XML External Entities (XXE)'
+    cwe: 'CWE-611: Improper Restriction of XML External Entity Reference'
+  severity: WARNING
+  languages: [javascript] 
+  pattern-either:
+    - pattern: |
+        require('sax');
+        ...
+        $PARSER.ondoctype = ...;
+    - pattern: |
+        require('sax');
+        ...
+        $PARSER.on('doctype',...);


### PR DESCRIPTION
under https://github.com/returntocorp/semgrep-rules/issues/508

as stated in module description https://www.npmjs.com/package/sax#regarding-doctype-s-and-entity-s
developers have to parse Entities on their own, so the rule is intended to warn about possible weakness while parsing for DTDs