### PR TITLE
add python version for yamlfmt hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
   rev: 0.0.13
   hooks:
   - id: yamlfmt
+    language_version: python3.6
         # NOTE: If you change these settings, be sure to also
         # change the semgrep.live YAML settings, otherwise diffs will fail
         # to lint


### PR DESCRIPTION
I know that it is lame but I still work from Ubuntu 16 where python 2.7 is the default, so I had to specify python version for `yamlfmt` hook explicitly