### PR TITLE
add xml2json-xxe rule

### DIFF
--- a/javascript/xml2json/security/audit/xml2json-xxe.js
+++ b/javascript/xml2json/security/audit/xml2json-xxe.js
@@ -1,0 +1,21 @@
+function test1(body) {
+    // ruleid: xml2json-xxe
+    const xml2json = require('xml2json')
+    const result = xml2json.toJson(body, { object: true, arrayNotation: true })
+    return result
+}
+
+function okTest1() {
+    // ok
+    const xml2json = require('xml2json')
+    const result = xml2json.toJson('<xml></xml>', { object: true, arrayNotation: true })
+    return result
+}
+
+function okTest1() {
+    // ok
+    const xml2json = require('xml2json')
+    let body = '<xml></xml>'
+    const result = xml2json.toJson(body, { object: true, arrayNotation: true })
+    return result
+}

--- a/javascript/xml2json/security/audit/xml2json-xxe.yaml
+++ b/javascript/xml2json/security/audit/xml2json-xxe.yaml
@@ -1,0 +1,25 @@
+rules:
+- id: xml2json-xxe
+  message: |
+    If unverified user data can reach the XML Parser it can result in XML External or
+    Internal Entity (XXE) Processing vulnerabilities
+  metadata:
+    owasp: 'A4: XML External Entities (XXE)'
+    cwe: 'CWE-611: Improper Restriction of XML External Entity Reference'
+  severity: WARNING
+  languages: [javascript]
+  patterns:
+  - pattern: |
+      var $XML = require('xml2json');
+      ...
+      $XML.toJson(...);
+  - pattern-not: |
+      var $XML = require('xml2json');
+      ...
+      $XML.toJson("...",...);
+  - pattern-not: |-
+      var $XML = require('xml2json');
+      ...
+      var $S = "...";
+      ...
+      $XML.toJson($S,...);


### PR DESCRIPTION
For https://github.com/returntocorp/semgrep-rules/issues/508

this is intended to work for `xml2json` module which uses `node-expat` behind (https://github.com/returntocorp/semgrep-rules/tree/develop/javascript/node-expat/security/audit) so passing untrusted stuff in it has the same consequences