### PR TITLE
add express-xml2json-xxe-event rule

### DIFF
--- a/javascript/express/security/audit/express-xml2json-xxe-event.js
+++ b/javascript/express/security/audit/express-xml2json-xxe-event.js
@@ -1,0 +1,54 @@
+function test1() {
+    var winston = require('winston'),
+        express = require('express'),
+        expat = require('xml2json');
+
+    var xmlParsingMiddleware = function(req, res, next) {
+        var buf = '';
+        req.setEncoding('utf8');
+        req.on('data', function (chunk) {
+            buf += chunk
+        });
+// ruleid: express-xml2json-xxe-event
+        req.on('end', function () {
+            req.body = expat.toJson(buf, {coerce: true, object: true});
+            next();
+        });
+    };
+}
+
+function test2() {
+    const express = require('express')
+    const app = express()
+    const port = 3000
+
+    app.get('/', (req, res) => {
+        var buf = '';
+        req.setEncoding('utf8');
+        req.on('data', function (chunk) {
+            buf += chunk
+        });
+// ruleid: express-xml2json-xxe-event
+        req.on('end', function () {
+            req.body = expat.toJson(buf, {coerce: true, object: true});
+            next();
+        });
+    })
+
+    app.listen(port, () => console.log(`Example app listening at http://localhost:${port}`))
+}
+
+function okTest() {
+    const express = require('express')
+    const app = express()
+    const port = 3000
+    const someEvent = require('some-event')
+
+// ok
+    someEvent.on('event', function (err, data) {
+        req.body = expat.toJson(data, {coerce: true, object: true});
+        next();
+    });
+
+    app.listen(port, () => console.log(`Example app listening at http://localhost:${port}`))
+}

--- a/javascript/express/security/audit/express-xml2json-xxe-event.yaml
+++ b/javascript/express/security/audit/express-xml2json-xxe-event.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: express-xml2json-xxe-event
+  message: |
+    Xml Parser is used inside Request Event.
+    Make sure that unverified user data can not reach the XML Parser,
+    as it can result in XML External or Internal Entity (XXE) Processing vulnerabilities
+  metadata:
+    owasp: 'A4: XML External Entities (XXE)'
+    cwe: 'CWE-611: Improper Restriction of XML External Entity Reference'
+  severity: WARNING
+  languages: [javascript]
+  patterns:
+  - pattern-inside: |
+      ...
+      require('xml2json');
+      ...
+  - pattern-either:
+    - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
+    - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
+    - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
+    - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
+  - pattern: $REQ.on('...', function(...) { ... $EXPAT.toJson($INPUT,...); ... });


### PR DESCRIPTION
`express` edition of the rule: https://github.com/returntocorp/semgrep-rules/blob/develop/javascript/xml2json/security/audit/xml2json-xxe.yaml

based on a few real findings