### PR TITLE
Fix unintentional metavariable matching

### DIFF
--- a/javascript/lang/correctness/useless-assign.yaml
+++ b/javascript/lang/correctness/useless-assign.yaml
@@ -2,14 +2,14 @@ rules:
 - id: useless-assignment
   patterns:
   - pattern-not: |
-      $X = $Y;
-      $X = $X.$Z(...);
+      $A = $B;
+      $A = $A.$C(...);
   - pattern-not: |
-      $X = $Y;
-      $X = $Z + $X;
+      $D = $E;
+      $D = $F + $D;
   - pattern-not: |
-      $X = $Y;
-      $X = $X + $Z;
+      $H = $I;
+      $H = $H + $J;
   - pattern: |
       $X = $Y;
       $X = $Z;

--- a/javascript/lang/correctness/useless-assign.yaml
+++ b/javascript/lang/correctness/useless-assign.yaml
@@ -2,14 +2,14 @@ rules:
 - id: useless-assignment
   patterns:
   - pattern-not: |
-      $A = $B;
-      $A = $A.$C(...);
+      $X = $Y;
+      $X = $X.$METHOD(...);
   - pattern-not: |
-      $D = $E;
-      $D = $F + $D;
+      $X = $Y;
+      $X = $PREPEND + $X;
   - pattern-not: |
-      $H = $I;
-      $H = $H + $J;
+      $X = $Y;
+      $X = $X + $POSTPEND;
   - pattern: |
       $X = $Y;
       $X = $Z;


### PR DESCRIPTION
https://github.com/returntocorp/semgrep/pull/947 depends on this.

Not sure why `semgrep-rules/python/flask/security/injection/ssrf-requests.yaml` is failing on that PR. That test works locally for me. I'll give this change a shot, then continue to debug if there's still issues.