### PR TITLE
add jose-exposed-data rule

### DIFF
--- a/javascript/jose/security/audit/jose-exposed-data.js
+++ b/javascript/jose/security/audit/jose-exposed-data.js
@@ -1,0 +1,23 @@
+const config = require('./config')
+const {JWT} = require('jose')
+
+function example(user) {
+// ruleid: jose-exposed-data
+    const token = JWT.sign(user, secret)
+    return token;
+}
+
+function example2(user) {
+// ok
+    const token = JWT.sign({name: user.name}, secret)
+    return token;
+}
+
+function example3(user) {
+// ok
+    const obj = {
+        name: user.name
+    }
+    const token = JWT.sign(obj, secret)
+    return token;
+}

--- a/javascript/jose/security/audit/jose-exposed-data.yaml
+++ b/javascript/jose/security/audit/jose-exposed-data.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: jose-exposed-data
+  message: |
+    The object is passed strictly to jose.JWT.sign(...)
+    Make sure that sensitive information is not exposed through JWT token payload.
+  severity: WARNING
+  metadata:
+    owasp: A3:2017-Sensitive Data Exposure
+    cwe: 'CWE-522: Insufficiently Protected Credentials'
+  languages: [javascript]
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        ...
+        require('jose');
+        ...
+  - pattern-either:
+    - pattern-inside: function (...,$INPUT,...) {...}
+    - pattern-inside: function $F(...,$INPUT,...) {...}
+  - pattern-either:
+    - pattern: $JOSE.JWT.sign($INPUT,...)
+    - pattern: $JWT.sign($INPUT,...)


### PR DESCRIPTION
the rule is intended to find when an object is converted to JWT token without explicitly striping sensitive data from it