### PR TITLE
Refactor python disabled verification rules.

### DIFF
--- a/python/lang/security/audit/network/disabled-cert-validation.py
+++ b/python/lang/security/audit/network/disabled-cert-validation.py
@@ -1,5 +1,4 @@
 import urllib3 as ur3
-import requests as req
 import ssl as sss
 
 import socket
@@ -38,9 +37,6 @@ proxy = ur3.ProxyManager('http://localhost:3128/', cert_reqs = ssl.CERT_NONE)
 # ruleid:disabled-cert-validation
 pool = ur3.connectionpool.HTTPSConnectionPool(cert_reqs=ssl.CERT_OPTIONAL)
 
-# ruleid:http-not-https-connection
-pool2 = ur3.connectionpool.HTTPConnectionPool(bla)
-
 # ruleid:disabled-cert-validation
 pool = ur3.connection_from_url('someurl', cert_reqs= ssl.CERT_NONE)
 
@@ -63,13 +59,3 @@ pool = ur3.proxy_from_url('someurl', cert_reqs= ssl.CERT_NONE)
 pool = ur3.proxy_from_url('someurl', cert_reqs= ssl.CERT_REQUIED)
 # ok
 pool = ur3.proxy_from_url('someurl', cert_reqs=None)
-
-r = req.get(some_url, stream=True)
-import requests
-r = requests.post(some_url, stream=True)
-
-# ruleid:disabled-cert-validation-requests
-r = req.get(some_url, stream=True, verify=False)
-import requests
-# ruleid:disabled-cert-validation-requests
-r = requests.post(some_url, stream=True, verify=False)

--- a/python/lang/security/audit/network/disabled-cert-validation.yaml
+++ b/python/lang/security/audit/network/disabled-cert-validation.yaml
@@ -18,32 +18,4 @@ rules:
     cwe: 'CWE-295: Improper Certificate Validation'
     owasp: 'A3: Sensitive Data Exposure'
   languages: [python]
-  severity: WARNING
-- id: http-not-https-connection
-  patterns:
-  - pattern-either:
-    - pattern: urllib3.HTTPConnectionPool(...)
-    - pattern: urllib3.connectionpool.HTTPConnectionPool(...)
-  message: suggest HTTPS over HTTP connection
-  metadata:
-    cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
-    owasp: 'A3: Sensitive Data Exposure'
-  languages: [python]
-  severity: WARNING
-- id: disabled-cert-validation-requests
-  patterns:
-  - pattern-either:
-    - pattern: requests.put(..., verify=False, ...)
-    - pattern: requests.patch(..., verify=False, ...)
-    - pattern: requests.delete(..., verify=False, ...)
-    - pattern: requests.head(..., verify=False, ...)
-    - pattern: requests.options(..., verify=False, ...)
-    - pattern: requests.request(..., verify=False, ...)
-    - pattern: requests.get(..., verify=False, ...)
-    - pattern: requests.post(..., verify=False, ...)
-  message: certificate verification explicitly disabled, insecure connections possible
-  metadata:
-    cwe: 'CWE-295: Improper Certificate Validation'
-    owasp: 'A3: Sensitive Data Exposure'
-  languages: [python]
-  severity: WARNING
+  severity: ERROR

--- a/python/lang/security/audit/network/http-not-https-connection.py
+++ b/python/lang/security/audit/network/http-not-https-connection.py
@@ -1,0 +1,7 @@
+import urllib3 as ur3
+
+# ruleid:http-not-https-connection
+pool = ur3.connectionpool.HTTPConnectionPool("example.com")
+
+# ok
+spool = ur3.connectionpool.HTTPSConnectionPool("example.com")

--- a/python/lang/security/audit/network/http-not-https-connection.yaml
+++ b/python/lang/security/audit/network/http-not-https-connection.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: http-not-https-connection
+  patterns:
+  - pattern-either:
+    - pattern: urllib3.HTTPConnectionPool(...)
+    - pattern: urllib3.connectionpool.HTTPConnectionPool(...)
+  message: |
+    Detected HTTPConnectionPool. It is recommended to use
+    HTTPSConnectionPool instead for security.
+  metadata:
+    cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
+    owasp: 'A3: Sensitive Data Exposure'
+    references:
+    - https://urllib3.readthedocs.io/en/1.2.1/pools.html#urllib3.connectionpool.HTTPSConnectionPool
+  languages: [python]
+  severity: ERROR

--- a/python/requests/security/disabled-cert-validation.py
+++ b/python/requests/security/disabled-cert-validation.py
@@ -1,0 +1,17 @@
+
+import requests as req
+import requests
+
+some_url = "https://example.com"
+
+# ok
+r = req.get(some_url, stream=True)
+# ok
+r = requests.post(some_url, stream=True)
+
+# ruleid:disabled-cert-validation
+r = req.get(some_url, stream=True, verify=False)
+# ruleid:disabled-cert-validation
+r = requests.post(some_url, stream=True, verify=False)
+# ruleid:disabled-cert-validation
+r = requests.post(some_url, verify=False, stream=True)

--- a/python/requests/security/disabled-cert-validation.yaml
+++ b/python/requests/security/disabled-cert-validation.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: disabled-cert-validation
+  patterns:
+  - pattern-either:
+    - pattern: requests.put(..., verify=False, ...)
+    - pattern: requests.patch(..., verify=False, ...)
+    - pattern: requests.delete(..., verify=False, ...)
+    - pattern: requests.head(..., verify=False, ...)
+    - pattern: requests.options(..., verify=False, ...)
+    - pattern: requests.request(..., verify=False, ...)
+    - pattern: requests.get(..., verify=False, ...)
+    - pattern: requests.post(..., verify=False, ...)
+  message: |
+    Certificate verification has been explicitly disabled. This
+    permits for insecure connections to insecure servers.
+  metadata:
+    cwe: 'CWE-295: Improper Certificate Validation'
+    owasp: 'A3: Sensitive Data Exposure'
+    references:
+    - https://stackoverflow.com/questions/41740361/is-it-safe-to-disable-ssl-certificate-verification-in-pythonss-requests-lib
+  languages: [python]
+  severity: ERROR


### PR DESCRIPTION
Split up python disabled verification rules.

Previously there were three rules in one file. One of these rules used `pattern-where-python` which created complications for use of these rules in other rule packs.

This PR factors out these rules into their own files with their own tests.