### PR TITLE
Fix regression using latest semgrep

### DIFF
--- a/contrib/nodejsscan/header_cors_star.yaml
+++ b/contrib/nodejsscan/header_cors_star.yaml
@@ -16,7 +16,7 @@ rules:
 - id: express_cors
   patterns:
   - pattern-inside: |
-      $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) { ... })
+      $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) { ... });
   - pattern-either:
     - pattern: |
         $APP.options('*', cors(...))

--- a/java/lang/security/audit/formatted-sql-string.yaml
+++ b/java/lang/security/audit/formatted-sql-string.yaml
@@ -9,8 +9,8 @@ rules:
     injection if variables in the SQL statement are not properly sanitized.
     Use a prepared statements (java.sql.PreparedStatement) instead.
   patterns:
-  - pattern-not: $W.execute(<... "=~/.*TABLE *$/" ...>)
-  - pattern-not: $W.execute(<... "=~/.*TABLE %s$/" ...>)
+  - pattern-not: $W.execute(<... "=~/.*TABLE *$/" ...>);
+  - pattern-not: $W.execute(<... "=~/.*TABLE %s$/" ...>);
   - pattern-either:
     - pattern: $W.execute($X + $Y, ...);
     - pattern: |


### PR DESCRIPTION
I've recently added ';' in the generic AST, but this introduced
some regressions in semgrep-rules because the range changed
and if you're using pattern-not or pattern-inside, this has implications.
Indeed if one pattern use ';' and the other not, then the range are
different and the intersection or negation might not trigger.

I didn't anticipate this problem ... It might be better to remove
back those ';' in the generic AST, but at the same time it also
allows better autofixing in the futur and better matching display
(we will highlight the ';' in semgrep.live if your pattern uses one).

Test plan:
make test (with latest semgrep-core locally;
hopefully the docker image will catch up)