### PR TITLE
* python/boto3/security/hardcoded-token.yaml: We can now rely on const propagation for Python

### DIFF
--- a/python/boto3/security/hardcoded-token.py
+++ b/python/boto3/security/hardcoded-token.py
@@ -11,9 +11,9 @@ s = boto3.sessions
 # ruleid:hardcoded-token
 s.Session(aws_access_key_id="AKIAxxxxxxxxxxxxxxxx")
 
-# ruleid:hardcoded-token
 uhoh_key = "AKIAxxxxxxxxxxxxxxxx"
 ok_secret = os.environ.get("SECRET_ACCESS_KEY")
+# ruleid:hardcoded-token
 s3 = boto3.resource(
     "s3",
     aws_access_key_id=uhoh_key,
@@ -23,8 +23,9 @@ s3 = boto3.resource(
 )
 
 ok_key = os.environ.get("ACCESS_KEY_ID")
-# ruleid:hardcoded-token
+
 uhoh_secret = "jWnyxxxxxxxxxxxxxxxxX7ZQxxxxxxxxxxxxxxxx"
+# ruleid:hardcoded-token
 s3 = boto3.resource(
     "s3",
     aws_access_key_id=ok_key,

--- a/python/boto3/security/hardcoded-token.yaml
+++ b/python/boto3/security/hardcoded-token.yaml
@@ -16,13 +16,5 @@ rules:
     - pattern: $W(..., aws_secret_access_key="=~/[A-Za-z0-9/+=]+/", ...)
     - pattern: $W(..., aws_access_key_id="=~/^AKI/", ...)
     - pattern: $W(..., aws_session_token="...", ...)
-    - pattern: |
-        $ACCESSKEY = "=~/^AKI/"
-        ...
-        $W(..., aws_access_key_id=$ACCESSKEY, ...)
-    - pattern: |
-        $SECRETKEY = "=~/[A-Za-z0-9]+/"
-        ...
-        $W(..., aws_secret_access_key=$SECRETKEY, ...)
   languages: [python]
   severity: WARNING


### PR DESCRIPTION
No need to write an extra pattern matching the global declaration

Test plan:
make test