### PR TITLE
Add PostMessage Security Rules

### DIFF
--- a/javascript/browser/security/insecure-postmessage-configuration.js
+++ b/javascript/browser/security/insecure-postmessage-configuration.js
@@ -1,0 +1,37 @@
+let data={pName : "Bob", pAge: "35"};
+var popup = window.open(/* popup details */);
+
+//ruleid:wildcard-postmessage-configuration
+popup.postMessage(data, '*');
+//ruleid:wildcard-postmessage-configuration
+popup.postMessage( JSON.stringify( data ), '*' );
+
+//postMessage Safe Usage
+popup.postMessage("hello there!", "http://domain.tld");    
+popup.postMessage( JSON.stringify( data ), 'semgrep.dev/editor');
+
+//ruleid:insufficient-postmessage-origin-validation
+window.addEventListener("message", receiveMessage, false);
+
+
+//addEventListener Safe Usage (Origin Checked)
+const globalRegex = RegExp('/^http://www.examplesender.com$/', 'g');
+window.addEventListener("message", function(message){
+    if(globalRegex.test(message.origin)){
+         console.log(message.data);
+   }
+});
+
+//addEventListener Safe Usage (Origin Checked)
+window.addEventListener("message", function(message){
+if (event.origin !== "http://example.com") {
+    return;
+}
+});
+
+//addEventListener Safe Usage (Origin Checked)
+window.addEventListener("message", function(message){
+if (event.origin == "http://example.com") {
+    alert("Works");
+}
+});

--- a/javascript/browser/security/insecure-postmessage-configuration.yaml
+++ b/javascript/browser/security/insecure-postmessage-configuration.yaml
@@ -1,0 +1,41 @@
+rules:
+  - id: wildcard-postmessage-configuration
+    patterns:
+      - pattern-either: 
+        - pattern: |
+            $OBJECT.postMessage(...,'*')
+    message: |
+              The target origin of the window.postMessage() API is set to "*". This could allow for information disclosure due to the possibility of any origin allowed to receive the message.
+    languages:
+    - javascript
+    severity: WARNING
+    metadata:
+      owasp: 'A6: Sensitive Data Exposure'
+      cwe: 'CWE-345: Insufficient Verification of Data Authenticity'
+  - id: insufficient-postmessage-origin-validation
+    patterns:
+      - pattern-either: 
+        - pattern: |
+            window.addEventListener(...)
+      - pattern-not: |
+          window.addEventListener(..., function($OBJECT){ if ($OBJ.origin == $X) {
+                      ...
+                  }; });
+      - pattern-not: |
+          window.addEventListener(..., function($OBJECT){ if ($REGEX.test($OBJECT.origin)){
+              ...
+          }; });
+      - pattern-not: |
+          window.addEventListener(..., function($OBJECT){ if ($OBJ.origin !== $X) {
+                      ...
+                  }; });
+    message: |
+      No validation of origin is done by the addEventListener API. It may be possible to exploit this flaw to perform Cross Origin attacks such as Cross-Site Scripting(XSS).
+    languages:
+    - javascript
+    fix: |
+      
+    severity: WARNING
+    metadata:
+      owasp: 'A6: Sensitive Data Exposure'
+      cwe: 'CWE-345: Insufficient Verification of Data Authenticity'


### PR DESCRIPTION
This PR contains two rules related to Postmessage security. One for postMessage API wilcard issues and another for addEventListener API not checking origin. The addEventListener rule pattern will have False Negative cases since I am only checking for two common semantic patterns.

### References
* https://labs.detectify.com/2016/12/08/the-pitfalls-of-postmessage/
* https://docs.ioin.in/writeup/www.exploit-db.com/_docs_40287_pdf/index.pdf