### PR TITLE
Add unsafe ruamel.yaml usage rule

### DIFF
--- a/python/lang/security/deserialization/avoid-unsafe-ruamel.py
+++ b/python/lang/security/deserialization/avoid-unsafe-ruamel.py
@@ -1,0 +1,16 @@
+from ruamel.yaml import YAML
+
+#ok:avoid-unsafe-ruamel
+y1 = YAML()  # default is 'rt'
+
+#ok:avoid-unsafe-ruamel
+y2 = YAML(typ='rt')
+
+#ok:avoid-unsafe-ruamel
+y3 = YAML(typ='safe')
+
+#ruleid:avoid-unsafe-ruamel
+y3 = YAML(typ='unsafe')
+
+#ruleid:avoid-unsafe-ruamel
+y4 = YAML(typ='base')

--- a/python/lang/security/deserialization/avoid-unsafe-ruamel.yaml
+++ b/python/lang/security/deserialization/avoid-unsafe-ruamel.yaml
@@ -1,0 +1,18 @@
+rules:
+- id: avoid-unsafe-ruamel
+  metadata:
+    owasp: 'A8: Insecure Deserialization'
+    cwe: 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://yaml.readthedocs.io/en/latest/basicuse.html?highlight=typ
+  languages:
+  - python
+  message: |
+    Avoid using unsafe `ruamel.yaml.YAML()`. `ruamel.yaml.YAML` can
+    create arbitrary Python objects. A malicious actor could exploit
+    this to run arbitrary code. Use `YAML(typ='rt')` or
+    `YAML(typ='safe')` instead.
+  severity: ERROR
+  pattern-either:
+  - pattern: ruamel.yaml.YAML(..., typ='unsafe', ...)
+  - pattern: ruamel.yaml.YAML(..., typ='base', ...)


### PR DESCRIPTION
Our Python YAML deserialization rule looks for PyYAML but not `ruamel.yaml`. To support internal use-cases let's check for unsafe `ruamel` too.