### PR TITLE
Add rules for HttpOnly and Secure flags in Gorilla session cookies

### DIFF
--- a/go/gorilla/security/audit/session-cookie-missing-httponly.go
+++ b/go/gorilla/security/audit/session-cookie-missing-httponly.go
@@ -1,0 +1,94 @@
+// cf. https://github.com/0c34/govwa/blob/139693e56406b5684d2a6ae22c0af90717e149b8/user/session/session.go
+
+package session
+
+import (
+	"log"
+	"fmt"
+	"net/http"
+	"govwa/util/config"
+	"github.com/gorilla/sessions"
+)
+
+type Self struct{}
+
+func New() *Self {
+	return &Self{}
+}
+
+var store = sessions.NewCookieStore([]byte(config.Cfg.Sessionkey))
+
+func (self *Self) SetSession(w http.ResponseWriter, r *http.Request, data map[string]string) {
+	session, err := store.Get(r, "govwa")
+
+	if err != nil {
+		log.Println(err.Error())
+	}
+
+    // ruleid: session-cookie-missing-httponly
+	session.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   3600,
+		HttpOnly: false, //set to false for xss :)
+        Secure: true,
+	}
+
+	session.Values["govwa_session"] = true
+
+	//create new session to store on server side
+	if data != nil {
+		for key, value := range data {
+			session.Values[key] = value
+		}
+	}
+	err = session.Save(r, w) //safe session and send it to client as cookie
+	
+		if err != nil {
+			log.Println(err.Error())
+		}
+}
+
+func (self *Self) GetSession(r *http.Request, key string) string  {
+	session, err := store.Get(r, "govwa")
+
+	if err != nil {
+		log.Println(err.Error())
+		return ""
+	}
+	data := session.Values[key]
+	sv := fmt.Sprintf("%v", data)
+	return sv
+}
+
+func (self *Self) DeleteSession(w http.ResponseWriter, r *http.Request) {
+	session, err := store.Get(r, "govwa")
+	if err != nil {
+		log.Println(err.Error())
+	}
+	
+    // ruleid: session-cookie-missing-httponly
+	session.Options = &sessions.Options{
+		MaxAge:   -1,
+		HttpOnly: false, //set to false for xss :) 
+	}
+
+	session.Values["govwa_session"] = false
+	err = session.Save(r, w) //safe session and send it to client as cookie
+
+	if err != nil {
+		log.Println(err.Error())
+	}
+
+	return
+}
+
+func (self *Self) IsLoggedIn(r *http.Request) bool {
+	s, err := store.Get(r, "govwa")
+	if err != nil {
+		log.Println(err.Error())
+	}
+	if auth, ok := s.Values["govwa_session"].(bool); !ok || !auth {
+		return false
+	}
+	return true
+}

--- a/go/gorilla/security/audit/session-cookie-missing-httponly.yaml
+++ b/go/gorilla/security/audit/session-cookie-missing-httponly.yaml
@@ -1,0 +1,29 @@
+rules:
+- id: session-cookie-missing-httponly
+  patterns:
+  - pattern-not-inside: |
+      &sessions.Options{
+        ...,
+        HttpOnly: true,
+        ...,
+      }
+  - pattern: |
+      &sessions.Options{
+        ...,
+      }
+  message: |
+    A session cookie was detected without setting the 'HttpOnly' flag.
+    The 'HttpOnly' flag for cookies instructs the browser to forbid
+    client-side scripts from reading the cookie which mitigates XSS
+    attacks. Set the 'HttpOnly' flag by setting 'HttpOnly' to 'true'
+    in the Options struct.
+  metadata:
+    cwe: "CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag"
+    owasp: 'A3: Sensitive Data Exposure'
+    references:
+    - https://github.com/0c34/govwa/blob/139693e56406b5684d2a6ae22c0af90717e149b8/user/session/session.go#L69
+  fix-regex:
+    regex: (HttpOnly\s*:\s+)false
+    replacement: \1true
+  severity: WARNING
+  languages: [go]

--- a/go/gorilla/security/audit/session-cookie-missing-secure.go
+++ b/go/gorilla/security/audit/session-cookie-missing-secure.go
@@ -1,0 +1,94 @@
+// cf. https://github.com/0c34/govwa/blob/139693e56406b5684d2a6ae22c0af90717e149b8/user/session/session.go
+
+package session
+
+import (
+	"log"
+	"fmt"
+	"net/http"
+	"govwa/util/config"
+	"github.com/gorilla/sessions"
+)
+
+type Self struct{}
+
+func New() *Self {
+	return &Self{}
+}
+
+var store = sessions.NewCookieStore([]byte(config.Cfg.Sessionkey))
+
+func (self *Self) SetSession(w http.ResponseWriter, r *http.Request, data map[string]string) {
+	session, err := store.Get(r, "govwa")
+
+	if err != nil {
+		log.Println(err.Error())
+	}
+
+    // ruleid: session-cookie-missing-secure
+	session.Options = &sessions.Options{
+		Path:     "/",
+		MaxAge:   3600,
+		HttpOnly: false, //set to false for xss :)
+        Secure: false,
+	}
+
+	session.Values["govwa_session"] = true
+
+	//create new session to store on server side
+	if data != nil {
+		for key, value := range data {
+			session.Values[key] = value
+		}
+	}
+	err = session.Save(r, w) //safe session and send it to client as cookie
+	
+		if err != nil {
+			log.Println(err.Error())
+		}
+}
+
+func (self *Self) GetSession(r *http.Request, key string) string  {
+	session, err := store.Get(r, "govwa")
+
+	if err != nil {
+		log.Println(err.Error())
+		return ""
+	}
+	data := session.Values[key]
+	sv := fmt.Sprintf("%v", data)
+	return sv
+}
+
+func (self *Self) DeleteSession(w http.ResponseWriter, r *http.Request) {
+	session, err := store.Get(r, "govwa")
+	if err != nil {
+		log.Println(err.Error())
+	}
+	
+    // ruleid: session-cookie-missing-secure
+	session.Options = &sessions.Options{
+		MaxAge:   -1,
+		HttpOnly: false, //set to false for xss :) 
+	}
+
+	session.Values["govwa_session"] = false
+	err = session.Save(r, w) //safe session and send it to client as cookie
+
+	if err != nil {
+		log.Println(err.Error())
+	}
+
+	return
+}
+
+func (self *Self) IsLoggedIn(r *http.Request) bool {
+	s, err := store.Get(r, "govwa")
+	if err != nil {
+		log.Println(err.Error())
+	}
+	if auth, ok := s.Values["govwa_session"].(bool); !ok || !auth {
+		return false
+	}
+	return true
+}

--- a/go/gorilla/security/audit/session-cookie-missing-secure.yaml
+++ b/go/gorilla/security/audit/session-cookie-missing-secure.yaml
@@ -1,0 +1,28 @@
+rules:
+- id: session-cookie-missing-secure
+  patterns:
+  - pattern-not-inside: |
+      &sessions.Options{
+        ...,
+        Secure: true,
+        ...,
+      }
+  - pattern: |
+      &sessions.Options{
+        ...,
+      }
+  message: |
+    A session cookie was detected without setting the 'Secure' flag.
+    The 'secure' flag for cookies prevents the client from transmitting
+    the cookie over insecure channels such as HTTP.  Set the 'Secure'
+    flag by setting 'Secure' to 'true' in the Options struct.
+  metadata:
+    cwe: "CWE-614: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute"
+    owasp: 'A3: Sensitive Data Exposure'
+    references:
+    - https://github.com/0c34/govwa/blob/139693e56406b5684d2a6ae22c0af90717e149b8/user/session/session.go#L69
+  fix-regex:
+    regex: (Secure\s*:\s+)false
+    replacement: \1true
+  severity: WARNING
+  languages: [go]


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep-rules/issues/818.