### PR TITLE
Django xss rules

### DIFF
--- a/python/django/security/audit/xss/class-extends-safestring.py
+++ b/python/django/security/audit/xss/class-extends-safestring.py
@@ -1,12 +1,17 @@
-from django.utils.safestring import SafeString, SafeData
+from django.utils.safestring import SafeString, SafeData, SafeText
 
 # ruleid:class-extends-safestring
-class IWantToBypassEsccaping(SafeString):
+class IWantToBypassEscaping(SafeString):
+    def __init__(self):
+        super().__init__()
+        
+# ruleid:class-extends-safestring
+class IWantToBypassEscaping2(SafeText):
     def __init__(self):
         super().__init__()
 
 # ruleid:class-extends-safestring
-class IWantToBypassEsccaping2(SafeData):
+class IWantToBypassEscaping3(SafeData):
     def __init__(self):
         super().__init__()
 

--- a/python/django/security/audit/xss/class-extends-safestring.py
+++ b/python/django/security/audit/xss/class-extends-safestring.py
@@ -1,0 +1,16 @@
+from django.utils.safestring import SafeString, SafeData
+
+# ruleid:class-extends-safestring
+class IWantToBypassEsccaping(SafeString):
+    def __init__(self):
+        super().__init__()
+
+# ruleid:class-extends-safestring
+class IWantToBypassEsccaping2(SafeData):
+    def __init__(self):
+        super().__init__()
+
+# ok:class-extends-safestring        
+class SomethingElse(str):
+    def __init__(self):
+        super().__init__()

--- a/python/django/security/audit/xss/class-extends-safestring.yaml
+++ b/python/django/security/audit/xss/class-extends-safestring.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: class-extends-safestring
+  message: |
+    Found a class extending 'SafeString' or 'SafeData'. These classes are
+    for bypassing the escaping enging built in to Django and should not be
+    used directly. Improper use of this class exposes your application to
+    cross-site scripting (XSS) vulnerabilities. If you need this functionality,
+    use 'mark_safe' instead and ensure no user data can reach it.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.1/howto/custom-template-tags/#filters-and-auto-escaping
+  languages:
+  - python
+  severity: WARNING
+  pattern-either:
+  - pattern: |
+      class $CLASS(django.utils.safestring.SafeString):
+        ...
+  - pattern: |-
+      class $CLASS(django.utils.safestring.SafeData):
+        ...

--- a/python/django/security/audit/xss/class-extends-safestring.yaml
+++ b/python/django/security/audit/xss/class-extends-safestring.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: class-extends-safestring
   message: |
-    Found a class extending 'SafeString' or 'SafeData'. These classes are
+    Found a class extending 'SafeString', 'SafeText' or 'SafeData'. These classes are
     for bypassing the escaping enging built in to Django and should not be
     used directly. Improper use of this class exposes your application to
     cross-site scripting (XSS) vulnerabilities. If you need this functionality,
@@ -11,12 +11,16 @@ rules:
     owasp: 'A7: Cross-site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.1/howto/custom-template-tags/#filters-and-auto-escaping
+    - https://github.com/django/django/blob/f138e75910b1e541686c4dce3d8f467f6fc234cb/django/utils/safestring.py#L11
   languages:
   - python
   severity: WARNING
   pattern-either:
   - pattern: |
       class $CLASS(django.utils.safestring.SafeString):
+        ...
+  - pattern: |
+      class $CLASS(django.utils.safestring.SafeText):
         ...
   - pattern: |-
       class $CLASS(django.utils.safestring.SafeData):

--- a/python/django/security/audit/xss/context-autoescape-off.py
+++ b/python/django/security/audit/xss/context-autoescape-off.py
@@ -1,0 +1,36 @@
+import base64
+import mimetypes
+import os
+
+from django.core.urlresolvers import reverse
+from django.http import HttpResponse
+from django.shortcuts import redirect, render
+from django.views.decorators.csrf import csrf_exempt
+
+# adapted from https://github.com/mpirnat/lets-be-bad-guys/blob/7cbf11014bfc6dc9e199dc0b8a64e4597bc2338f/badguys/vulnerable/views.py#L95
+
+def file_access(request):
+    msg = request.GET.get('msg', '')
+    # ok: context-autoescape-off
+    return render(request, 'vulnerable/injection/file_access.html',
+            {'msg': msg})
+
+## 03 - XSS
+
+def xss_form(request):
+    # ruleid: context-autoescape-off
+    env = {'qs': request.GET.get('qs', 'hello'), 'autoescape': False}
+    response = render(request, 'vulnerable/xss/form.html', env)
+    response.set_cookie(key='monster', value='omnomnomnomnom!')
+    return response
+
+
+def xss_path(request, path='default'):
+    # ruleid: context-autoescape-off
+    env = {'autoescape': False, 'path': path}
+    return render(request, 'vulnerable/xss/path.html', env)
+
+
+def xss_query(request):
+    # ruleid: context-autoescape-off
+    return render(request, 'vulnerable/xss/query.html', {'qs': request.GET.get('qs', 'hello'), "autoescape":False})

--- a/python/django/security/audit/xss/context-autoescape-off.yaml
+++ b/python/django/security/audit/xss/context-autoescape-off.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: context-autoescape-off
+  message: |
+    Detected a Context with autoescape diabled. If you are
+    rendering any web pages, this exposes your application to cross-site
+    scripting (XSS) vulnerabilities. Remove 'autoescape: False' or set it
+    to 'True'.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.1/ref/settings/#templates
+    - https://docs.djangoproject.com/en/3.1/topics/templates/#django.template.backends.django.DjangoTemplates
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-either:
+    - pattern: '{..., "autoescape": False, ...}'
+    - pattern: $D["autoescape"] = False
+  fix-regex:
+    regex: (autoescape.*?)False
+    replacement: \1True

--- a/python/django/security/audit/xss/direct-use-of-httpresponse.py
+++ b/python/django/security/audit/xss/direct-use-of-httpresponse.py
@@ -1,0 +1,49 @@
+import urllib
+from django.db.models import Q
+from django.auth import User
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.utils.translation import ugettext as _
+
+from org import engines, manageNoEngine, genericApiException
+
+def search_certificates(request):
+    user_filter = request.GET.get("user", "")
+    if not user_filter:
+        # ok:direct-use-of-httpresponse
+        return HttpResponseBadRequest("user was not given")
+
+
+    user = User.objects.get(Q(email=user_filter) | Q(username=user_filter))
+    if user.DoesNotExist:
+         # ruleid:direct-use-of-httpresponse
+        return HttpResponseBadRequest(_("user '{user}' does not exist").format(user_filter))
+
+def previewNode(request, uid):
+    """Preview evaluante node"""
+    try:
+        if uid in engines:
+            _nodeId = request.data.get('nodeId')
+            engines[uid].stoppable = True
+            _res = engines[uid].model.previewNode(_nodeId)
+            if _res is None:
+                # ok:direct-use-of-httpresponse
+                return HttpResponse('', status=204)
+            # ruleid:direct-use-of-httpresponse
+            return HttpResponse(_res)
+        return manageNoEngine()
+    except Exception as e:
+        return genericApiException(e, engines[uid])
+    finally:
+        engines[uid].stoppable = False
+
+def inline_test(request):
+    # ruleid:direct-use-of-httpresponse
+    return HttpResponse("Received {}".format(request.POST.get('message')))
+    
+
+def vote(request, question_id):
+    if request.method != "GET" and request.method != "POST":
+        # ruleid:direct-use-of-httpresponse
+        return HttpResponseBadRequest(
+            "This view can not handle method {0}\n".format(request.method), status=405
+        )

--- a/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
+++ b/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
@@ -1,0 +1,26 @@
+rules:
+- id: direct-use-of-httpresponse
+  message: |
+    Detected data rendered directly to the end user via 'HttpResponse'
+    or a similar object. This bypasses Django's built-in cross-site scripting
+    (XSS) defenses and could result in an XSS vulnerability. Use Django's
+    template engine to safely render HTML. 
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.1/intro/tutorial03/#a-shortcut-render
+    - https://docs.djangoproject.com/en/3.1/topics/http/shortcuts/#render
+  languages:
+  - python
+  severity: WARNING
+  patterns:
+  - pattern-not: django.http.$ANY("...", ...)
+  - pattern-either:
+    - pattern: django.http.HttpResponse(...)
+    - pattern: django.http.HttpResponseBadRequest(...)
+    - pattern: django.http.HttpResponseNotFound(...)
+    - pattern: django.http.HttpResponseForbidden(...)
+    - pattern: django.http.HttpResponseNotAllowed(...)
+    - pattern: django.http.HttpResponseGone(...)
+    - pattern: django.http.HttpResponseServerError(...)

--- a/python/django/security/audit/xss/filter-with-is-safe.py
+++ b/python/django/security/audit/xss/filter-with-is-safe.py
@@ -1,0 +1,263 @@
+# cf. https://github.com/django/django/blob/ecaac9e42f497be04ddc72dfebb6e397ccca9517/django/contrib/humanize/templatetags/humanize.py
+
+import re
+from datetime import date, datetime
+from decimal import Decimal
+
+from django import template
+from django.template import defaultfilters
+from django.utils.formats import number_format
+from django.utils.safestring import mark_safe
+from django.utils.timezone import is_aware, utc
+from django.utils.translation import (
+    gettext as _, gettext_lazy, ngettext, ngettext_lazy, npgettext_lazy,
+    pgettext, round_away_from_one,
+)
+
+register = template.Library()
+
+# ruleid:filter-with-is-safe
+@register.filter(is_safe=True)
+def ordinal(value):
+    """
+    Convert an integer to its ordinal as a string. 1 is '1st', 2 is '2nd',
+    3 is '3rd', etc. Works for any integer.
+    """
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return value
+    if value % 100 in (11, 12, 13):
+        # Translators: Ordinal format for 11 (11th), 12 (12th), and 13 (13th).
+        value = pgettext('ordinal 11, 12, 13', '{}th').format(value)
+    else:
+        templates = (
+            # Translators: Ordinal format when value ends with 0, e.g. 80th.
+            pgettext('ordinal 0', '{}th'),
+            # Translators: Ordinal format when value ends with 1, e.g. 81st, except 11.
+            pgettext('ordinal 1', '{}st'),
+            # Translators: Ordinal format when value ends with 2, e.g. 82nd, except 12.
+            pgettext('ordinal 2', '{}nd'),
+            # Translators: Ordinal format when value ends with 3, e.g. 83th, except 13.
+            pgettext('ordinal 3', '{}rd'),
+            # Translators: Ordinal format when value ends with 4, e.g. 84th.
+            pgettext('ordinal 4', '{}th'),
+            # Translators: Ordinal format when value ends with 5, e.g. 85th.
+            pgettext('ordinal 5', '{}th'),
+            # Translators: Ordinal format when value ends with 6, e.g. 86th.
+            pgettext('ordinal 6', '{}th'),
+            # Translators: Ordinal format when value ends with 7, e.g. 87th.
+            pgettext('ordinal 7', '{}th'),
+            # Translators: Ordinal format when value ends with 8, e.g. 88th.
+            pgettext('ordinal 8', '{}th'),
+            # Translators: Ordinal format when value ends with 9, e.g. 89th.
+            pgettext('ordinal 9', '{}th'),
+        )
+        value = templates[value % 10].format(value)
+    # Mark value safe so i18n does not break with <sup> or <sub> see #19988
+    return mark_safe(value)
+
+# ruleid:filter-with-is-safe
+@register.filter(is_safe=True)
+def intcomma(value, use_l10n=True):
+    """
+    Convert an integer to a string containing commas every three digits.
+    For example, 3000 becomes '3,000' and 45000 becomes '45,000'.
+    """
+    if use_l10n:
+        try:
+            if not isinstance(value, (float, Decimal)):
+                value = int(value)
+        except (TypeError, ValueError):
+            return intcomma(value, False)
+        else:
+            return number_format(value, use_l10n=True, force_grouping=True)
+    orig = str(value)
+    new = re.sub(r"^(-?\d+)(\d{3})", r'\g<1>,\g<2>', orig)
+    if orig == new:
+        return new
+    else:
+        return intcomma(new, use_l10n)
+
+
+# A tuple of standard large number to their converters
+intword_converters = (
+    (6, lambda number: ngettext('%(value)s million', '%(value)s million', number)),
+    (9, lambda number: ngettext('%(value)s billion', '%(value)s billion', number)),
+    (12, lambda number: ngettext('%(value)s trillion', '%(value)s trillion', number)),
+    (15, lambda number: ngettext('%(value)s quadrillion', '%(value)s quadrillion', number)),
+    (18, lambda number: ngettext('%(value)s quintillion', '%(value)s quintillion', number)),
+    (21, lambda number: ngettext('%(value)s sextillion', '%(value)s sextillion', number)),
+    (24, lambda number: ngettext('%(value)s septillion', '%(value)s septillion', number)),
+    (27, lambda number: ngettext('%(value)s octillion', '%(value)s octillion', number)),
+    (30, lambda number: ngettext('%(value)s nonillion', '%(value)s nonillion', number)),
+    (33, lambda number: ngettext('%(value)s decillion', '%(value)s decillion', number)),
+    (100, lambda number: ngettext('%(value)s googol', '%(value)s googol', number)),
+)
+
+# ok:filter-with-is-safe
+@register.filter(is_safe=False)
+def intword(value):
+    """
+    Convert a large integer to a friendly text representation. Works best
+    for numbers over 1 million. For example, 1000000 becomes '1.0 million',
+    1200000 becomes '1.2 million' and '1200000000' becomes '1.2 billion'.
+    """
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return value
+
+    abs_value = abs(value)
+    if abs_value < 1000000:
+        return value
+
+    for exponent, converter in intword_converters:
+        large_number = 10 ** exponent
+        if abs_value < large_number * 1000:
+            new_value = value / large_number
+            rounded_value = round_away_from_one(new_value)
+            return converter(abs(rounded_value)) % {
+                'value': defaultfilters.floatformat(new_value, 1),
+            }
+    return value
+
+# ruleid:filter-with-is-safe
+@register.filter(is_safe=True)
+def apnumber(value):
+    """
+    For numbers 1-9, return the number spelled out. Otherwise, return the
+    number. This follows Associated Press style.
+    """
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return value
+    if not 0 < value < 10:
+        return value
+    return (_('one'), _('two'), _('three'), _('four'), _('five'),
+            _('six'), _('seven'), _('eight'), _('nine'))[value - 1]
+
+
+# Perform the comparison in the default time zone when USE_TZ = True
+# (unless a specific time zone has been applied with the |timezone filter).
+# ok:filter-with-is-safe
+@register.filter(expects_localtime=True)
+def naturalday(value, arg=None):
+    """
+    For date values that are tomorrow, today or yesterday compared to
+    present day return representing string. Otherwise, return a string
+    formatted according to settings.DATE_FORMAT.
+    """
+    tzinfo = getattr(value, 'tzinfo', None)
+    try:
+        value = date(value.year, value.month, value.day)
+    except AttributeError:
+        # Passed value wasn't a date object
+        return value
+    today = datetime.now(tzinfo).date()
+    delta = value - today
+    if delta.days == 0:
+        return _('today')
+    elif delta.days == 1:
+        return _('tomorrow')
+    elif delta.days == -1:
+        return _('yesterday')
+    return defaultfilters.date(value, arg)
+
+
+# This filter doesn't require expects_localtime=True because it deals properly
+# with both naive and aware datetimes. Therefore avoid the cost of conversion.
+# ok:filter-with-is-safe
+@register.filter
+def naturaltime(value):
+    """
+    For date and time values show how many seconds, minutes, or hours ago
+    compared to current timestamp return representing string.
+    """
+    return NaturalTimeFormatter.string_for(value)
+
+
+class NaturalTimeFormatter:
+    time_strings = {
+        # Translators: delta will contain a string like '2 months' or '1 month, 2 weeks'
+        'past-day': gettext_lazy('%(delta)s ago'),
+        # Translators: please keep a non-breaking space (U+00A0) between count
+        # and time unit.
+        'past-hour': ngettext_lazy('an hour ago', '%(count)s hours ago', 'count'),
+        # Translators: please keep a non-breaking space (U+00A0) between count
+        # and time unit.
+        'past-minute': ngettext_lazy('a minute ago', '%(count)s minutes ago', 'count'),
+        # Translators: please keep a non-breaking space (U+00A0) between count
+        # and time unit.
+        'past-second': ngettext_lazy('a second ago', '%(count)s seconds ago', 'count'),
+        'now': gettext_lazy('now'),
+        # Translators: please keep a non-breaking space (U+00A0) between count
+        # and time unit.
+        'future-second': ngettext_lazy('a second from now', '%(count)s seconds from now', 'count'),
+        # Translators: please keep a non-breaking space (U+00A0) between count
+        # and time unit.
+        'future-minute': ngettext_lazy('a minute from now', '%(count)s minutes from now', 'count'),
+        # Translators: please keep a non-breaking space (U+00A0) between count
+        # and time unit.
+        'future-hour': ngettext_lazy('an hour from now', '%(count)s hours from now', 'count'),
+        # Translators: delta will contain a string like '2 months' or '1 month, 2 weeks'
+        'future-day': gettext_lazy('%(delta)s from now'),
+    }
+    past_substrings = {
+        # Translators: 'naturaltime-past' strings will be included in '%(delta)s ago'
+        'year': npgettext_lazy('naturaltime-past', '%d year', '%d years'),
+        'month': npgettext_lazy('naturaltime-past', '%d month', '%d months'),
+        'week': npgettext_lazy('naturaltime-past', '%d week', '%d weeks'),
+        'day': npgettext_lazy('naturaltime-past', '%d day', '%d days'),
+        'hour': npgettext_lazy('naturaltime-past', '%d hour', '%d hours'),
+        'minute': npgettext_lazy('naturaltime-past', '%d minute', '%d minutes'),
+    }
+    future_substrings = {
+        # Translators: 'naturaltime-future' strings will be included in '%(delta)s from now'
+        'year': npgettext_lazy('naturaltime-future', '%d year', '%d years'),
+        'month': npgettext_lazy('naturaltime-future', '%d month', '%d months'),
+        'week': npgettext_lazy('naturaltime-future', '%d week', '%d weeks'),
+        'day': npgettext_lazy('naturaltime-future', '%d day', '%d days'),
+        'hour': npgettext_lazy('naturaltime-future', '%d hour', '%d hours'),
+        'minute': npgettext_lazy('naturaltime-future', '%d minute', '%d minutes'),
+    }
+
+    @classmethod
+    def string_for(cls, value):
+        if not isinstance(value, date):  # datetime is a subclass of date
+            return value
+
+        now = datetime.now(utc if is_aware(value) else None)
+        if value < now:
+            delta = now - value
+            if delta.days != 0:
+                return cls.time_strings['past-day'] % {
+                    'delta': defaultfilters.timesince(value, now, time_strings=cls.past_substrings),
+                }
+            elif delta.seconds == 0:
+                return cls.time_strings['now']
+            elif delta.seconds < 60:
+                return cls.time_strings['past-second'] % {'count': delta.seconds}
+            elif delta.seconds // 60 < 60:
+                count = delta.seconds // 60
+                return cls.time_strings['past-minute'] % {'count': count}
+            else:
+                count = delta.seconds // 60 // 60
+                return cls.time_strings['past-hour'] % {'count': count}
+        else:
+            delta = value - now
+            if delta.days != 0:
+                return cls.time_strings['future-day'] % {
+                    'delta': defaultfilters.timeuntil(value, now, time_strings=cls.future_substrings),
+                }
+            elif delta.seconds == 0:
+                return cls.time_strings['now']
+            elif delta.seconds < 60:
+                return cls.time_strings['future-second'] % {'count': delta.seconds}
+            elif delta.seconds // 60 < 60:
+                count = delta.seconds // 60
+                return cls.time_strings['future-minute'] % {'count': count}
+            else:
+                count = delta.seconds // 60 // 60
+                return cls.time_strings['future-hour'] % {'count': count}

--- a/python/django/security/audit/xss/filter-with-is-safe.yaml
+++ b/python/django/security/audit/xss/filter-with-is-safe.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: filter-with-is-safe
+  message: |
+    Detected Django filters flagged with 'is_safe'. 'is_safe' tells Django
+    not to apply escaping on the value returned by this filter (although the
+    input is escaped). Used improperly, 'is_safe' could expose your application
+    to cross-site scripting (XSS) vulnerabilities. Ensure this filter does not
+    1) add HTML characters, 2) remove characters, or 3) use external data in
+    any way. Consider instead removing 'is_safe' and explicitly marking safe
+    content with 'mark_safe()'.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.1/topics/security/#cross-site-scripting-xss-protection
+    - https://docs.djangoproject.com/en/3.1/howto/custom-template-tags/#filters-and-auto-escaping
+    - https://stackoverflow.com/questions/7665512/why-use-is-safe
+  languages:
+  - python
+  severity: WARNING
+  pattern: |-
+    @register.filter(..., is_safe=True, ...)
+    def $FILTER(...):
+      ...

--- a/python/django/security/audit/xss/global-autoescape-off.py
+++ b/python/django/security/audit/xss/global-autoescape-off.py
@@ -1,0 +1,160 @@
+# cf. https://github.com/wsvincent/djangoforprofessionals/blob/3f1b4e1199af91b07593eb6fe521252dfc67c75d/ch10-books/config/settings.py
+
+from pathlib import Path
+from environs import Env # new
+
+env = Env() # new
+env.read_env() # new
+
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/dev/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = env("DJANGO_SECRET_KEY")
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = env.bool("DJANGO_DEBUG")
+
+ALLOWED_HOSTS = ['.herokuapp.com', 'localhost', '127.0.0.1']
+
+
+# Application definition
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'django.contrib.sites', # new
+
+    # Third-party
+    'crispy_forms', # new
+    'allauth', # new
+    'allauth.account', # new
+
+    # Local
+    'accounts', # new
+    'pages', # new
+    'books', # new
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+
+ROOT_URLCONF = 'config.urls'
+
+TEMPLATES = [
+    # ok: global-autoescape-off
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [str(BASE_DIR.joinpath('templates'))], # new
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+    # ruleid: global-autoescape-off
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [str(BASE_DIR.joinpath('templates'))], # new
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'autoescape': False
+        },
+    },
+]
+
+WSGI_APPLICATION = 'config.wsgi.application'
+
+
+# Database
+# https://docs.djangoproject.com/en/dev/ref/settings/#databases
+
+DATABASES = {
+    "default": env.dj_db_url("DATABASE_URL", default="postgres://postgres@db/postgres")
+}
+
+# Password validation
+# https://docs.djangoproject.com/en/dev/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+    },
+    {
+        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+    },
+]
+
+
+# Internationalization
+# https://docs.djangoproject.com/en/dev/topics/i18n/
+
+LANGUAGE_CODE = 'en-us'
+
+TIME_ZONE = 'UTC'
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/dev/howto/static-files/
+
+STATIC_URL = '/static/'
+STATICFILES_DIRS = [str(BASE_DIR.joinpath('static'))] # new
+STATIC_ROOT = str(BASE_DIR.joinpath('staticfiles')) # new
+STATICFILES_FINDERS = [ # new
+    "django.contrib.staticfiles.finders.FileSystemFinder",
+    "django.contrib.staticfiles.finders.AppDirectoriesFinder",
+]
+
+AUTH_USER_MODEL = 'accounts.CustomUser' # new
+
+# django-crispy-forms
+CRISPY_TEMPLATE_PACK = 'bootstrap4' # new
+
+# django-allauth config
+LOGIN_REDIRECT_URL = 'home'
+ACCOUNT_LOGOUT_REDIRECT = 'home' # new
+SITE_ID = 1 # new
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend', # new
+)
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend' # new
+ACCOUNT_SESSION_REMEMBER = True # new
+ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False # new
+ACCOUNT_USERNAME_REQUIRED = False # new
+ACCOUNT_AUTHENTICATION_METHOD = 'email' # new
+ACCOUNT_EMAIL_REQUIRED = True # new
+ACCOUNT_UNIQUE_EMAIL = True # new
+
+DEFAULT_FROM_EMAIL = 'admin@djangobookstore.com' # new

--- a/python/django/security/audit/xss/global-autoescape-off.yaml
+++ b/python/django/security/audit/xss/global-autoescape-off.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: global-autoescape-off
+  message: |
+    Autoescape is globally disbaled for this Django application. If you are
+    rendering any web pages, this exposes your application to cross-site
+    scripting (XSS) vulnerabilities. Remove 'autoescape: False' or set it
+    to 'True'.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.1/ref/settings/#templates
+    - https://docs.djangoproject.com/en/3.1/topics/templates/#django.template.backends.django.DjangoTemplates
+  languages:
+  - python
+  severity: WARNING
+  pattern: |
+    {..., 'BACKEND': ..., 'OPTIONS': {..., 'autoescape': False, ...}, ...}
+  fix-regex:
+    regex: (autoescape.*?)False
+    replacement: \1True

--- a/python/django/security/audit/xss/template-autoescape-off.html
+++ b/python/django/security/audit/xss/template-autoescape-off.html
@@ -1,0 +1,17 @@
+<h4>From: {{ from_email }}</h4>
+<h4>To:
+    {% for recipient in recipients %}
+    {{ recipient }}&nbsp;
+    {% endfor %}
+</h4>
+<h4>Subject: {{subject}}</h4>
+<div class="email-html" style="display: block;">
+    <!-- ruleid: template-autoescape-off -->
+    {% autoescape off %}
+    {{ html_message }}
+    {% endautoescape %}
+</div>
+<div class="email-text" style="display: none;">
+    <pre>{{ body }}</pre>
+</div>
+<hr>

--- a/python/django/security/audit/xss/template-autoescape-off.yaml
+++ b/python/django/security/audit/xss/template-autoescape-off.yaml
@@ -1,0 +1,19 @@
+rules:
+- id: template-autoescape-off
+  message: |
+    Detected a template block where autoescaping is explicitly
+    disabled with '{% autoescape off %}'. This allows rendering of raw HTML
+    in this segment. Turn autoescaping on to prevent cross-site scripting (XSS).
+    If you must do this, consider instead, using `mark_safe` in Python code.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#autoescape
+  languages:
+  - none
+  paths:
+    include:
+    - '*.html'
+  severity: WARNING
+  pattern-regex: '{%\s+autoescape\s+off\s+%}'

--- a/python/django/security/audit/xss/template-href-var.html
+++ b/python/django/security/audit/xss/template-href-var.html
@@ -1,0 +1,22 @@
+<h4>From: {{ from_email }}</h4>
+<h4>To:
+    {% for recipient in recipients %}
+    {{ recipient }}&nbsp;
+    {% endfor %}
+</h4>
+<h4>Subject: {{subject}}</h4>
+<div class="email" style="display: block;">
+    {{ message }}
+</div>
+<div class="email-text" style="display: none;">
+    <pre>{{ body }}</pre>
+    <!-- ruleid: template-href-var -->
+    <a href='{{ link }}'>{{ link_text }}</a>
+    <!-- ruleid: template-href-var -->
+    <a href = '{{ link }}' >{{ link_text }}</a>
+    <!-- ok: template-href-var -->
+    <a href="{% url 'login' %}">{{ link_text }}</a>
+    <!-- ok: template-href-var -->
+    <a href="https://example.com/">{{ link_text }}</a>
+</div>
+<hr>

--- a/python/django/security/audit/xss/template-href-var.yaml
+++ b/python/django/security/audit/xss/template-href-var.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: template-href-var
+  message: |
+    Detected a template variable used in an anchor tag with
+    the 'href' attribute. This allows a malicious actor to 
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks. Use the 'url' template tag
+    to safely generate a URL. You may also consider setting
+    the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
+    - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#url
+    - https://content-security-policy.com/
+  languages:
+  - none
+  paths:
+    include:
+    - '*.html'
+  severity: WARNING
+  pattern-regex: |-
+    .*href\s*=\s*[\"\']?{{\s*.*

--- a/python/django/security/audit/xss/template-var-unescaped-with-safeseq.html
+++ b/python/django/security/audit/xss/template-var-unescaped-with-safeseq.html
@@ -1,0 +1,22 @@
+{% block opengraph %}
+
+<!-- safeseq probably isn't used this way, but it illustrates the point -->
+
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="semgrep" />
+<meta property="og:description" content="content" />
+<!-- ruleid: template-var-unescaped-with-safeseq -->
+<meta property="og:image" content="{{ sequence_of_things | safeseq | join:','}}" />
+<meta property="og:image:type" content="image/jpeg" />
+<meta property="og:image:width" content="600" />
+<meta property="og:image:height" content="600" />
+<!-- ok: template-var-unescaped-with-safeseq -->
+<meta property="not-real-only-for-testing" content="{{ safeseq }}" />
+
+<!-- Google OAuth sign-in -->
+<meta name="google-signin-scope" content="profile email openid">
+<!-- ruleid: template-var-unescaped-with-safeseq -->
+<meta name="google-signin-client_id" content="{{ client_id | safeseq }}">
+
+{% endblock %}

--- a/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
+++ b/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
@@ -1,0 +1,19 @@
+rules:
+- id: template-var-unescaped-with-safeseq
+  message: |
+    Detected a segment of a Flask template where autoescaping is explicitly
+    disabled with '| safe' filter. This allows rendering of raw HTML
+    in this segment. Ensure no user data is rendered here, otherwise this
+    is a cross-site scripting (XSS) vulnerability.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.0/ref/templates/builtins/#safeseq
+  languages:
+  - none
+  paths:
+    include:
+    - '*.html'
+  severity: WARNING
+  pattern-regex: '{{.*?\|\s+safeseq(\s+}})?'

--- a/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
+++ b/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
@@ -1,10 +1,11 @@
 rules:
 - id: template-var-unescaped-with-safeseq
   message: |
-    Detected a segment of a Flask template where autoescaping is explicitly
-    disabled with '| safe' filter. This allows rendering of raw HTML
+    Detected a template variable where autoescaping is explicitly
+    disabled with '| safeseq' filter. This allows rendering of raw HTML
     in this segment. Ensure no user data is rendered here, otherwise this
-    is a cross-site scripting (XSS) vulnerability.
+    is a cross-site scripting (XSS) vulnerability. If you must do this,
+    use `mark_safe` in your Python code.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     owasp: 'A7: Cross-site Scripting (XSS)'


### PR DESCRIPTION
Follows this policy:

# XSS Prevention in Django

Conditions:

1. User input
2. Data manually rendered to end user
3. Data unescaped in template context
4. Data rendered to dangerous location in template

### 2. Data manually rendered to end user

1. Directly writing to `HttpResponse` and friends
    1. https://r2c.dev/blog/2020/be-careful-what-you-request-for-django-method/

### 3. Data unescaped in template context

1. Disabling autoescape
    1. Global disable in DjangoTemplates settings
        1. https://docs.djangoproject.com/en/3.1/topics/templates/#django.template.backends.django.DjangoTemplates
    2. `autoescape=False` in a template Context
        1. [cf. https://github.com/django/django/blob/54ea290e5bbd19d87bd8dba807738eeeaf01a362/django/template/context.py#L135](https://github.com/django/django/blob/54ea290e5bbd19d87bd8dba807738eeeaf01a362/django/template/context.py#L135)
        2. Template.render
            1. https://docs.djangoproject.com/en/3.1/ref/templates/api/#django.template.Template.render
        3. render_to_string
            1. https://docs.djangoproject.com/en/3.1/topics/templates/#django.template.loader.render_to_string
        4. render shortcut
            1. https://docs.djangoproject.com/en/3.1/topics/http/shortcuts/#django.shortcuts.render
2. Marking “Safe” content
    1. Python
        1. `mark_safe`
        2. `SafeString` class
            1. https://docs.djangoproject.com/en/3.1/howto/custom-template-tags/
        3. `is_safe=True` with `@register.filter(...)`
        4. Conditional escape: `@register.filter(needs_autoescape=**True**)` with `def initial_letter_filter(text, autoescape=**False**):`
            1. Uncertain of this one???
        5. `__html__`???
        6. `html_safe` on a class???
    2. Templates
        1. `| safe` and `| safeseq`
        2. `{% autoescape off %}` block

### 4. Data rendered to dangerous location in template

1. Unquoted HTML attributes
    1. cf. https://docs.djangoproject.com/en/3.1/topics/security/#cross-site-scripting-xss-protection
2. Probably `href`, similar to Flask
3. JS template strings? (like in Go)
4. tags? (like in Go)

## Mitigations

1. Ban `{% autoescape off %}`
    1. Prefer `mark_safe` only if necessary
2. Ban `| safe`
    1. Prefer `mark_safe` only if necessary
3. Ban `| safeseq`
    1. Prefer `mark_safe` only if necessary
4. Ban `mark_safe`
    1. Review on a case-by-case basis and whitelist using `# nosem`
5. Ban class extensions from `SafeString`
    1. Prefer `mark_safe` only if necessary
6. Ban `is_safe=True` with `@register.filter`
    1. Prefer `mark_safe` only if necessary
7. Ban conditional escape logic in custom filter?
8. Ban directly writing to `HttpResponse` and friends (except perhaps if doing JSON or an API, or something similar)
    1. Use `render()`
9. Ban unquoted HTML attributes
10. Templates variables in `href` must use the `url` template function
    1. cf. https://docs.djangoproject.com/en/3.1/intro/tutorial03/#removing-hardcoded-urls-in-templates
11. Ban `autoescape=False` in template Contexts
12. Ban global autoescape off



|Control	|Description	|Semgrep Rule	|
|---	|---	|---	|
|1	|Ban `autoescape off`	|python.django.security.audit.xss.template-autoescape-off	|
|2	|Ban `\| safe`	|python.flask.security.xss.audit.template-unescaped-with-safe.template-unescaped-with-safe	|
|3	|Ban `\| safeseq`	|python.django.security.audit.xss.template-var-unescaped-with-safeseq	|
|4	|Ban `mark_safe`	|python.django.security.audit.avoid-mark-safe.avoid-mark-safe	|
|5	|Ban class extensions from `SafeString`	|python.django.security.audit.xss.class-extends-safestring	|
|6	|Ban `is_safe=True` with `@register.filter`	|python.django.security.audit.xss.filter-with-is-safe	|
|7	|Ban escape logic in custom filters?	|TBD	|
|8	|Ban directly writing to HttpResponse+friends	|python.django.security.audit.xss.direct-use-of-httpresponse	|
|9	|Ban unquoted HTML attributes	|python.flask.security.xss.audit.template-unquoted-attribute-var.template-unquoted-attribute-var	|
|10	|Require `url` for template vars in `href`	|python.django.security.audit.xss.template-href-var	|
|11	|Ban `autoescape=False` in template Contexts	|python.django.security.audit.xss.context-autoescape-off	|
|12	|Ban global autoescape off	|python.django.security.audit.xss.global-autoescape-off	|



