### PR TITLE
Fix java xss rules

### DIFF
--- a/java/lang/security/audit/xss/jsp/use-jstl-escaping.jsp
+++ b/java/lang/security/audit/xss/jsp/use-jstl-escaping.jsp
@@ -1,0 +1,9 @@
+<!-- ruleid: use-jstl-escaping -->
+<input value="${param.foo}" />
+<!-- ok: use-jstl-escaping -->
+<c:out value="${param.foo}" />
+
+<div>
+    <!-- this is the reason use-escapexml is the preferred rule. JSP allows dangling EL expressions -->
+    ${param.foo}
+</div>

--- a/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
+++ b/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
@@ -1,17 +1,18 @@
 rules:
-- id: use-escapexml
+- id: use-jstl-escaping
   message: |
-    Detected an Expression Language segment that does not escape
+    Detected an Expression Language segment in a tag that does not escape
     output. This is dangerous because if any data in this expression
     can be controlled externally, it is a cross-site scripting
-    vulnerability. Instead, use the 'escapeXml' function from
-    the JSTL taglib. See https://www.tutorialspoint.com/jsp/jstl_function_escapexml.htm
+    vulnerability. Instead, use the 'out' tag from the JSTL taglib
+    to escape this expression. 
+    See https://www.tutorialspoint.com/jsp/jstl_core_out_tag.htm
     for more information.
   metadata:
     owasp: 'A7: Cross-site Scripting (XSS)'
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
     references:
-    - https://www.tutorialspoint.com/jsp/jstl_function_escapexml.htm
+    - https://www.tutorialspoint.com/jsp/jstl_core_out_tag.htm
     - https://stackoverflow.com/a/4948856
     - https://stackoverflow.com/a/3180202
   pattern-regex: <(?![A-Za-z0-9]+:out).*?\$\{.*?\}.*>

--- a/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
+++ b/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: use-escapexml
+  message: |
+    Detected an Expression Language segment that does not escape
+    output. This is dangerous because if any data in this expression
+    can be controlled externally, it is a cross-site scripting
+    vulnerability. Instead, use the 'escapeXml' function from
+    the JSTL taglib. See https://www.tutorialspoint.com/jsp/jstl_function_escapexml.htm
+    for more information.
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: 'CWE-116: Improper Encoding or Escaping of Output'
+    references:
+    - https://www.tutorialspoint.com/jsp/jstl_function_escapexml.htm
+    - https://stackoverflow.com/a/4948856
+    - https://stackoverflow.com/a/3180202
+  pattern-regex: <(?![A-Za-z0-9]+:out).*?\$\{.*?\}.*>
+  paths:
+    include:
+    - '*.jsp'
+  languages: [none]
+  severity: WARNING

--- a/java/lang/security/audit/xss/no-direct-response-writer.yaml
+++ b/java/lang/security/audit/xss/no-direct-response-writer.yaml
@@ -2,6 +2,12 @@ rules:
 - id: no-direct-response-writer
   patterns:
   - pattern-either:
+    - pattern-inside: |
+        $RETURN $METHOD(..., HttpServletResponse $RESP, ...) { ... }
+    - pattern-inside: |
+        HttpServletResponse $RESPONSE = ...;
+        ...
+  - pattern-either:
     - pattern: |
         (HttpServletResponse $RESPONSE).getWriter(...).$WRITE(...)
     - pattern: |
@@ -12,8 +18,9 @@ rules:
         (ServletOutputStream $WRITER).$WRITE(...)
     - pattern: |
         (OutputStream $WRITER).$WRITE(...)
-  - pattern-not: |
-      $WRITER.$WRITE("...", ...)
+  - pattern-not: $WRITER.$WRITE("...", ...)
+  - pattern-not: $WRITER.flush(...)
+  - pattern-not: $WRITER.close(...)
   message: |
     Detected a direct write to the HTTP response. This bypasses any
     view or template environments, including HTML escaping, which may


### PR DESCRIPTION
Reduce FPs in not directly writing to responsewriter rule.
Also added a new rule for detecting `<c:out>` tags in templates but this will not be used as a part of the XSS pack. It's here for completeness. (... And because I realized how to do the right regex :| )