### PR TITLE
* python/lang/correctness/common-mistakes/is-comparison-string.py: Fix

### DIFF
--- a/python/lang/correctness/common-mistakes/is-comparison-string.py
+++ b/python/lang/correctness/common-mistakes/is-comparison-string.py
@@ -1,7 +1,4 @@
-x = 'foo'
-# useless reassign below, but without this, x would now be considered a
-# constant and constant propagation would apply.
-x = 'foo'
+x = object()
 
 # ruleid:identical-is-comparison
 if x is x:

--- a/python/lang/correctness/common-mistakes/is-comparison-string.py
+++ b/python/lang/correctness/common-mistakes/is-comparison-string.py
@@ -1,4 +1,7 @@
 x = 'foo'
+# useless reassign below, but without this, x would now be considered a
+# constant and constant propagation would apply.
+x = 'foo'
 
 # ruleid:identical-is-comparison
 if x is x:


### PR DESCRIPTION
Add extra assign to not make 'x' a constant.
Indeed, Iago recently fixed a bug in the const-analysis which
now kick-in in this file and leads to more reported errors.

Related to https://github.com/returntocorp/semgrep/pull/1676

Test plan:
make test with latest semgrep