### PR TITLE
Secure defaults XSS rules for Express.js

### DIFF
--- a/javascript/express/security/audit/xss/direct-response-write.js
+++ b/javascript/express/security/audit/xss/direct-response-write.js
@@ -1,0 +1,119 @@
+
+const express = require('express')
+const router = express.Router()
+
+router.get('/greeting', (req, res) => {
+    const { name } = req.query;
+    // ruleid: direct-response-write
+    res.send('<h1> Hello :' + name + "</h1>")
+})
+
+//template handle escaping 
+router.get('/greet-template', (req, res) => {
+    name = req.query.name
+    // ok: direct-response-write
+    res.render('index', { user_name: name });
+})
+
+module.exports = router
+
+
+app.get('/', function (req, res) {
+    var user = req.query.name;
+
+    msg = "Hi " + user
+    // ruleid: direct-response-write
+    res.send('Response</br>' + msg);
+});
+
+
+var msg = '';
+app.get('/3', function (req, res) {
+    var user = req.query.name;
+
+    msg = "Hi " + user
+    // ruleid: direct-response-write
+    res.send('Response</br>' + msg);
+});
+
+app.get('/2', function (req, res) {
+    var user = { user: req.query.name };
+    // ruleid: direct-response-write
+    res.send('Response</br>' + user.name);
+});
+
+app.get('/1', function (req, res) {
+    var user = req.query.name;
+    var msg = [];
+    msg.push(user);
+    // ruleid: direct-response-write
+    res.send('Response</br>' + msg[0]);
+});
+
+app.get('/4', function (req, res) {
+    var user = req.query.name;
+    var header = "<html>";
+    var msg = 'Hi ' + user;
+    var footer = "</html>";
+    var output = header + msg + footer;
+    // ruleid: direct-response-write
+    res.send(output);
+});
+
+
+
+
+
+var express = require('express');
+var app = express();
+app.get('/', function (req, res) {
+    var resp = req.query.name;
+    // ruleid: direct-response-write
+    res.send('Response</br>' + resp);
+});
+app.get('/3', function (req, res) {
+    var resp = req.query.name;
+    // ruleid: direct-response-write
+    res.write('Response</br>' + resp);
+});
+
+app.get('/3', function (req, res) {
+    var resp = req.foo;
+    var x = 1;
+    // ruleid: direct-response-write
+    res.write('Response</br>' + resp);
+});
+
+app.get('/xss', function (req, res) {
+    var html = "ASadad" + req.query.name + "Asdadads"
+    // ruleid: direct-response-write
+    res.write('Response</br>' + html);
+});
+app.get('/xss', function (req, res) {
+    // ruleid: direct-response-write
+    res.write('Response</br>' + req.query('doo'));
+});
+app.get('/xss', function (req, res) {
+    // ruleid: direct-response-write
+    res.write('Response</br>' + req.query.name);
+});
+
+app.get('/noxss', function (req, res) {
+    var resp = req.query.name;
+    // ok: direct-response-write
+    res.write('Response</br>');
+});
+
+app.get('/noxs2s', function (req, res) {
+    var resp = req.query.name;
+    // ruleid: direct-response-write
+    res.write('Response</br>' + foo);
+});
+
+app.get('/xss', function (req, res) {
+    var resp = req.query.name;
+    var html = "ASadad" + resp + "Asdadads"
+    // ruleid: direct-response-write
+    res.write('Response</br>' + html);
+});
+app.listen(8000);

--- a/javascript/express/security/audit/xss/direct-response-write.yaml
+++ b/javascript/express/security/audit/xss/direct-response-write.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: direct-response-write
+  message: >-
+    Detected direclty writing to a Response object. This bypasses
+    any HTML escaping and may expose your app to a cross-site scripting
+    (XSS) vulnerability. Instead, use 'resp.render()' to render
+    safely escaped HTML.
+  languages:
+  - javascript
+  severity: ERROR
+  metadata:
+    owasp: 'A7: Cross-Site Scripting (XSS)'
+    cwe: >-
+      CWE-79: Improper Neutralization of Input During Web Page Generation
+      ('Cross-site Scripting')
+  patterns:
+  - pattern-inside: |
+      $APP.get($ROUTE, function ($REQ, $RES) { ... });
+  - pattern-not: $RES.$ANY("...")
+  - pattern-either:
+    - pattern: $RES.write(...)
+    - pattern: $RES.send(...)

--- a/javascript/express/security/audit/xss/ejs/explicit-unescape.ejs
+++ b/javascript/express/security/audit/xss/ejs/explicit-unescape.ejs
@@ -1,0 +1,51 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<body onload="carregarDemo();">
+    <div class="content">
+        <div id="mustache-header"></div>
+        <div id="mustache-cards"></div>
+    </div>
+</body>
+
+<div class="jumbotron text-center">
+    <!-- ruleid: template-explicit-unescape -->
+    <h1 class="display-4">Oi, meu nome é <%- autor.nome %> <%= autor.sobrenome %>!</h1>
+    <p class="lead">Isso é apenas uma demonstração de como utilizar o Mustache.JS</p>
+</div>
+
+<div class="text-center">
+    <!-- ok: template-explicit-unescape -->
+    <h2>Apresentando o time da <b><%= time.nome %></b></h2>
+    <!-- ruleid: template-explicit-unescape -->
+    <h6>Predio <%- time.predio %></h6>
+</div>
+<div class="container" style="margin-top: 30px;">
+    <div class="row">  
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="card-header text-center">
+                    <!-- ruleid: template-explicit-unescape -->
+                    <b><%- nome %></b>
+                </div>
+                <div class="card-body">
+                    <!-- ok: template-explicit-unescape -->
+                    <%= template-table %>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</html>

--- a/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: template-explicit-unescape
+  message: |
+    Detected an explicit unescape in an EJS template, using
+    '<%- ... %>' If external data can reach these locations,
+    your application is exposed to a cross-site scripting (XSS)
+    vulnerability. Use '<%= ... %>' to escape this data. If you
+    need escaping, ensure no external data can reach this location.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - http://www.managerjs.com/blog/2015/05/will-ejs-escape-save-me-from-xss-sorta/
+  languages:
+  - none
+  paths:
+    include:
+    - '*.ejs'
+    - '*.html'
+  severity: WARNING
+  pattern-regex: <%-.*?%>
+  fix-regex:
+    regex: <%-(.*?)%>
+    replacement: <%=\1%>

--- a/javascript/express/security/audit/xss/ejs/var-in-href.ejs
+++ b/javascript/express/security/audit/xss/ejs/var-in-href.ejs
@@ -1,0 +1,50 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<body onload="carregarDemo();">
+    <div class="content">
+        <div id="mustache-header"></div>
+        <div id="mustache-cards"></div>
+    </div>
+</body>
+
+<div class="jumbotron text-center">
+    <h1 class="display-4">Oi, meu nome é <%= autor.nome %> <%= autor.sobrenome %>!</h1>
+    <p class="lead">Asso é apenas uma demonstração de como utilizar o Mustache.JS</p>
+    <!-- ruleid: var-in-href -->
+    <a href="<%= link %>" class="text-center">Click me</a>
+	<!-- ok: var-in-href -->
+    <a href="/<%= link %>" class="text-center">Click me</a>
+</div>
+
+<div class="text-center">
+    <h2>Apresentando o time da <b><%= time.nome %></b></h2>
+    <h6>Predio <%= time.predio %></h6>
+</div>
+<div class="container" style="margin-top: 30px;">
+    <div class="row">  
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="card-header text-center">
+                    <b><%= nome %></b>
+                </div>
+                <div class="card-body">
+                    <%= template-table %>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</html>

--- a/javascript/express/security/audit/xss/ejs/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-href.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: var-in-href
+  message: |
+    Detected a template variable used in an anchor tag with
+    the 'href' attribute. This allows a malicious actor to 
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks. If using a relative URL,
+    start with a literal forward slash and concatenate the URL,
+    like this: href='/<%= link %>'. You may also consider setting
+    the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
+    - https://github.com/pugjs/pug/issues/2952
+  languages:
+  - none
+  paths:
+    include:
+    - '*.ejs'
+    - '*.html'
+  severity: WARNING
+  pattern-regex: <a.*href=.*?[^\/&=]<%.*?%>.*?>

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
@@ -1,0 +1,56 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<body onload="carregarDemo();">
+    <div class="content">
+        <div id="mustache-header"></div>
+        <div id="mustache-cards"></div>
+    </div>
+</body>
+
+<script type="text/javascript">
+    <!-- ruleid: var-in-script-tag -->
+    var message = <%= message %>;
+</script>
+
+<script type="text/javascript">
+    <!-- ruleid: var-in-script-tag -->
+    var message = <%= message %>;
+    console.log(message);
+    console.log("more statements here");
+    var message2 = <%= message2 %>;
+    var flash = document.getElementById("flash");
+    flash.text = message;
+</script>
+
+<div class="text-center">
+    <h2>Apresentando o time da <b><%= time.nome %></b></h2>
+    <h6>Predio <%= time.predio %></h6>
+</div>
+<div class="container" style="margin-top: 30px;">
+    <div class="row">  
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="card-header text-center">
+                    <b><%= nome %></b>
+                </div>
+                <div class="card-body">
+                    <%= template-table %>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+</html>

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
@@ -19,13 +19,9 @@ rules:
   - none
   paths:
     include:
-    - '*.pug'
+    - '*.ejs'
+    - '*.html'
   severity: WARNING
-  pattern-either:
-  - pattern-regex: script\s*=[A-Za-z0-9]+
-  - pattern-regex: script\s*=.*["']\s*\+.*
-  - pattern-regex: script\s*=[^'"]+\+.*
-  - pattern-regex: script\(.*?\)\s*=\s*[A-Za-z0-9]+
-  - pattern-regex: script\(.*?\)\s*=\s*.*["']\s*\+.*
-  - pattern-regex: script\(.*?\)\s*=\s*[^'"]+\+.*
+  patterns:
+  - pattern-regex: <%.*?%>(.|\n)*?<\/script>
 

--- a/javascript/express/security/audit/xss/mustache/escape-function-overwrite.js
+++ b/javascript/express/security/audit/xss/mustache/escape-function-overwrite.js
@@ -1,0 +1,25 @@
+// cf. https://github.com/janl/mustache.js/#include-templates
+
+// e.g., browser code:
+// ruleid: escape-function-overwrite
+Mustache.escape = function(val) { return val; }
+
+function renderHello() {
+  var template = document.getElementById('template').innerHTML;
+  var rendered = Mustache.render(template, { name: 'Luke' });
+  document.getElementById('target').innerHTML = rendered;
+}
+
+// e.g., Node.js code:
+function node() {
+  const template = require("mustache");
+  // ruleid: escape-function-overwrite
+  template.escape = (t) => { return t; }
+  let html = template.render(blogItem, { });
+}
+
+function ok() {
+  // ok: escape-function-overwrite
+  const template = require("mustache");
+  let html = template.render(blogItem, { });
+}

--- a/javascript/express/security/audit/xss/mustache/escape-function-overwrite.yaml
+++ b/javascript/express/security/audit/xss/mustache/escape-function-overwrite.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: escape-function-overwrite
+  message: |
+    The Mustache escape function is being overwritten. This could bypass
+    HTML escaping safety measures built into the rendering engine, exposing
+    your application to cross-site scripting (XSS) vulnerabilities. If you
+    need unescaped HTML, use the triple brace operator in your template:
+    '{{{ ... }}}'.
+  languages: [javascript]
+  severity: WARNING
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-Site Scripting (XSS)'
+    references:
+    - https://github.com/janl/mustache.js/#variables
+  patterns:
+  - pattern-either:
+    - pattern: Mustache.escape = ...
+    - patterns:
+      - pattern-inside: |
+          $MUSTACHE = require("mustache");
+          ...
+      - pattern: $MUSTACHE.escape = ...

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
@@ -1,0 +1,60 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<body onload="carregarDemo();">
+    <div class="content">
+        <div id="mustache-header"></div>
+        <div id="mustache-cards"></div>
+    </div>
+</body>
+
+<script id="template-header" type="x-tmpl-mustache">
+    <div class="jumbotron text-center">
+        <!-- ruleid: template-explicit-unescape -->
+        <h1 class="display-4">Oi, meu nome é {{{autor.nome}}} {{autor.sobrenome}}!</h1>
+        <p class="lead">Isso é apenas uma demonstração de como utilizar o Mustache.JS</p>
+    </div>
+</script>
+
+<script id="template-cards" type="x-tmpl-mustache">    
+    <div class="text-center">
+        <!-- ok: template-explicit-unescape -->
+        <h2>Apresentando o time da <b>{{time.nome}}</b></h2>
+        <!-- ruleid: template-explicit-unescape -->
+        <h6>Predio {{{time.predio}}}</h6>
+    </div>
+    {{#time}}
+    <div class="container" style="margin-top: 30px;">
+        <div class="row">  
+            {{#squads}}      
+            <div class="col-sm-6">
+                <div class="card">
+                    <div class="card-header text-center">
+                        <!-- ruleid: template-explicit-unescape -->
+                        <b>{{&nome}}</b>
+                    </div>
+                    <div class="card-body">
+                        <!-- ok: template-explicit-unescape -->
+                        {{! Partial de tabela de membros do Squad }}
+                        {{> template-table}} 
+                    </div>
+                </div>
+            </div>
+            {{/squads}}
+        </div>
+    </div>
+    {{/time}}    
+</script>
+
+</html>

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: template-explicit-unescape
+  message: |
+    Detected an explicit unescape in a Mustache template, using
+    triple braces '{{{...}}}' or ampersand '&'. If external data
+    can reach these locations,
+    your application is exposed to a cross-site scripting (XSS)
+    vulnerability. If you must do this, ensure no external data
+    can reach this location.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://github.com/janl/mustache.js/#variables
+  languages:
+  - none
+  paths:
+    include:
+    - '*.mustache'
+    - '*.html'
+  severity: WARNING
+  pattern-either:
+  - pattern-regex: '{{{.*?}}}'
+  - pattern-regex: '{{.*&.*}}'

--- a/javascript/express/security/audit/xss/mustache/var-in-href.mustache
+++ b/javascript/express/security/audit/xss/mustache/var-in-href.mustache
@@ -21,18 +21,19 @@
 
 <script id="template-header" type="x-tmpl-mustache">
     <div class="jumbotron text-center">
-        <!-- ruleid: template-explicit-unescape -->
-        <h1 class="display-4">Oi, meu nome é {{{autor.nome}}} {{autor.sobrenome}}!</h1>
+        <h1 class="display-4">Oi, meu nome é {{autor.nome}} {{autor.sobrenome}}!</h1>
         <p class="lead">Isso é apenas uma demonstração de como utilizar o Mustache.JS</p>
+        <!-- ruleid: var-in-href -->
+        <a href="{{ link }}" class="text-center">Click me</a>
+		<!-- ok: var-in-href -->
+        <a href="/{{ link }}" class="text-center">Click me</a>
     </div>
 </script>
 
 <script id="template-cards" type="x-tmpl-mustache">    
     <div class="text-center">
-        <!-- ok: template-explicit-unescape -->
         <h2>Apresentando o time da <b>{{time.nome}}</b></h2>
-        <!-- ruleid: template-explicit-unescape -->
-        <h6>Predio {{{time.predio}}}</h6>
+        <h6>Predio {{time.predio}}</h6>
     </div>
     {{#time}}
     <div class="container" style="margin-top: 30px;">
@@ -41,11 +42,9 @@
             <div class="col-sm-6">
                 <div class="card">
                     <div class="card-header text-center">
-                        <!-- ruleid: template-explicit-unescape -->
-                        <b>{{&nome}}</b>
+                        <b>{{nome}}</b>
                     </div>
                     <div class="card-body">
-                        <!-- ok: template-explicit-unescape -->
                         {{! Partial de tabela de membros do Squad }}
                         {{> template-table}} 
                     </div>

--- a/javascript/express/security/audit/xss/mustache/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-href.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: var-in-href
+  message: |
+    Detected a template variable used in an anchor tag with
+    the 'href' attribute. This allows a malicious actor to 
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks. If using a relative URL,
+    start with a literal forward slash and concatenate the URL,
+    like this: href='/{{link}}'. You may also consider setting
+    the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
+    - https://github.com/pugjs/pug/issues/2952
+  languages:
+  - none
+  paths:
+    include:
+    - '*.mustache'
+    - '*.html'
+  severity: WARNING
+  pattern-regex: <a.*href=.*?[^\/&=]{{.*?}}.*?>

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.mustache
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.mustache
@@ -1,0 +1,61 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<body onload="carregarDemo();">
+    <div class="content">
+        <div id="mustache-header"></div>
+        <div id="mustache-cards"></div>
+    </div>
+</body>
+
+<script type="text/javascript">
+    <!-- ruleid: var-in-script-tag -->
+    var message = {{ message }};
+</script>
+
+<script type="text/javascript">
+    <!-- ruleid: var-in-script-tag -->
+    var message = {{ message }};
+    console.log(message);
+    console.log("more statements here");
+    var message2 = {{ message2 }};
+    var flash = document.getElementById("flash");
+    flash.text = message;
+</script>
+
+<div class="text-center">
+    <h2>Apresentando o time da <b>{{time.nome}}</b></h2>
+    <h6>Predio {{time.predio}}</h6>
+</div>
+{{#time}}
+<div class="container" style="margin-top: 30px;">
+    <div class="row">  
+        {{#squads}}      
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="card-header text-center">
+                    <b>{{nome}}</b>
+                </div>
+                <div class="card-body">
+                    {{! Partial de tabela de membros do Squad }}
+                    {{> template-table}} 
+                </div>
+            </div>
+        </div>
+        {{/squads}}
+    </div>
+</div>
+{{/time}}    
+
+</html>

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
@@ -1,0 +1,27 @@
+rules:
+- id: var-in-script-tag
+  message: |
+    Detected a template variable used in a script tag.
+    Although template variables are HTML escaped, HTML
+    escaping does not always prevent cross-site scripting (XSS)
+    attacks when used directly in JavaScript. If you need this
+    data on the rendered page, consider placing it in the HTML
+    portion (outside of a script tag). Alternatively, use a
+    JavaScript-specific encoder, such as the one available
+    in OWASP ESAPI.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
+    - https://github.com/ESAPI/owasp-esapi-js
+  languages:
+  - none
+  paths:
+    include:
+    - '*.mustache'
+    - '*.html'
+  severity: WARNING
+  patterns:
+  - pattern-regex: '{{.*?}}(.|\n)*?<\/script>'
+

--- a/javascript/express/security/audit/xss/pug/and-attributes.pug
+++ b/javascript/express/security/audit/xss/pug/and-attributes.pug
@@ -1,0 +1,33 @@
+// cf. https://github.com/abdulaz1z/nodejs-pug-starter/blob/42b48dd68416a87904258d1228686321206efc36/views/index.pug
+doctype html
+html(lang="en")
+  include includes/head.pug
+  body
+    //- Navigation
+    nav(class="navbar navbar-expand-lg navbar-dark bg-dark fixed-bottom")
+      div(class="container")
+        a(class="navbar-brand" href="/") NodeJs-Pug-Starter
+        button(class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation")
+          // ruleid: template-and-attributes
+          span()&attributes({"class": "navbar-toggler-icon"})
+            
+        div(class="collapse navbar-collapse" id="navbarResponsive")
+          ul(class="navbar-nav ml-auto")
+            li(class="nav-item")
+              a(class="nav-link" href="/") Home
+            li(class="nav-item")
+              a(class="nav-link" target="_blank" href!="/docs") Documentation
+    
+    //- Page Content
+    section
+      div(class="container")
+        div(class="row")
+          div(class="col-lg-6")
+            - var attrs = {};
+            - attrs.class = "mb-5";
+            // ruleid: template-and-attributes
+            h1(class="mt-5 text-white")&attributes(attrs) Simple App
+            p(class= "text-light") This project is a simple application skeleton for a NodeJs web app with PugJs templating. You can use it to quickly bootstrap your NodeJs webapp projects and dev environment for these projects.
+            
+    script(src='vendor/jquery/jquery.min.js')  
+    script(src='vendor/bootstrap/js/bootstrap.bundle.min.js')

--- a/javascript/express/security/audit/xss/pug/and-attributes.yaml
+++ b/javascript/express/security/audit/xss/pug/and-attributes.yaml
@@ -1,0 +1,20 @@
+rules:
+- id: template-and-attributes
+  message: |
+    Detected a unescaped variables using '&attributes'.
+    If external data can reach these locations,
+    your application is exposed to a cross-site scripting (XSS)
+    vulnerability. If you must do this, ensure no external data
+    can reach this location.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://pugjs.org/language/attributes.html#attributes
+  languages:
+  - none
+  paths:
+    include:
+    - '*.pug'
+  severity: WARNING
+  pattern-regex: .*&attributes.*

--- a/javascript/express/security/audit/xss/pug/explicit-unescape.pug
+++ b/javascript/express/security/audit/xss/pug/explicit-unescape.pug
@@ -1,0 +1,31 @@
+// cf. https://github.com/abdulaz1z/nodejs-pug-starter/blob/42b48dd68416a87904258d1228686321206efc36/views/index.pug
+doctype html
+html(lang="en")
+  include includes/head.pug
+  body
+    //- Navigation
+    nav(class="navbar navbar-expand-lg navbar-dark bg-dark fixed-bottom")
+      div(class="container")
+        a(class="navbar-brand" href="/") NodeJs-Pug-Starter
+        button(class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation")
+          span(class="navbar-toggler-icon")
+            
+        div(class="collapse navbar-collapse" id="navbarResponsive")
+          ul(class="navbar-nav ml-auto")
+            li(class="nav-item")
+              a(class="nav-link" href="/") Home
+            li(class="nav-item")
+              // ruleid: template-explicit-unescape
+              a(class="nav-link" target="_blank" href!=url) Documentation
+    
+    //- Page Content
+    section
+      div(class="container")
+        div(class="row")
+          div(class="col-lg-6")
+            // ruleid: template-explicit-unescape
+            h1(class="mt-5 text-white") !{title_text}
+            p(class= "text-light") This project is a simple application skeleton for a NodeJs web app with PugJs templating. You can use it to quickly bootstrap your NodeJs webapp projects and dev environment for these projects.
+            
+    script(src='vendor/jquery/jquery.min.js')  
+    script(src='vendor/bootstrap/js/bootstrap.bundle.min.js')

--- a/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: template-explicit-unescape
+  message: |
+    Detected an explicit unescape in a Pug template, using either
+    '!=' or '!{...}'. If external data can reach these locations,
+    your application is exposed to a cross-site scripting (XSS)
+    vulnerability. If you must do this, ensure no external data
+    can reach this location.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://pugjs.org/language/code.html#unescaped-buffered-code
+    - https://pugjs.org/language/attributes.html#unescaped-attributes
+  languages:
+  - none
+  paths:
+    include:
+    - '*.pug'
+  severity: WARNING
+  pattern-either:
+  - pattern-regex: \w.*(!=).*
+  - pattern-regex: '!{.*?}'

--- a/javascript/express/security/audit/xss/pug/var-in-href.pug
+++ b/javascript/express/security/audit/xss/pug/var-in-href.pug
@@ -1,0 +1,32 @@
+// cf. https://github.com/abdulaz1z/nodejs-pug-starter/blob/42b48dd68416a87904258d1228686321206efc36/views/index.pug
+doctype html
+html(lang="en")
+  include includes/head.pug
+  body
+    //- Navigation
+    nav(class="navbar navbar-expand-lg navbar-dark bg-dark fixed-bottom")
+      div(class="container")
+        // ok: var-in-href
+        a(class="navbar-brand" href="/") NodeJs-Pug-Starter
+        button(class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation")
+          span(class="navbar-toggler-icon")
+            
+        div(class="collapse navbar-collapse" id="navbarResponsive")
+          ul(class="navbar-nav ml-auto")
+            li(class="nav-item")
+              // ok: var-in-href
+              a(class="nav-link" href="/") Home
+            li(class="nav-item")
+              // ruleid: var-in-href
+              a(class="nav-link" href=url) Documentation
+    
+    //- Page Content
+    section
+      div(class="container")
+        div(class="row")
+          div(class="col-lg-6")
+            h1(class="mt-5") NodeJs-Pug-Starter
+            p This project is a simple application skeleton for a NodeJs web app with PugJs templating. You can use it to quickly bootstrap your NodeJs webapp projects and dev environment for these projects.
+            
+    script(src='vendor/jquery/jquery.min.js')  
+    script(src='vendor/bootstrap/js/bootstrap.bundle.min.js')

--- a/javascript/express/security/audit/xss/pug/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-href.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: var-in-href
+  message: |
+    Detected a template variable used in an anchor tag with
+    the 'href' attribute. This allows a malicious actor to 
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks. If using a relative URL,
+    start with a literal forward slash and concatenate the URL,
+    like this: a(href='/'+url). You may also consider setting
+    the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://github.com/pugjs/pug/issues/2952
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
+  languages:
+  - none
+  paths:
+    include:
+    - '*.pug'
+  severity: WARNING
+  pattern-regex: a\(.*href=[^'"].*\)

--- a/javascript/express/security/audit/xss/pug/var-in-script-tag.pug
+++ b/javascript/express/security/audit/xss/pug/var-in-script-tag.pug
@@ -1,0 +1,23 @@
+html
+    head
+        title=title
+        body
+        h1=message
+        a(href='/' + link)='hello'
+        // ruleid: var-in-script-tag
+        script(type="text/javascript")=src
+
+        // ruleid: var-in-script-tag
+        script(type="text/javascript")="a += " + a
+
+        // ruleid: var-in-script-tag
+        script(type="text/javascript") = a + "blah"
+
+        // ruleid: var-in-script-tag
+        script="var a = " + a
+
+        // ok: var-in-script-tag
+        script="var a = 1;"
+
+        // ok: var-in-script-tag
+        script="var a = 1; a+=1"

--- a/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
@@ -1,0 +1,31 @@
+rules:
+- id: var-in-href
+  message: |
+    Detected a template variable used in a script tag.
+    Although template variables are HTML escaped, HTML
+    escaping does not always prevent cross-site scripting (XSS)
+    attacks when used directly in JavaScript. If you need this
+    data on the rendered page, consider placing it in the HTML
+    portion (outside of a script tag). Alternatively, use a
+    JavaScript-specific encoder, such as the one available
+    in OWASP ESAPI.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
+    - https://github.com/ESAPI/owasp-esapi-js
+  languages:
+  - none
+  paths:
+    include:
+    - '*.pug'
+  severity: WARNING
+  pattern-either:
+  - pattern-regex: script\s*=[A-Za-z0-9]+
+  - pattern-regex: script\s*=.*["']\s*\+.*
+  - pattern-regex: script\s*=[^'"]+\+.*
+  - pattern-regex: script\(.*?\)\s*=\s*[A-Za-z0-9]+
+  - pattern-regex: script\(.*?\)\s*=\s*.*["']\s*\+.*
+  - pattern-regex: script\(.*?\)\s*=\s*[^'"]+\+.*
+


### PR DESCRIPTION
# XSS Prevention in Express.js

Conditions:

1. User input (reflected, stored)
2. Variable sent outside of template context
3. Variable is unescaped in template
4. Variable in dangerous location in template



### 2. Variable sent outside of template context

* Sending data directly to user
    * `res.send(...)`
    * `res.write(...)`
        * use `res.render(<template>, ...)` instead

### 3. Variable is unescaped in template

* Jade & Pug
    * `!=` operator
    * `!{this}` ← that syntax
        * https://stackoverflow.com/questions/6926247/nodejs-jade-escape-markup
        * https://pugjs.org/language/attributes.html#unescaped-attributes
    * & attributes
        * https://pugjs.org/language/attributes.html#attributes
* Mustache & Handlebars
    * triple mustache `{{{ ... }}}`
    * You can also use `&` to unescape a variable.
    * If you'd like to change HTML-escaping behavior globally (for example, to template non-HTML formats), you can override Mustache's escape function. For example, to disable all escaping: `Mustache.escape = function(text) {return text;};`.
* EJS
    * `<%- ... %>` 
        * cf. http://www.managerjs.com/blog/2015/05/will-ejs-escape-save-me-from-xss-sorta/

### 4. Variable in dangerous location in template

* variable in `href` attribute.
    * Jade & Pug
        * *Is there a way to do something like `url_for` in Flask?*
        * Sort of... start with a slash, like this: `a(href='/' + link)='hello'`
            * cf. https://github.com/pugjs/pug/issues/2952
    * Mustache
        * <a href=“{{ ... }}”>
            * Suggest <a href=“/{{ ... }}”> ← slash in front
    * EJS
        * <a href=“<%= ... %>”>
            * Suggest <a href=“/<%= ... %>”> ← slash in front
* In a JavaScript context
    * https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough

## Mitigations

1. Ban directly writing to Response objects.
    1. Prefer rendering in templates.
2. Ban global disable.
    1. Pug
        1. None?
    2. Mustache
        1. Ban `Mustache.escape = function(text) {return text;};`
    3. EJS
        1. None?
3. Flag template unescapes
    1. Pug
        1. Flag `!=`
        2. Flag `!{...}`
        3. Flag `&attributes`
    2. Mustache
        1. Flag `{{{...}}}`
        2. Flag `&` to escape vars
    3. EJS
        1. Flag `<%- ... %>`

