### PR TITLE
Secure Defaults for Rails XSS

### DIFF
--- a/ruby/rails/security/audit/xss/avoid-content-tag.rb
+++ b/ruby/rails/security/audit/xss/avoid-content-tag.rb
@@ -1,0 +1,29 @@
+# cf. https://apidock.com/rails/ActionView/Helpers/TagHelper/content_tag
+
+# ruleid: avoid-content-tag
+content_tag(:p, "Hello world!")
+ # => <p>Hello world!</p>
+
+# ruleid: avoid-content-tag
+content_tag(:div, content_tag(:p, "Hello world!"), class: "strong")
+ # => <div class="strong"><p>Hello world!</p></div>
+
+# ruleid: avoid-content-tag
+content_tag(:div, "Hello world!", class: ["strong", "highlight"])
+ # => <div class="strong highlight">Hello world!</div>
+
+# ruleid: avoid-content-tag
+content_tag("select", options, multiple: true)
+ # => <select multiple="multiple">...options...</select>
+
+# cf. https://stackoverflow.com/a/4205709
+module InputHelper
+  def editable_input(label,name)
+    # ruleid: avoid-content-tag
+    content_tag :div, :class => "field" do
+      # ruleid: avoid-content-tag
+      content_tag(:label,label) + # Note the + in this line
+      text_field_tag(name,'', :class => 'medium new_value')
+    end
+  end
+end

--- a/ruby/rails/security/audit/xss/avoid-content-tag.yaml
+++ b/ruby/rails/security/audit/xss/avoid-content-tag.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: avoid-content-tag
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    references:
+    - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/template_injection/index.markdown
+    - https://www.netsparker.com/blog/web-security/preventing-xss-ruby-on-rails-web-applications/
+  message: |
+    'content_tag()' bypasses HTML escaping for some portion of the content.
+    If external data can reach here, this exposes your application
+    to cross-site scripting (XSS) attacks. Ensure no external data reaches here.
+    If you must do this, create your HTML manually and use 'html_safe'. Ensure no
+    external data enters the HTML-safe string!
+  languages: [ruby]
+  severity: WARNING
+  pattern: content_tag(...)

--- a/ruby/rails/security/audit/xss/avoid-html-safe.rb
+++ b/ruby/rails/security/audit/xss/avoid-html-safe.rb
@@ -1,0 +1,19 @@
+# cf. https://makandracards.com/makandra/2579-everything-you-know-about-html_safe-is-wrong
+
+# ok: avoid-html-safe
+"foo".length
+
+# ruleid: avoid-html-safe
+"foo".html_safe
+
+# ruleid: avoid-html-safe
+"<div>foo</div>".html_safe + "<bar>"
+
+# ruleid: avoid-html-safe
+html = "<div>".html_safe
+
+# ok: avoid-html-safe
+html = "<div>"
+
+# ruleid: avoid-html-safe
+"<div>".html_safe.tap

--- a/ruby/rails/security/audit/xss/avoid-html-safe.yaml
+++ b/ruby/rails/security/audit/xss/avoid-html-safe.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: avoid-html-safe
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    references:
+    - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/template_injection/index.markdown
+    - https://www.netsparker.com/blog/web-security/preventing-xss-ruby-on-rails-web-applications/
+  message: |
+    'html_safe()' does not make the supplied string safe. 'html_safe()' bypasses
+    HTML escaping. If external data can reach here, this exposes your application
+    to cross-site scripting (XSS) attacks. Ensure no external data reaches here.
+  languages: [ruby]
+  severity: WARNING
+  pattern-either:
+  - pattern: $STR.html_safe
+  - pattern: $STR.html_safe.$MORE

--- a/ruby/rails/security/audit/xss/avoid-raw.rb
+++ b/ruby/rails/security/audit/xss/avoid-raw.rb
@@ -1,0 +1,61 @@
+# cf. https://github.com/rails/rails/blob/62d089a4ad0170320b851addf76f7f48a49d68d8/actionview/test/template/output_safety_helper_test.rb
+
+# frozen_string_literal: true
+
+require "abstract_unit"
+
+class OutputSafetyHelperTest < ActionView::TestCase
+  tests ActionView::Helpers::OutputSafetyHelper
+
+  def setup
+    @string = "hello"
+  end
+
+  test "raw returns the safe string" do
+    # ruleid: avoid-raw
+    result = raw(@string)
+    assert_equal @string, result
+    assert_predicate result, :html_safe?
+  end
+
+  test "raw handles nil values correctly" do
+    # ruleid: avoid-raw
+    assert_equal "", raw(nil)
+  end
+
+  test "safe_join should html_escape any items, including the separator, if they are not html_safe" do
+    # ruleid: avoid-raw
+    joined = safe_join([raw("<p>foo</p>"), "<p>bar</p>"], "<br />")
+    assert_equal "<p>foo</p>&lt;br /&gt;&lt;p&gt;bar&lt;/p&gt;", joined
+
+    # ruleid: avoid-raw
+    joined = safe_join([raw("<p>foo</p>"), raw("<p>bar</p>")], raw("<br />"))
+    assert_equal "<p>foo</p><br /><p>bar</p>", joined
+  end
+
+  test "safe_join should work recursively similarly to Array.join" do
+    joined = safe_join(["a", ["b", "c"]], ":")
+    assert_equal "a:b:c", joined
+
+    joined = safe_join(['"a"', ["<b>", "<c>"]], " <br/> ")
+    assert_equal "&quot;a&quot; &lt;br/&gt; &lt;b&gt; &lt;br/&gt; &lt;c&gt;", joined
+  end
+
+  test "safe_join should return the safe string separated by $, when second argument is not passed" do
+    default_delimeter = $,
+
+    begin
+      $, = nil
+      joined = safe_join(["a", "b"])
+      assert_equal "ab", joined
+
+      silence_warnings do
+        $, = "|"
+      end
+      joined = safe_join(["a", "b"])
+      assert_equal "a|b", joined
+    ensure
+      $, = default_delimeter
+    end
+  end
+end

--- a/ruby/rails/security/audit/xss/avoid-raw.yaml
+++ b/ruby/rails/security/audit/xss/avoid-raw.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: avoid-raw
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    references:
+    - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/template_injection/index.markdown
+    - https://www.netsparker.com/blog/web-security/preventing-xss-ruby-on-rails-web-applications/
+  message: |
+    'raw()' bypasses HTML escaping. If external data can reach here, this exposes your application
+    to cross-site scripting (XSS) attacks. If you must do this, construct individual strings
+    and mark them as safe for HTML rendering with `html_safe()`.
+  languages: [ruby]
+  severity: WARNING
+  pattern: raw(...)

--- a/ruby/rails/security/audit/xss/avoid-render-inline.rb
+++ b/ruby/rails/security/audit/xss/avoid-render-inline.rb
@@ -1,0 +1,193 @@
+# cf. https://github.com/rails/rails/blob/939fe523126198d43ecedeacc05dd7fdb1eae3d9/actionpack/test/controller/action_pack_assertions_test.rb
+
+
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "controller/fake_controllers"
+
+class ActionPackAssertionsController < ActionController::Base
+  def nothing() head :ok end
+
+  # ok: avoid-render-inline
+  def hello_xml_world() render template: "test/hello_xml_world"; end
+
+  def assign_this
+    @howdy = "ho"
+    # ruleid: avoid-render-inline
+    render inline: "Mr. Henke"
+  end
+
+  def render_based_on_parameters
+    # ok: avoid-render-inline
+    render plain: "Mr. #{params[:name]}"
+  end
+
+  def render_url
+    # ok: avoid-render-inline
+    render html: "<div>#{url_for(action: 'flash_me', only_path: true)}</div>"
+  end
+
+  def render_text_with_custom_content_type
+    # ok: avoid-render-inline
+    render body: "Hello!", content_type: Mime[:rss]
+  end
+
+  def session_stuffing
+    session["xmas"] = "turkey"
+    # ok: avoid-render-inline
+    render text: "ho ho ho"
+  end
+
+  def raise_exception_on_get
+    raise "get" if request.get?
+    # ok: avoid-render-inline
+    render text: "request method: #{request.env['REQUEST_METHOD']}"
+  end
+
+  def raise_exception_on_post
+    raise "post" if request.post?
+    # ok: avoid-render-inline
+    render plain: "request method: #{request.env['REQUEST_METHOD']}"
+  end
+
+  def render_file_absolute_path
+    # ok: avoid-render-inline
+    render file: File.expand_path("../../README.rdoc", __dir__)
+  end
+
+  def render_file_relative_path
+    # ok: avoid-render-inline
+    render file: "README.rdoc"
+  end
+end
+
+# Used to test that assert_response includes the exception message
+# in the failure message when an action raises and assert_response
+# is expecting something other than an error.
+class AssertResponseWithUnexpectedErrorController < ActionController::Base
+  def index
+    raise "FAIL"
+  end
+
+  def show
+    # ok: avoid-render-inline
+    render plain: "Boom", status: 500
+  end
+end
+
+module Admin
+  class InnerModuleController < ActionController::Base
+    def index
+      head :ok
+    end
+
+    def redirect_to_index
+      redirect_to admin_inner_module_path
+    end
+
+    def redirect_to_absolute_controller
+      redirect_to controller: "/content"
+    end
+
+    def redirect_to_fellow_controller
+      redirect_to controller: "user"
+    end
+
+    def redirect_to_top_level_named_route
+      redirect_to top_level_url(id: "foo")
+    end
+  end
+end
+
+class ApiOnlyController < ActionController::API
+  def nothing
+    head :ok
+  end
+
+  def redirect_to_new_route
+    redirect_to new_route_url
+  end
+end
+
+class ActionPackAssertionsControllerTest < ActionController::TestCase
+  def test_render_file_absolute_path
+    get :render_file_absolute_path
+    assert_match(/\A= Action Pack/, @response.body)
+  end
+
+  def test_render_file_relative_path
+    get :render_file_relative_path
+    assert_match(/\A= Action Pack/, @response.body)
+  end
+
+  def test_get_request
+    assert_raise(RuntimeError) { get :raise_exception_on_get }
+    get :raise_exception_on_post
+    assert_equal "request method: GET", @response.body
+  end
+
+  def test_post_request
+    assert_raise(RuntimeError) { post :raise_exception_on_post }
+    post :raise_exception_on_get
+    assert_equal "request method: POST", @response.body
+  end
+
+  def test_get_post_request_switch
+    post :raise_exception_on_get
+    assert_equal "request method: POST", @response.body
+    get :raise_exception_on_post
+    assert_equal "request method: GET", @response.body
+    post :raise_exception_on_get
+    assert_equal "request method: POST", @response.body
+    get :raise_exception_on_post
+    assert_equal "request method: GET", @response.body
+  end
+
+  def test_string_constraint
+    with_routing do |set|
+      set.draw do
+        get "photos", to: "action_pack_assertions#nothing", constraints: { subdomain: "admin" }
+      end
+    end
+  end
+
+  def test_with_routing_works_with_api_only_controllers
+    @controller = ApiOnlyController.new
+
+    with_routing do |set|
+      set.draw do
+        get "new_route", to: "api_only#nothing"
+        get "redirect_to_new_route", to: "api_only#redirect_to_new_route"
+      end
+
+      process :redirect_to_new_route
+      assert_redirected_to "http://test.host/new_route"
+    end
+  end
+
+  def test_assert_redirect_to_named_route_failure
+    with_routing do |set|
+      set.draw do
+        get "route_one", to: "action_pack_assertions#nothing", as: :route_one
+        get "route_two", to: "action_pack_assertions#nothing", id: "two", as: :route_two
+
+        ActiveSupport::Deprecation.silence do
+          get ":controller/:action"
+        end
+      end
+      process :redirect_to_named_route
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to "http://test.host/route_two"
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to %r(^http://test.host/route_two)
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to controller: "action_pack_assertions", action: "nothing", id: "two"
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to route_two_url
+      end
+    end
+  end

--- a/ruby/rails/security/audit/xss/avoid-render-inline.yaml
+++ b/ruby/rails/security/audit/xss/avoid-render-inline.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: avoid-render-inline
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    references:
+    - https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#inline-renders---even-worse-than-xss
+  message: |
+    'render inline: ...' renders an entire ERB template inline and is dangerous.
+    If external data can reach here, this exposes your application
+    to server-side template injection (SSTI) or cross-site scripting (XSS) attacks.
+    Instead, consider using a partial or another safe rendering method.
+  languages: [ruby]
+  severity: WARNING
+  pattern: 'render inline: ...'

--- a/ruby/rails/security/audit/xss/avoid-render-text.rb
+++ b/ruby/rails/security/audit/xss/avoid-render-text.rb
@@ -1,0 +1,192 @@
+# cf. https://github.com/rails/rails/blob/939fe523126198d43ecedeacc05dd7fdb1eae3d9/actionpack/test/controller/action_pack_assertions_test.rb
+
+
+# frozen_string_literal: true
+
+require "abstract_unit"
+require "controller/fake_controllers"
+
+class ActionPackAssertionsController < ActionController::Base
+  def nothing() head :ok end
+
+  # ok: avoid-render-text
+  def hello_xml_world() render template: "test/hello_xml_world"; end
+
+  def assign_this
+    @howdy = "ho"
+    render inline: "Mr. Henke"
+  end
+
+  def render_based_on_parameters
+    # ok: avoid-render-text
+    render plain: "Mr. #{params[:name]}"
+  end
+
+  def render_url
+    # ok: avoid-render-text
+    render html: "<div>#{url_for(action: 'flash_me', only_path: true)}</div>"
+  end
+
+  def render_text_with_custom_content_type
+    # ok: avoid-render-text
+    render body: "Hello!", content_type: Mime[:rss]
+  end
+
+  def session_stuffing
+    session["xmas"] = "turkey"
+    # ruleid: avoid-render-text
+    render text: "ho ho ho"
+  end
+
+  def raise_exception_on_get
+    raise "get" if request.get?
+    # ruleid: avoid-render-text
+    render text: "request method: #{request.env['REQUEST_METHOD']}"
+  end
+
+  def raise_exception_on_post
+    raise "post" if request.post?
+    # ok: avoid-render-text
+    render plain: "request method: #{request.env['REQUEST_METHOD']}"
+  end
+
+  def render_file_absolute_path
+    # ok: avoid-render-text
+    render file: File.expand_path("../../README.rdoc", __dir__)
+  end
+
+  def render_file_relative_path
+    # ok: avoid-render-text
+    render file: "README.rdoc"
+  end
+end
+
+# Used to test that assert_response includes the exception message
+# in the failure message when an action raises and assert_response
+# is expecting something other than an error.
+class AssertResponseWithUnexpectedErrorController < ActionController::Base
+  def index
+    raise "FAIL"
+  end
+
+  def show
+    # ok: avoid-render-text
+    render plain: "Boom", status: 500
+  end
+end
+
+module Admin
+  class InnerModuleController < ActionController::Base
+    def index
+      head :ok
+    end
+
+    def redirect_to_index
+      redirect_to admin_inner_module_path
+    end
+
+    def redirect_to_absolute_controller
+      redirect_to controller: "/content"
+    end
+
+    def redirect_to_fellow_controller
+      redirect_to controller: "user"
+    end
+
+    def redirect_to_top_level_named_route
+      redirect_to top_level_url(id: "foo")
+    end
+  end
+end
+
+class ApiOnlyController < ActionController::API
+  def nothing
+    head :ok
+  end
+
+  def redirect_to_new_route
+    redirect_to new_route_url
+  end
+end
+
+class ActionPackAssertionsControllerTest < ActionController::TestCase
+  def test_render_file_absolute_path
+    get :render_file_absolute_path
+    assert_match(/\A= Action Pack/, @response.body)
+  end
+
+  def test_render_file_relative_path
+    get :render_file_relative_path
+    assert_match(/\A= Action Pack/, @response.body)
+  end
+
+  def test_get_request
+    assert_raise(RuntimeError) { get :raise_exception_on_get }
+    get :raise_exception_on_post
+    assert_equal "request method: GET", @response.body
+  end
+
+  def test_post_request
+    assert_raise(RuntimeError) { post :raise_exception_on_post }
+    post :raise_exception_on_get
+    assert_equal "request method: POST", @response.body
+  end
+
+  def test_get_post_request_switch
+    post :raise_exception_on_get
+    assert_equal "request method: POST", @response.body
+    get :raise_exception_on_post
+    assert_equal "request method: GET", @response.body
+    post :raise_exception_on_get
+    assert_equal "request method: POST", @response.body
+    get :raise_exception_on_post
+    assert_equal "request method: GET", @response.body
+  end
+
+  def test_string_constraint
+    with_routing do |set|
+      set.draw do
+        get "photos", to: "action_pack_assertions#nothing", constraints: { subdomain: "admin" }
+      end
+    end
+  end
+
+  def test_with_routing_works_with_api_only_controllers
+    @controller = ApiOnlyController.new
+
+    with_routing do |set|
+      set.draw do
+        get "new_route", to: "api_only#nothing"
+        get "redirect_to_new_route", to: "api_only#redirect_to_new_route"
+      end
+
+      process :redirect_to_new_route
+      assert_redirected_to "http://test.host/new_route"
+    end
+  end
+
+  def test_assert_redirect_to_named_route_failure
+    with_routing do |set|
+      set.draw do
+        get "route_one", to: "action_pack_assertions#nothing", as: :route_one
+        get "route_two", to: "action_pack_assertions#nothing", id: "two", as: :route_two
+
+        ActiveSupport::Deprecation.silence do
+          get ":controller/:action"
+        end
+      end
+      process :redirect_to_named_route
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to "http://test.host/route_two"
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to %r(^http://test.host/route_two)
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to controller: "action_pack_assertions", action: "nothing", id: "two"
+      end
+      assert_raise(ActiveSupport::TestCase::Assertion) do
+        assert_redirected_to route_two_url
+      end
+    end
+  end

--- a/ruby/rails/security/audit/xss/avoid-render-text.yaml
+++ b/ruby/rails/security/audit/xss/avoid-render-text.yaml
@@ -1,0 +1,18 @@
+rules:
+- id: avoid-render-text
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    references:
+    - https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#inline-renders---even-worse-than-xss
+  message: |
+    'render text: ...' actually sets the content-type to 'text/html'.
+    If external data can reach here, this exposes your application
+    to cross-site scripting (XSS) attacks. Instead, use 'render plain: ...' to
+    render non-HTML text.
+  languages: [ruby]
+  severity: WARNING
+  pattern: 'render text: ...'
+  fix-regex:
+    regex: 'text:'
+    replacement: 'plain:'

--- a/ruby/rails/security/audit/xss/manual-template-creation.rb
+++ b/ruby/rails/security/audit/xss/manual-template-creation.rb
@@ -1,0 +1,20 @@
+require 'erb'
+
+class FaxHelper
+
+  def to_fax
+    html = File.open(path_to_template).read
+    # ruleid: manual-template-creation
+    template = ERB.new(html)
+    template.result
+  end
+
+end
+
+
+x = 42
+# ruleid: manual-template-creation
+template = ERB.new <<-EOF
+  The value of x is: <%= x %>
+EOF
+puts template.result(binding)

--- a/ruby/rails/security/audit/xss/manual-template-creation.yaml
+++ b/ruby/rails/security/audit/xss/manual-template-creation.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: manual-template-creation
+  metadata:
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    references:
+    - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/template_injection/index.markdown
+  message: |
+    Detected manual creation of an ERB template. Manual creation of templates
+    may expose your application to server-side template injection (SSTI) or
+    cross-site scripting (XSS) attacks if user input is used to create the
+    template. Instead, create a '.erb' template file and use 'render'.
+  languages: [ruby]
+  severity: WARNING
+  pattern: ERB.new(...)

--- a/ruby/rails/security/audit/xss/templates/alias-for-html-safe.erb
+++ b/ruby/rails/security/audit/xss/templates/alias-for-html-safe.erb
@@ -1,0 +1,7 @@
+@custom_page_title = “Page <strong>Title</strong>” 
+<div> 
+  <!-- ruleid: alias-for-html-safe -->
+  <h1><%== @custom_page_title %></h1> 
+  <!-- ok: alias-for-html-safe -->
+  <h1><%= @custom_page_title %></h1> 
+</div>

--- a/ruby/rails/security/audit/xss/templates/alias-for-html-safe.yaml
+++ b/ruby/rails/security/audit/xss/templates/alias-for-html-safe.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: alias-for-html-safe
+  message: ''
+  metadata:
+    references:
+    - https://medium.com/sumone-technical-blog/a-pretty-way-to-unescape-html-in-a-ruby-on-rails-application-efc22b850027
+    - https://stackoverflow.com/questions/4251284/raw-vs-html-safe-vs-h-to-unescape-html#:~:text===
+  languages: [none]
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <%==.*?%>

--- a/ruby/rails/security/audit/xss/templates/avoid-content-tag.erb
+++ b/ruby/rails/security/audit/xss/templates/avoid-content-tag.erb
@@ -1,0 +1,7 @@
+@custom_page_title = “Page <strong>Title</strong>” 
+<div> 
+  <!-- ruleid: avoid-content-tag -->
+  <h1><%= content_tag :p @custom_page_title %></h1> 
+  <!-- ok: avoid-content-tag -->
+  <h1><%= @custom_page_title %></h1> 
+</div>

--- a/ruby/rails/security/audit/xss/templates/avoid-content-tag.yaml
+++ b/ruby/rails/security/audit/xss/templates/avoid-content-tag.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: avoid-content-tag
+  message: ''
+  metadata:
+    references:
+    - https://medium.com/sumone-technical-blog/a-pretty-way-to-unescape-html-in-a-ruby-on-rails-application-efc22b850027
+    - https://stackoverflow.com/questions/4251284/raw-vs-html-safe-vs-h-to-unescape-html#:~:text===
+  languages: [none]
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <%=.*?content_tag.*?%>

--- a/ruby/rails/security/audit/xss/templates/avoid-html-safe.erb
+++ b/ruby/rails/security/audit/xss/templates/avoid-html-safe.erb
@@ -1,0 +1,7 @@
+@custom_page_title = “Page <strong>Title</strong>” 
+<div> 
+  <!-- ruleid: avoid-html-safe -->
+  <h1><%= @custom_page_title.html_safe %></h1> 
+  <!-- ok: avoid-html-safe -->
+  <h1><%= @custom_page_title %></h1> 
+</div>

--- a/ruby/rails/security/audit/xss/templates/avoid-html-safe.yaml
+++ b/ruby/rails/security/audit/xss/templates/avoid-html-safe.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: avoid-html-safe
+  message: ''
+  metadata:
+    references:
+    - https://medium.com/sumone-technical-blog/a-pretty-way-to-unescape-html-in-a-ruby-on-rails-application-efc22b850027
+    - https://stackoverflow.com/questions/4251284/raw-vs-html-safe-vs-h-to-unescape-html#:~:text===
+  languages: [none]
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <%=.*?html_safe.*?%>

--- a/ruby/rails/security/audit/xss/templates/avoid-raw.erb
+++ b/ruby/rails/security/audit/xss/templates/avoid-raw.erb
@@ -1,0 +1,7 @@
+@custom_page_title = “Page <strong>Title</strong>” 
+<div> 
+  <!-- ruleid: avoid-raw -->
+  <h1><%= raw @custom_page_title %></h1> 
+  <!-- ok: avoid-raw -->
+  <h1><%= @custom_page_title %></h1> 
+</div>

--- a/ruby/rails/security/audit/xss/templates/avoid-raw.yaml
+++ b/ruby/rails/security/audit/xss/templates/avoid-raw.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: avoid-raw
+  message: ''
+  metadata:
+    references:
+    - https://medium.com/sumone-technical-blog/a-pretty-way-to-unescape-html-in-a-ruby-on-rails-application-efc22b850027
+    - https://stackoverflow.com/questions/4251284/raw-vs-html-safe-vs-h-to-unescape-html#:~:text===
+  languages: [none]
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <%=.*?raw.*?%>

--- a/ruby/rails/security/audit/xss/templates/dangerous-link-to.erb
+++ b/ruby/rails/security/audit/xss/templates/dangerous-link-to.erb
@@ -1,0 +1,8 @@
+<h1>Welcome#index</h1>
+<p>Find me in app/views/welcome/index.html.erb</p>
+<!-- ok: dangerous-link-to -->
+<%= link_to "Go here", "/blahblah" %>
+<!-- ok: dangerous-link-to -->
+<%= link_to "Go here", "/"+@link %>
+<!-- ruleid: dangerous-link-to -->
+<%= link_to "Go here", @link %>

--- a/ruby/rails/security/audit/xss/templates/dangerous-link-to.yaml
+++ b/ruby/rails/security/audit/xss/templates/dangerous-link-to.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: dangerous-link-to
+  message: |
+    Detected a template variable used in 'link_to'. This will
+    generate dynamic data in the 'href' attribute.
+    This allows a malicious actor to 
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks. If using a relative URL,
+    start with a literal forward slash and concatenate the URL,
+    like this: 'link_to "Here", "/"+@link'. You may also consider
+    setting the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#cross-site-scripting-xss
+    - https://brakemanscanner.org/docs/warning_types/link_to_href/
+  languages:
+  - none
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <%.*?link_to(?!.*\+).*?\@.*?%>

--- a/ruby/rails/security/audit/xss/templates/unquoted-attribute.erb
+++ b/ruby/rails/security/audit/xss/templates/unquoted-attribute.erb
@@ -1,0 +1,19 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+
+<div class="jumbotron text-center">
+    <h1 class="display-4">Oi, meu nome é <%= nome %>!</h1>
+    <p class="lead">Isso é apenas uma demonstração de como utilizar o Mustache.JS</p>
+    <!-- ruleid: unquoted-attribute -->
+    <a href=<%= link %> class="text-center">Click me</a>
+    <!-- ruleid: unquoted-attribute -->
+    <a href=/<%= link %> class="text-center">Click me</a>
+    <!-- ok: unquoted-attribute -->
+    <a href="<%= link %>" class="text-center">Click me</a>
+    <!-- ok: unquoted-attribute -->
+    <a href='<%= link %>' class="text-center">Click me</a>
+</div>
+
+</html>

--- a/ruby/rails/security/audit/xss/templates/unquoted-attribute.yaml
+++ b/ruby/rails/security/audit/xss/templates/unquoted-attribute.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: unquoted-attribute
+  message: |
+    Detected a unquoted template variable as an attribute. If unquoted, a
+    malicious actor could inject custom JavaScript handlers. To fix this,
+    add quotes around the template expression, like this: "<%= expr %>".
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#unquoted-attributes
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
+  languages:
+  - none
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <.*=.*<%=.*?%>(\s+|>).*
+  fix-regex:
+    regex: <%=(.*?)%>
+    replacement: '"<%=\1%>"'

--- a/ruby/rails/security/audit/xss/templates/var-in-href.erb
+++ b/ruby/rails/security/audit/xss/templates/var-in-href.erb
@@ -1,0 +1,15 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+
+<div class="jumbotron text-center">
+    <h1 class="display-4">Oi, meu nome é <%= nome %>!</h1>
+    <p class="lead">Isso é apenas uma demonstração de como utilizar o Mustache.JS</p>
+    <!-- ruleid: var-in-href -->
+    <a href="<%= link %>" class="text-center">Click me</a>
+    <!-- ok: var-in-href -->
+    <a href="/<%= link %>" class="text-center">Click me</a>
+</div>
+
+</html>

--- a/ruby/rails/security/audit/xss/templates/var-in-href.yaml
+++ b/ruby/rails/security/audit/xss/templates/var-in-href.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: var-in-href
+  message: |
+    Detected a template variable used in an anchor tag with
+    the 'href' attribute. This allows a malicious actor to 
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks. If using a relative URL,
+    start with a literal forward slash and concatenate the URL,
+    like this: href='/<%= link =>'. You may also consider setting
+    the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
+    - https://github.com/pugjs/pug/issues/2952
+  languages:
+  - none
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <a.*href=.*?[^\/&=]<%.*?%>.*?>

--- a/ruby/rails/security/audit/xss/templates/var-in-script-tag.erb
+++ b/ruby/rails/security/audit/xss/templates/var-in-script-tag.erb
@@ -1,0 +1,23 @@
+<!-- ok: var-in-script-tag -->
+<script type="text/javascript" src="whatever.js"></script>
+
+<!-- ruleid: var-in-script-tag -->
+<script>current_user_id = <%=param[:id]%></script>
+<!-- ok: var-in-script-tag -->
+<div>Hello <%=param[:id]%></div>
+
+<script type="text/javascript">
+    <!-- ruleid: var-in-script-tag -->
+    var message = <%= message %>;
+</script>
+
+<script type="text/javascript">
+    <!-- ok: var-in-script-tag -->
+    var message = <%= j message %>;
+</script>
+
+<script type="text/javascript">
+    <!-- ok: var-in-script-tag -->
+    var message = <%= escape_javascript message %>;
+	console.log(message);
+</script>

--- a/ruby/rails/security/audit/xss/templates/var-in-script-tag.yaml
+++ b/ruby/rails/security/audit/xss/templates/var-in-script-tag.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: var-in-script-tag
+  message: |
+    Detected a template variable used in a script tag.
+    Although template variables are HTML escaped, HTML
+    escaping does not always prevent cross-site scripting (XSS)
+    attacks when used directly in JavaScript. If you need to do
+    this, use `escape_javascript` or its alias, `j`. However, this
+    will not protect from XSS in all circumstances; see the references
+    for more information. Consider placing this value in the HTML
+    portion (outside of a script tag). 
+  metadata:
+    references:
+    - https://www.netsparker.com/blog/web-security/preventing-xss-ruby-on-rails-web-applications/
+    - https://www.youtube.com/watch?v=yYTkLUEdIyE
+    - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
+  languages: [none]
+  paths:
+    include:
+    - '*.erb'
+  severity: WARNING
+  pattern-regex: <%(?!.*(j\b|escape_javascript\b)).*?%>([^\/]|\n)*?<\/script>


### PR DESCRIPTION
# XSS Prevention in Ruby on Rails

Conditions:

1. User input (reflected, stored)
2. Bypass escaping engine
3. Unescaped variable enters template context
4. Variable is unescaped in template
5. Variable in dangerous location in template

### 2. Bypass escaping engine

* Creating a template manually, like with `ERB.new(...)` with formatting or user input
    * https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/template_injection/index.markdown
* Using `render text`
    * https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#inline-renders---even-worse-than-xss
* Using `render inline`
    * https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#inline-renders---even-worse-than-xss

### 3. Unescaped variable enters template context

* `html_safe()` 
* `content_tag(...)`
    * https://brakemanscanner.org/docs/warning_types/content_tag/
* `raw(...)`
    * https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html#method-i-raw
* disabling `ActiveSupport#escape_html_entities_in_json`
    * https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/cross_site_scripting_to_json/index.markdown

### 4. Variable is unescaped in template

* `raw` 
* `$PROP.html_safe`
* `content_tag`

### 5. Variable in dangerous location in template

* unquoted template variable in HTML attribute
* template variable in `href` attribute
    * even with `link_to`
        * https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/link_to_href/index.markdown
* template variable in JS context
    * Use `escape_javascript`, or its alias `j`
        * https://blog.ircmaxell.com/2018/06/protecting-rails-xss.html

## Mitigations

1. Ban manual template creation
2. Ban `html_safe()`
    1. Exemptions via `nosem`
3. Ban `content_tag()`
    1. Use `html_safe()`
4. Ban `raw()`
    1. Use `html_safe()`
5. Flag `ActiveSupport#escape_html_entities_in_json = False`
6. Ban `raw` in templates
    1. Use `html_safe()` in Ruby code
7. Ban `$PROP.html_safe` in templates
    1. Use `html_safe()` in Ruby code
8. Ban `<%== ... %>`, which is an alias for `html_safe()`
9. Ban `content_tag` in templates
    1. Use `html_safe()` in Ruby code
10. Flag unquoted template variables in HTML attributes
11. Flag template variables in `href` attribute
12. Flag `link_to`
13. Require `escape_javascript` for all template variables in JavaScript or script tags
14. Ban `render text` 
15. Ban `render inline`

|Control	|Description	|Semgrep Rule	|
|---	|---	|---	|
|1	|Ban manual template creation	|ruby.rails.security.audit.xss.manual-template-creation.manual-template-creation	|
|2	|Ban `html_safe()`	|ruby.rails.security.audit.xss.avoid-html-safe.avoid-html-safe	|
|3	|Ban `content_tag()`	|ruby.rails.security.audit.xss.avoid-content-tag.avoid-content-tag	|
|4	|Ban `raw()`	|ruby.rails.security.audit.xss.avoid-raw.avoid-raw	|
|5	|Flag `ActiveSupport#escape_html_entities_in_json = False`	|ruby.lang.security.json-entity-escape.json-entity-escape	|
|6	|Ban `raw` in templates	|ruby.rails.security.audit.xss.templates.avoid-raw.avoid-raw	|
|7	|Ban `$PROP.html_safe` in templates	|ruby.rails.security.audit.xss.templates.avoid-html-safe.avoid-html-safe	|
|8	|Ban `<%== ... %>`, which is an alias for `html_safe()`	|ruby.rails.security.audit.xss.templates.alias-for-html-safe.alias-for-html-safe	|
|9	|Ban `content_tag` in templates	|ruby.rails.security.audit.xss.templates.avoid-content-tag.avoid-content-tag	|
|10	|Flag unquoted template variables in HTML attributes	|ruby.rails.security.audit.xss.templates.unquoted-attribute.unquoted-attribute	|
|11	|Flag template variables in `href` attribute	|ruby.rails.security.audit.xss.templates.var-in-href.var-in-href	|
|12	|Flag `link_to`	|ruby.rails.security.audit.xss.templates.dangerous-link-to.dangerous-link-to	|
|13	|Require `escape_javascript` for all template variables in JavaScript or script tags	|ruby.rails.security.audit.xss.templates.var-in-script-tag.var-in-script-tag	|
|14	|Ban `render text` 	|ruby.rails.security.audit.xss.avoid-render-text.avoid-render-text	|
|15	|Ban `render inline`	|ruby.rails.security.audit.xss.avoid-render-inline.avoid-render-inline	|

