### PR TITLE
fix FPs in explicit-unescape for Pug in JavaScript

### DIFF
--- a/javascript/express/security/audit/xss/pug/explicit-unescape.pug
+++ b/javascript/express/security/audit/xss/pug/explicit-unescape.pug
@@ -17,7 +17,11 @@ html(lang="en")
             li(class="nav-item")
               // ruleid: template-explicit-unescape
               a(class="nav-link" target="_blank" href!=url) Documentation
-    
+
+    // ok: template-explicit-unescape
+    if disableSignUp !== true
+      a.button(href="/signup")=t("Signup")
+
     //- Page Content
     section
       div(class="container")

--- a/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
@@ -19,5 +19,5 @@ rules:
     - '*.pug'
   severity: WARNING
   pattern-either:
-  - pattern-regex: \w.*(!=).*
+  - pattern-regex: \w.*(!=)[^=].*
   - pattern-regex: '!{.*?}'


### PR DESCRIPTION
update for not covering `!==` like:

```
    if disableSignUp !== true
      a.button(href="/signup")=t("Signup")
```