### PR TITLE
fix FPs in explicit-unescape for Ejs and Mustache in JavaScript

### DIFF
--- a/javascript/express/security/audit/xss/ejs/explicit-unescape.ejs
+++ b/javascript/express/security/audit/xss/ejs/explicit-unescape.ejs
@@ -43,6 +43,10 @@
                     <!-- ok: template-explicit-unescape -->
                     <%= template-table %>
                 </div>
+                <div>
+                    <!-- ok: template-explicit-unescape -->
+                    <%- include('partials/example', {data: data}); %>
+                </div>
             </div>
         </div>
     </div>

--- a/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
@@ -18,7 +18,7 @@ rules:
     - '*.ejs'
     - '*.html'
   severity: WARNING
-  pattern-regex: <%-.*?%>
+  pattern-regex: <%-((?!include).)*?%>
   fix-regex:
     regex: <%-(.*?)%>
     replacement: <%=\1%>

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
@@ -19,6 +19,9 @@
     </div>
 </body>
 
+<!-- ok: template-explicit-unescape -->
+{{{include 'html/partials/some-partial.html'}}}
+
 <script id="template-header" type="x-tmpl-mustache">
     <div class="jumbotron text-center">
         <!-- ruleid: template-explicit-unescape -->

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
@@ -20,5 +20,5 @@ rules:
     - '*.html'
   severity: WARNING
   pattern-either:
-  - pattern-regex: '{{{.*?}}}'
+  - pattern-regex: '{{{((?!include).)*?}}}'
   - pattern-regex: '{{.*&.*}}'


### PR DESCRIPTION
in Ejs and Mustache the common case for using raw output for including parts of the template, e.g.
```
 <%- include('user/show', {user: user}); %>
``` 