### PR TITLE
fix FPs for Ejs and Mustache in JavaScript

### DIFF
--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
@@ -34,6 +34,11 @@
     flash.text = message;
 </script>
 
+<script src="app.js"></script>
+<!-- ok: var-in-script-tag -->
+<%= title %>
+<script src="script.js"></script>
+
 <div class="text-center">
     <h2>Apresentando o time da <b><%= time.nome %></b></h2>
     <h6>Predio <%= time.predio %></h6>

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
@@ -23,5 +23,4 @@ rules:
     - '*.html'
   severity: WARNING
   patterns:
-  - pattern-regex: <\s*script[^>]*>(.|\n)*?<%.*?%>(.|\n)*?<\s*/\s*script>
-
+  - pattern-regex: <%.*?%>((?!(<\s*script[^>]*>))(.|\n))*?<\s*/\s*script>

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
@@ -23,5 +23,5 @@ rules:
     - '*.html'
   severity: WARNING
   patterns:
-  - pattern-regex: <%.*?%>(.|\n)*?<\/script>
+  - pattern-regex: <\s*script[^>]*>(.|\n)*?<%.*?%>(.|\n)*?<\s*/\s*script>
 

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
@@ -17,6 +17,7 @@ rules:
   paths:
     include:
     - '*.mustache'
+    - '*.hbs'
     - '*.html'
   severity: WARNING
   pattern-either:

--- a/javascript/express/security/audit/xss/mustache/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-href.yaml
@@ -19,6 +19,7 @@ rules:
   paths:
     include:
     - '*.mustache'
+    - '*.hbs'
     - '*.html'
   severity: WARNING
   pattern-regex: <a.*href\s*=(\s|['"])*?{{.*?}}.*

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.mustache
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.mustache
@@ -34,6 +34,11 @@
     flash.text = message;
 </script>
 
+<script type="text/javascript" src="mustache.js"></script>
+<!-- ok: var-in-script-tag -->
+{{ message }}
+<script type="text/javascript" src="demo.js"></script>
+
 <div class="text-center">
     <h2>Apresentando o time da <b>{{time.nome}}</b></h2>
     <h6>Predio {{time.predio}}</h6>

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
@@ -24,5 +24,5 @@ rules:
     - '*.html'
   severity: WARNING
   patterns:
-  - pattern-regex: <\s*script[^>]*>(.|\n)*?{{.*?}}(.|\n)*?<\s*/\s*script>
+  - pattern-regex: '{{.*?}}((?!(<\s*script[^>]*>))(.|\n))*?<\s*/\s*script>'
 

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
@@ -20,8 +20,9 @@ rules:
   paths:
     include:
     - '*.mustache'
+    - '*.hbs'
     - '*.html'
   severity: WARNING
   patterns:
-  - pattern-regex: '{{.*?}}(.|\n)*?<\/script>'
+  - pattern-regex: <\s*script[^>]*>(.|\n)*?{{.*?}}(.|\n)*?<\s*/\s*script>
 


### PR DESCRIPTION
1. Mustache rules should also apply to Handlebars templates, so I added coverage for `.hbs` files
from docs: (and experience :))
https://handlebarsjs.com/
```
Handlebars is largely compatible with Mustache templates. In most cases it is possible to swap out Mustache with Handlebars and continue using your current templates.
```

2. lots of false positives on the platform for situations like this:
```html
<script src="app.js"></script>
<%= title %>
<script src="script.js"></script>
```