### PR TITLE
Detect Unsafe deserialization of a JMS ObjectMessage

### DIFF
--- a/java/lang/security/insecure-jms-deserialization.java
+++ b/java/lang/security/insecure-jms-deserialization.java
@@ -1,0 +1,72 @@
+package com.rands.couponproject.ejb;
+
+import java.util.Date;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.EJB;
+import javax.ejb.MessageDriven;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.ObjectMessage;
+import javax.jms.TextMessage;
+
+import org.apache.log4j.Logger;
+
+import com.rands.couponproject.jpa.Income;
+
+/**
+ * Message-Driven Bean implementation class for: IncomeConsumerBean
+ */
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(
+        propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+        @ActivationConfigProperty(
+        propertyName = "destination", propertyValue = "java:/jms/queue/MyQueue")
+        })
+public class IncomeConsumerBean implements MessageListener {
+    
+    static Logger logger = Logger.getLogger(IncomeConsumerBean.class);
+    
+    @EJB
+    IncomeServiceBean isb;
+
+    /**
+     * Default constructor. 
+     */
+    public IncomeConsumerBean() {
+        // TODO Auto-generated constructor stub
+    }
+    
+    /**
+     * @see MessageListener#onMessage(Message)
+     */
+    public void onMessage(Message message) {
+        try {
+            if (message instanceof TextMessage) {
+                logger.info("onMessage received a TextMessage at " + new Date());
+                TextMessage msg = (TextMessage) message;
+                logger.warn("onMessage ignoring TextMessage : " + msg.getText());
+            } else if (message instanceof ObjectMessage) {
+                logger.info("onMessage received an ObjectMessage at " + new Date());
+                
+                ObjectMessage msg = (ObjectMessage) message;
+                
+                Object o = msg.getObject(); // variant 1 : calling getObject method directly on an ObjectMessage object
+                logger.info("o=" + o);
+                
+                Income income = (Income) msg.getObject(); // variant 2 : calling getObject method and casting to a custom class 
+                logger.info("Message is : " + income);
+                
+                isb.StoreIncome(income);
+            } else {
+                logger.error("onMessage received an invalid message type");
+            }
+ 
+        } catch (JMSException e) {
+            logger.error("onMessage failed : " + e.toString());
+        }
+    }
+
+
+}

--- a/java/lang/security/insecure-jms-deserialization.java
+++ b/java/lang/security/insecure-jms-deserialization.java
@@ -52,9 +52,11 @@ public class IncomeConsumerBean implements MessageListener {
                 
                 ObjectMessage msg = (ObjectMessage) message;
                 
+                // ruleid: insecure-jms-deserialization
                 Object o = msg.getObject(); // variant 1 : calling getObject method directly on an ObjectMessage object
                 logger.info("o=" + o);
                 
+                // ruleid: insecure-jms-deserialization
                 Income income = (Income) msg.getObject(); // variant 2 : calling getObject method and casting to a custom class 
                 logger.info("Message is : " + income);
                 

--- a/java/lang/security/insecure-jms-deserialization.yaml
+++ b/java/lang/security/insecure-jms-deserialization.yaml
@@ -1,0 +1,29 @@
+rules:
+- id: insecure-jms-deserialization
+  severity: WARNING
+  languages:
+  - java
+  metadata:
+    cwe: 'CWE-502: Deserialization of Untrusted Data'
+    owasp: 'A8: Insecure Deserialization'
+    references:
+    - https://www.blackhat.com/docs/us-16/materials/us-16-Kaiser-Pwning-Your-Java-Messaging-With-Deserialization-Vulnerabilities-wp.pdf
+  message: |
+    JMS Object messages depend on Java Serialization for marshalling/unmarshalling of the message payload when ObjectMessage.getObject() is called.
+    Deserialization of untrusted data can lead to security flaws; a remote attacker could via a crafted JMS ObjectMessage to execute
+    arbitrary code with the permissions of the application listening/consuming JMS Messages.
+    In this case, the JMS MessageListener consume an ObjectMessage type recieved inside 
+    the onMessage method, which may lead to arbitrary code execution when calling the $Y.getObject method.
+  patterns:
+  - pattern-inside: |
+      public class $JMS_LISTENER implements MessageListener {
+        ...
+        public void onMessage(Message $JMS_MSG) {
+            ...
+        }
+      }
+  - pattern-either:
+    - pattern-inside: $X = $Y.getObject(...);
+    - pattern-inside: $X = ($Z) $Y.getObject(...);
+
+


### PR DESCRIPTION
This rule aim to detect insecure deserialization of Java Message Service (JMS) ObjectMessage object.

**Description** : Deserialization of untrusted data can lead to security flaws; a remote attacker could via a crafted JMS ObjectMessage execute arbitrary code with the permissions of the application listening/consuming JMS Messages.

For more details : https://www.blackhat.com/docs/us-16/materials/us-16-Kaiser-Pwning-Your-Java-Messaging-With-Deserialization-Vulnerabilities.pdf (slide 57 contains a sample vulnerable code).