### PR TITLE
Ignore NullBooleanField for django's nontext field must set null=True

### DIFF
--- a/python/django/correctness/nontext-field-must-set-null-true.yaml
+++ b/python/django/correctness/nontext-field-must-set-null-true.yaml
@@ -11,6 +11,7 @@ rules:
   - pattern-not: $F = django.db.models.URLField(...)
   - pattern-not: $F = django.db.models.UUIDField(...)
   - pattern-not: $F = django.db.models.ManyToManyField(...)
+  - pattern-not: $F = django.db.models.NullBooleanField(...)
   - pattern-not: $F = $X(..., null=True, blank=True, ...)
   - pattern: $F = $X(..., blank=True, ...)
   message: null=True should be set if blank=True is set on non-text fields.


### PR DESCRIPTION
I know NullBooleanField is being deprecated in 3.1 but older projects can still use it so probably best to have it ignored by the rule.