### PR TITLE
Remove wrong semicolons

### DIFF
--- a/contrib/nodejsscan/layer7_object_dos.yaml
+++ b/contrib/nodejsscan/layer7_object_dos.yaml
@@ -15,9 +15,9 @@ rules:
         $OBJ = $REQ.body.$FOO;
         ...
   - pattern-inside: |
-      for(...){...};
+      for(...){...}
   - pattern: |
-      $OBJ.length;
+      $OBJ.length
   message: Layer7 Denial of Service. Looping over user controlled objects can result in DoS.
   languages:
   - javascript

--- a/javascript/browser/security/insecure-postmessage-configuration.yaml
+++ b/javascript/browser/security/insecure-postmessage-configuration.yaml
@@ -20,15 +20,15 @@ rules:
       - pattern-not: |
           window.addEventListener(..., function($OBJECT){ if ($OBJ.origin == $X) {
                       ...
-                  }; });
+                  } });
       - pattern-not: |
           window.addEventListener(..., function($OBJECT){ if ($REGEX.test($OBJECT.origin)){
               ...
-          }; });
+          } });
       - pattern-not: |
           window.addEventListener(..., function($OBJECT){ if ($OBJ.origin !== $X) {
                       ...
-                  }; });
+                  } });
     message: |
       No validation of origin is done by the addEventListener API. It may be possible to exploit this flaw to perform Cross Origin attacks such as Cross-Site Scripting(XSS).
     languages:


### PR DESCRIPTION
With the recent changes to the Javascript pattern parser, semicolons
are now more meaningful, and a pattern like
'foo(...) {...};'  is parsed a a sequence of 2 statements: a for and
an empty statement.

test plan:
make test