### PR TITLE
Fix javascript.lang.correctness.useless-assignment false positive.

### DIFF
--- a/javascript/lang/correctness/useless-assign.js
+++ b/javascript/lang/correctness/useless-assign.js
@@ -20,3 +20,11 @@ console.log(z);
 // ok
 a = "Hi ";
 a += "Mom";
+
+// ok
+b = i;
+b = f(1, b);
+
+// ok
+c = j;
+c = f(1, g(c));

--- a/javascript/lang/correctness/useless-assign.yaml
+++ b/javascript/lang/correctness/useless-assign.yaml
@@ -6,6 +6,9 @@ rules:
       $X = $X.$METHOD(...);
   - pattern-not: |
       $X = $Y;
+      $X = $FUNC(..., <... $X ...>, ...);
+  - pattern-not: |
+      $X = $Y;
       $X = $PREPEND + $X;
   - pattern-not: |
       $X = $Y;


### PR DESCRIPTION
A repeated assignment isn't useless if the value of the first assignment
is used as an input to a function call in the second assignment.

I didn't make it as general as possible since the other patterns also aren't.
The deep expression operator could be used to also excluded false positives
like:

    z = y;
    z = 1 + $FUNC(z);