### PR TITLE
Port most of the ocamllint rules to semgrep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,5 @@ test:
 	semgrep --validate --config=$$PWD/javascript $$PWD
 	semgrep --validate --config=$$PWD/java $$PWD
 	semgrep --validate --config=$$PWD/go $$PWD
+	semgrep --validate --config=$$PWD/ocaml $$PWD
 	semgrep --test --strict --test-ignore-todo --dangerously-allow-arbitrary-code-execution-from-rules $$PWD

--- a/ocaml/lang/best-practice/bool.ml
+++ b/ocaml/lang/best-practice/bool.ml
@@ -1,0 +1,14 @@
+let test a =
+  (* ruleid:ocamllint-bool-true *)
+  let x = a = true in
+  (* ruleid:ocamllint-bool-true *)
+  let x = a == true in
+  (* ruleid:ocamllint-bool-false *)
+  let x = a = false in
+  (* ruleid:ocamllint-bool-false *)
+  let x = a == false in
+  (* ruleid:ocamllint-bool-true *)
+  let x = a != false in
+  (* ruleid:ocamllint-bool-false *)
+  let x = a <> true in
+  ()

--- a/ocaml/lang/best-practice/bool.yaml
+++ b/ocaml/lang/best-practice/bool.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: ocamllint-bool-true
+  pattern-either:
+  - pattern: $X = true
+  - pattern: $X == true
+  - pattern: $X != false
+  message: Comparison to boolean. Just use `$X`
+  languages: [ocaml]
+  severity: WARNING
+- id: ocamllint-bool-false
+  pattern-either:
+  - pattern: $X = false
+  - pattern: $X == false
+  - pattern: $X <> true
+  message: Comparison to boolean. Just use `not $X`
+  languages: [ocaml]
+  severity: WARNING

--- a/ocaml/lang/best-practice/ifs.ml
+++ b/ocaml/lang/best-practice/ifs.ml
@@ -1,0 +1,11 @@
+let test a =
+  (* ruleid:ocamllint-useless-else *)
+  if a
+  then print_string a
+  else ()
+
+let test2 a =
+  (* ruleid:ocamllint-backwards-if *)
+  if a
+  then ()
+  else print_string a

--- a/ocaml/lang/best-practice/ifs.yaml
+++ b/ocaml/lang/best-practice/ifs.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: ocamllint-useless-else
+  pattern: if $E then $E1 else ()
+  message: Useless else. Just remove the else branch;
+  languages: [ocaml]
+  severity: WARNING
+- id: ocamllint-backwards-if
+  pattern: if $E then () else $E2
+  message: Backwards if. Rewrite the code as 'if not $E then $E2'.
+  languages: [ocaml]
+  severity: WARNING

--- a/ocaml/lang/best-practice/ref.ml
+++ b/ocaml/lang/best-practice/ref.ml
@@ -1,0 +1,6 @@
+let test x =
+  (* ruleid:ocamllint-ref-incr *)
+  x := x + 1;
+  (* ruleid:ocamllint-ref-decr *)
+  x := x - 1;
+  ()

--- a/ocaml/lang/best-practice/ref.yaml
+++ b/ocaml/lang/best-practice/ref.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: ocamllint-ref-incr
+  pattern: $X := $X + 1
+  message: You should use `incr`
+  languages: [ocaml]
+  severity: WARNING
+- id: ocamllint-ref-decr
+  pattern: $X := $X - 1
+  message: You should use `decr
+  languages: [ocaml]
+  severity: WARNING

--- a/ocaml/lang/best-practice/string.ml
+++ b/ocaml/lang/best-practice/string.ml
@@ -1,0 +1,20 @@
+let test s =
+  (* ruleid:ocamllint-str-first-chars *)
+  String.sub s 0 20
+
+let test2 s =
+  (* ruleid:ocamllint-str-string-after *)
+  String.sub s 20 (String.length s - 20)
+
+let test3 s =
+  (* ruleid:ocamllint-str-last-chars *)
+  String.sub s (String.length s - 20) 20
+
+
+let test 4 s = 
+  (* ruleid:ocamllint-useless-sprintf *)
+  let s1 = Printf.sprintf "this is useless" in
+  (* ruleid:ocamllint-useless-sprintf *)
+  let s2 = Printf.sprintf "%s" "this is also useless" in
+  let s3 = Printf.sprintf "this is an %d int" 2 in
+  ()

--- a/ocaml/lang/best-practice/string.yaml
+++ b/ocaml/lang/best-practice/string.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: ocamllint-str-first-chars
+  pattern: String.sub $S 0 $N
+  message: Use instead `Str.first_chars`
+  languages: [ocaml]
+  severity: WARNING
+- id: ocamllint-str-string-after
+  pattern: String.sub $S $N (String.length $S - $N)
+  message: Use instead `Str.string_after`
+  languages: [ocaml]
+  severity: WARNING
+- id: ocamllint-str-last-chars
+  pattern: String.sub $S (String.length $S - $N) $N
+  message: Use instead `Str.last_chars`
+  languages: [ocaml]
+  severity: WARNING
+- id: ocamllint-useless-sprintf
+  pattern-either: 
+  - pattern: Printf.sprintf "..."
+  - pattern: Printf.sprintf "%s" $S
+  message: Useless sprintf
+  languages: [ocaml]
+  severity: WARNING

--- a/ocaml/lang/correctness/useless_if.ml
+++ b/ocaml/lang/correctness/useless_if.ml
@@ -1,0 +1,6 @@
+let test a b =
+  (* ruleid:ocamllint-useless-if *)
+  if foo
+  then a+b
+  else a+b
+

--- a/ocaml/lang/correctness/useless_if.yaml
+++ b/ocaml/lang/correctness/useless_if.yaml
@@ -1,0 +1,6 @@
+rules:
+- id: ocamllint-useless-if
+  pattern: if $X then $E else $E
+  message: Useless if. Both branches are equal.
+  languages: [ocaml]
+  severity: ERROR

--- a/ocaml/lang/correctness/useless_let.ml
+++ b/ocaml/lang/correctness/useless_let.ml
@@ -1,3 +1,5 @@
 let test () =
-  (* ruleid:ocamllint-useless-let *)
-  let x = 3 in x
+  (* todoruleid:ocamllint-useless-let *)
+  let x = 3 in 
+  x
+

--- a/ocaml/lang/correctness/useless_let.ml
+++ b/ocaml/lang/correctness/useless_let.ml
@@ -1,0 +1,3 @@
+let test () =
+  (* ruleid:ocamllint-useless-let *)
+  let x = 3 in x

--- a/ocaml/lang/correctness/useless_let.yaml
+++ b/ocaml/lang/correctness/useless_let.yaml
@@ -1,0 +1,6 @@
+rules:
+- id: useless-let
+  pattern: let $X = $E in $X
+  message: Useless let
+  languages: [ocaml]
+  severity: ERROR

--- a/ocaml/lang/performance/list.ml
+++ b/ocaml/lang/performance/list.ml
@@ -1,5 +1,11 @@
 let test xs =
-  (* ruleid:length-list-zero *)
+  (* ruleid:ocamllint-length-list-zero *)
   if List.length xs = 0
+  then 1
+  else 2
+
+let test2 xs =
+  (* ruleid:ocamllint-length-more-than-zero *)
+  if List.length xs > 0
   then 1
   else 2

--- a/ocaml/lang/performance/list.yaml
+++ b/ocaml/lang/performance/list.yaml
@@ -1,6 +1,11 @@
 rules:
-- id: length-list-zero
+- id: ocamllint-length-list-zero
   pattern: List.length $X = 0
   message: You probably want $X = [], which is faster.
+  languages: [ocaml]
+  severity: WARNING
+- id: ocamllint-length-more-than-zero
+  pattern: List.length $X > 0
+  message: You probably want $X <> [], which is faster.
   languages: [ocaml]
   severity: WARNING


### PR DESCRIPTION
This is porting most of the rules at:
https://github.com/cryptosense/ocamllint/blob/3477d6f7313a1394ffb1176d04b7d33d3f6670e1/lib/ocamllint_rules.ml#L140

Most of the test cases were also ported:
https://github.com/cryptosense/ocamllint/blob/3477d6f7313a1394ffb1176d04b7d33d3f6670e1/test/tests.ml#L37

A few remaining rules can't be easily encoded in semgrep
(e.g., the constant match), or
are now detected by the compiler
(e.g., the incorrect use of partial application), or
don't seem very useful
(e.g., the application of list operations on singletons).

test plan:
make test