### PR TITLE
Move number comparisons from pattern-where-python to metavariable-comparison where possible

### DIFF
--- a/go/lang/correctness/overflow/overflow.yaml
+++ b/go/lang/correctness/overflow/overflow.yaml
@@ -8,7 +8,10 @@ rules:
       $F, $ERR := strconv.Atoi($NUM)
       ...
       int16($F)
-  - pattern-where-python: int(vars['$NUM'].replace('"', '')) > 32767 or int(vars['$NUM'].replace('"', '')) < -32768
+  - metavariable-comparison:
+      metavariable: $NUM
+      comparison: $NUM > 32767 or $NUM < -32768
+      strip: true
 - id: integer-overflow-int32
   message: Potential Integer overflow made by strconv.Atoi result conversion to int32
   languages: [go]
@@ -18,5 +21,7 @@ rules:
       $F, $ERR := strconv.Atoi($NUM)
       ...
       int32($F)
-  - pattern-where-python: |-
-      int(vars['$NUM'].replace('"', '')) > 2147483647 or int(vars['$NUM'].replace('"', '')) < -2147483648
+  - metavariable-comparison:
+      metavariable: $NUM
+      comparison: $NUM > 2147483647 or $NUM < -2147483648
+      strip: true

--- a/go/lang/correctness/permissions/file_permission.yaml
+++ b/go/lang/correctness/permissions/file_permission.yaml
@@ -9,8 +9,10 @@ rules:
   patterns:
   - pattern: |
       os.Chmod($NAME, $PERM)
-  - pattern-where-python: |
-      int(vars['$PERM'], 8) > 0o600
+  - metavariable-comparison:
+      metavariable: $PERM
+      comparison: $PERM > 0o600
+      base: 8
 - id: incorrect-default-permission
   message: Expect permissions to be `0600` or less for ioutil.WriteFile()
   metadata:
@@ -21,8 +23,10 @@ rules:
   patterns:
   - pattern: |
       ioutil.WriteFile($NAME, $DATA, $PERM)
-  - pattern-where-python: |
-      int(vars['$PERM'], 8) > 0o600
+  - metavariable-comparison:
+      metavariable: $PERM
+      comparison: $PERM > 0o600
+      base: 8
 - id: incorrect-default-permission
   message: Expect permissions to be `0600` or less for ioutil.WriteFile()
   metadata:
@@ -33,8 +37,10 @@ rules:
   patterns:
   - pattern: |
       os.Mkdir($NAME, $PERM)
-  - pattern-where-python: |
-      int(vars['$PERM'], 8) > 0o600
+  - metavariable-comparison:
+      metavariable: $PERM
+      comparison: $PERM > 0o600
+      base: 8
 - id: incorrect-default-permission
   message: Expect permissions to be `0600` or less for ioutil.WriteFile()
   metadata:
@@ -45,8 +51,10 @@ rules:
   patterns:
   - pattern: |
       os.MkdirAll($NAME, $PERM)
-  - pattern-where-python: |
-      int(vars['$PERM'], 8) > 0o600
+  - metavariable-comparison:
+      metavariable: $PERM
+      comparison: $PERM > 0o600
+      base: 8
 - id: incorrect-default-permission
   message: Expect permissions to be `0600` or less for ioutil.WriteFile()
   metadata:
@@ -57,5 +65,7 @@ rules:
   patterns:
   - pattern: |
       os.OpenFile($NAME, $FLAG, $PERM)
-  - pattern-where-python: |-
-      int(vars['$PERM'], 8) > 0o600
+  - metavariable-comparison:
+      metavariable: $PERM
+      comparison: $PERM > 0o600
+      base: 8

--- a/go/lang/security/audit/crypto/use_of_weak_rsa_key.yaml
+++ b/go/lang/security/audit/crypto/use_of_weak_rsa_key.yaml
@@ -15,5 +15,6 @@ rules:
         rsa.GenerateKey(..., $BITS)
     - pattern: |
         rsa.GenerateMultiPrimeKey(..., $BITS)
-  - pattern-where-python: |-
-      int(vars['$BITS']) < 2048
+  - metavariable-comparison:
+      metavariable: $BITS
+      comparison: $BITS < 2048

--- a/java/lang/security/audit/blowfish-insufficient-key-size.yaml
+++ b/java/lang/security/audit/blowfish-insufficient-key-size.yaml
@@ -15,5 +15,6 @@ rules:
       $KEYGEN = KeyGenerator.getInstance("Blowfish");
       ...
       $KEYGEN.init($SIZE);
-  - pattern-where-python: |-
-      int(vars['$SIZE']) < 128
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 128

--- a/java/lang/security/audit/crypto/weak-rsa.java
+++ b/java/lang/security/audit/crypto/weak-rsa.java
@@ -9,6 +9,7 @@ public class WeakRSA {
   }
 
   static void rsaOK() {
+    // ok: use-of-weak-rsa-key
     KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
     keyGen.initialize(2048);
   }

--- a/java/lang/security/audit/crypto/weak-rsa.yaml
+++ b/java/lang/security/audit/crypto/weak-rsa.yaml
@@ -14,5 +14,6 @@ rules:
       KeyPairGenerator $KEY = $G.getInstance("RSA");
       ...
       $KEY.initialize($BITS);
-  - pattern-where-python: |-
-      int(vars['$BITS']) < 2048
+  - metavariable-comparison:
+      metavariable: $BITS
+      comparison: $BITS < 2048

--- a/python/cryptography/security/insufficient-dsa-key-size.yaml
+++ b/python/cryptography/security/insufficient-dsa-key-size.yaml
@@ -4,13 +4,9 @@ rules:
   - pattern-either:
     - pattern: cryptography.hazmat.primitives.asymmetric.dsa.generate_private_key(..., key_size=$SIZE, ...)
     - pattern: cryptography.hazmat.primitives.asymmetric.dsa.generate_private_key($SIZE, ...)
-  - pattern-where-python: |
-      alert = False
-      try:
-        alert = int(vars['$SIZE']) < 2048
-      except:
-        alert = False
-      alert
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
   message: |
     Detected an insufficient key size for DSA. NIST recommends
     a key size of 2048 or higher.

--- a/python/cryptography/security/insufficient-rsa-key-size.yaml
+++ b/python/cryptography/security/insufficient-rsa-key-size.yaml
@@ -4,13 +4,9 @@ rules:
   - pattern-either:
     - pattern: cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key(..., key_size=$SIZE, ...)
     - pattern: cryptography.hazmat.primitives.asymmetric.rsa.generate_private_key($EXP, $SIZE, ...)
-  - pattern-where-python: |
-      alert = False
-      try:
-        alert = int(vars['$SIZE']) < 2048
-      except:
-        alert = False
-      alert
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
   message: |
     Detected an insufficient key size for RSA. NIST recommends
     a key size of 2048 or higher.

--- a/python/pycryptodome/security/insufficient-dsa-key-size.yaml
+++ b/python/pycryptodome/security/insufficient-dsa-key-size.yaml
@@ -6,13 +6,9 @@ rules:
     - pattern: Crypto.PublicKey.DSA.generate($SIZE, ...)
     - pattern: Cryptodome.PublicKey.DSA.generate(..., bits=$SIZE, ...)
     - pattern: Cryptodome.PublicKey.DSA.generate($SIZE, ...)
-  - pattern-where-python: |
-      alert = False
-      try:
-        alert = int(vars['$SIZE']) < 2048
-      except:
-        alert = False
-      alert
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
   message: |
     Detected an insufficient key size for DSA. NIST recommends
     a key size of 2048 or higher.

--- a/python/pycryptodome/security/insufficient-rsa-key-size.yaml
+++ b/python/pycryptodome/security/insufficient-rsa-key-size.yaml
@@ -6,13 +6,9 @@ rules:
     - pattern: Crypto.PublicKey.RSA.generate($SIZE, ...)
     - pattern: Cryptodome.PublicKey.RSA.generate(..., bits=$SIZE, ...)
     - pattern: Cryptodome.PublicKey.RSA.generate($SIZE, ...)
-  - pattern-where-python: |
-      alert = False
-      try:
-        alert = int(vars['$SIZE']) < 2048
-      except:
-        alert = False
-      alert
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048
   message: |
     Detected an insufficient key size for RSA. NIST recommends
     a key size of 2048 or higher.


### PR DESCRIPTION
Depends on https://github.com/returntocorp/semgrep/pull/1824.

We'll obviously need `metavariable-comparison` to be released before we can move forward here. We may even want to delay this change until a bit after to give people time to upgrade before we break any builds with backwards-incompatible rules. I'll put this in draft state until then.

But... it works! The tests pass :tada: 