### PR TITLE
Add Typescript to languages of javascript/lang/ and javascript/browser/ rules

### DIFF
--- a/javascript/browser/security/dom-based-xss.yaml
+++ b/javascript/browser/security/dom-based-xss.yaml
@@ -1,19 +1,18 @@
 rules:
 - id: dom-based-xss
-  pattern-either:
-  - pattern: document.write(<... document.location.$W ...>)
-  - pattern: document.write(<... location.$W ...>)
-  message: |
-    Detected possible DOM-based XSS. This occurs because a portion of the URL is being used
-    to construct an element added directly to the page. For example, a malicious actor could
-    send someone a link like this: http://www.some.site/page.html?default=<script>alert(document.cookie)</script>
-    which would add the script to the page.
-    Consider whitelisting appropriate values or using an approach which does not involve the URL.
+  languages:
+  - javascript
+  - typescript
+  message: "Detected possible DOM-based XSS. This occurs because a portion of the URL is being used\nto construct an element\
+    \ added directly to the page. For example, a malicious actor could\nsend someone a link like this: http://www.some.site/page.html?default=<script>alert(document.cookie)</script>\n\
+    which would add the script to the page.\nConsider whitelisting appropriate values or using an approach which does not\
+    \ involve the URL.\n"
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     owasp: 'A7: Cross-site Scripting (XSS)'
     references:
     - https://owasp.org/www-community/attacks/DOM_Based_XSS
+  pattern-either:
+  - pattern: document.write(<... document.location.$W ...>)
+  - pattern: document.write(<... location.$W ...>)
   severity: ERROR
-  languages:
-  - javascript

--- a/javascript/browser/security/eval-detected.yaml
+++ b/javascript/browser/security/eval-detected.yaml
@@ -1,15 +1,15 @@
 rules:
 - id: eval-detected
-  patterns:
-  - pattern-not: eval("...")
-  - pattern: eval(...)
-  message: |
-    Detected the use of eval(). eval() can be dangerous if used to evaluate
-    dynamic content. If this content can be input from outside the program, this
-    may be a code injection vulnerability. Ensure evaluated content is not definable
-    by external sources.
+  languages:
+  - javascript
+  - typescript
+  message: "Detected the use of eval(). eval() can be dangerous if used to evaluate\ndynamic content. If this content can\
+    \ be input from outside the program, this\nmay be a code injection vulnerability. Ensure evaluated content is not definable\n\
+    by external sources.\n"
   metadata:
     cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
     owasp: 'A1: Injection'
-  languages: [javascript]
+  patterns:
+  - pattern-not: eval("...")
+  - pattern: eval(...)
   severity: WARNING

--- a/javascript/browser/security/insecure-innerhtml.yaml
+++ b/javascript/browser/security/insecure-innerhtml.yaml
@@ -1,14 +1,13 @@
 rules:
 - id: insecure-innerhtml
-  patterns:
-  - pattern: |
-      $EL.innerHTML = $HTML;
-  - pattern-not: |
-      $EL.innerHTML = "...";
-  message: |
-    User controlled data in a `$EL.innerHTML` is an anti-pattern than can lead to XSS vulnerabilities
+  languages:
+  - javascript
+  - typescript
+  message: "User controlled data in a `$EL.innerHTML` is an anti-pattern than can lead to XSS vulnerabilities\n"
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     owasp: 'A7: Cross-site Scripting (XSS)'
-  languages: [javascript]
+  patterns:
+  - pattern: "$EL.innerHTML = $HTML;\n"
+  - pattern-not: "$EL.innerHTML = \"...\";\n"
   severity: WARNING

--- a/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
+++ b/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
@@ -1,28 +1,18 @@
 rules:
-- id: insufficient-postmessage-origin-validation
-  patterns:
-  - pattern-either:
-    - pattern: |
-        window.addEventListener(...)
-  - pattern-not: |
-      window.addEventListener(..., function($OBJECT){ if ($OBJ.origin == $X) {
-                  ...
-              } });
-  - pattern-not: |
-      window.addEventListener(..., function($OBJECT){ if ($REGEX.test($OBJECT.origin)){
-          ...
-      } });
-  - pattern-not: |
-      window.addEventListener(..., function($OBJECT){ if ($OBJ.origin !== $X) {
-                  ...
-              } });
-  message: |
-    No validation of origin is done by the addEventListener API. It may be possible to exploit this flaw to perform Cross Origin attacks such as Cross-Site Scripting(XSS).
+- fix: ''
+  id: insufficient-postmessage-origin-validation
   languages:
   - javascript
-  fix: |
-
-  severity: WARNING
+  - typescript
+  message: "No validation of origin is done by the addEventListener API. It may be possible to exploit this flaw to perform\
+    \ Cross Origin attacks such as Cross-Site Scripting(XSS).\n"
   metadata:
-    owasp: 'A6: Sensitive Data Exposure'
     cwe: 'CWE-345: Insufficient Verification of Data Authenticity'
+    owasp: 'A6: Sensitive Data Exposure'
+  patterns:
+  - pattern-either:
+    - pattern: "window.addEventListener(...)\n"
+  - pattern-not: "window.addEventListener(..., function($OBJECT){ if ($OBJ.origin == $X) {\n            ...\n        } });\n"
+  - pattern-not: "window.addEventListener(..., function($OBJECT){ if ($REGEX.test($OBJECT.origin)){\n    ...\n} });\n"
+  - pattern-not: "window.addEventListener(..., function($OBJECT){ if ($OBJ.origin !== $X) {\n            ...\n        } });\n"
+  severity: WARNING

--- a/javascript/browser/security/open-redirect.yaml
+++ b/javascript/browser/security/open-redirect.yaml
@@ -1,27 +1,20 @@
 rules:
 - id: js-open-redirect
-  message: |
-    Possible open redirect
+  languages:
+  - javascript
+  - typescript
+  message: "Possible open redirect\n"
   metadata:
     cwe: 'CWE-601: URL Redirection to Untrusted Site (Open Redirect)'
     owasp: 'A1: Injection'
-  languages: [javascript]
-  severity: WARNING
   patterns:
   - pattern-either:
-    - pattern: |
-        window.location.replace($URL)
-    - pattern: |
-        location.replace($URL)
-    - pattern: |
-        window.location.href = $URL
-    - pattern: |
-        location.href = $URL
-  - pattern-not: |
-      window.location.href = "..."
-  - pattern-not: |
-      location.href = "..."
-  - pattern-not: |
-      location.replace("...")
-  - pattern-not: |-
-      window.location.replace("...")
+    - pattern: "window.location.replace($URL)\n"
+    - pattern: "location.replace($URL)\n"
+    - pattern: "window.location.href = $URL\n"
+    - pattern: "location.href = $URL\n"
+  - pattern-not: "window.location.href = \"...\"\n"
+  - pattern-not: "location.href = \"...\"\n"
+  - pattern-not: "location.replace(\"...\")\n"
+  - pattern-not: window.location.replace("...")
+  severity: WARNING

--- a/javascript/browser/security/raw-html-concat.yaml
+++ b/javascript/browser/security/raw-html-concat.yaml
@@ -1,10 +1,9 @@
 rules:
 - id: raw-html-concat
-  message: >-
-    User controlled data in a HTML string may result in XSS
   languages:
   - javascript
-  severity: WARNING
+  - typescript
+  message: User controlled data in a HTML string may result in XSS
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     owasp: 'A7: Cross-site Scripting (XSS)'
@@ -12,82 +11,31 @@ rules:
     - https://owasp.org/www-community/attacks/xss/
   patterns:
   - pattern-either:
-    - pattern: |
-        "..." + (<... window ...>);
-    - pattern: |
-        (<... window ...>) + "...";
-    - pattern: |
-        "..." + (<... location ...>);
-    - pattern: |
-        (<... location ...>) + "...";
-    - pattern: |
-        "..." + (<... document ...>);
-    - pattern: |
-        (<... document ...>) + "...";
+    - pattern: "\"...\" + (<... window ...>);\n"
+    - pattern: "(<... window ...>) + \"...\";\n"
+    - pattern: "\"...\" + (<... location ...>);\n"
+    - pattern: "(<... location ...>) + \"...\";\n"
+    - pattern: "\"...\" + (<... document ...>);\n"
+    - pattern: "(<... document ...>) + \"...\";\n"
     - patterns:
       - pattern-either:
-        - pattern-inside: |
-            function $FUNC(..., $X, ...) {
-              ...
-            }
-        - pattern-inside: |
-            function (..., $X, ...) {
-              ...
-            }
-        - pattern-inside: |
-            function $FUNC(...) {
-              ...
-              $X = (<... document ...>);
-              ...
-            }
-        - pattern-inside: |
-            function (...) {
-              ...
-              $X = (<... document ...>);
-              ...
-            }
-        - pattern-inside: |
-            function $FUNC(...) {
-              ...
-              $X = (<... window ...>);
-              ...
-            }
-        - pattern-inside: |
-            function (...) {
-              ...
-              $X = (<... window ...>);
-              ...
-            }
-        - pattern-inside: |
-            function $FUNC(...) {
-              ...
-              $X = (<... location ...>);
-              ...
-            }
-        - pattern-inside: |
-            function (...) {
-              ...
-              $X = (<... location ...>);
-              ...
-            }
+        - pattern-inside: "function $FUNC(..., $X, ...) {\n  ...\n}\n"
+        - pattern-inside: "function (..., $X, ...) {\n  ...\n}\n"
+        - pattern-inside: "function $FUNC(...) {\n  ...\n  $X = (<... document ...>);\n  ...\n}\n"
+        - pattern-inside: "function (...) {\n  ...\n  $X = (<... document ...>);\n  ...\n}\n"
+        - pattern-inside: "function $FUNC(...) {\n  ...\n  $X = (<... window ...>);\n  ...\n}\n"
+        - pattern-inside: "function (...) {\n  ...\n  $X = (<... window ...>);\n  ...\n}\n"
+        - pattern-inside: "function $FUNC(...) {\n  ...\n  $X = (<... location ...>);\n  ...\n}\n"
+        - pattern-inside: "function (...) {\n  ...\n  $X = (<... location ...>);\n  ...\n}\n"
       - pattern-either:
-        - pattern: |
-            "..." + (<... $X ...>);
-        - pattern: |
-            "..." + (<... $X[...] ...>);
-        - pattern: |
-            "..." + (<... $X.$PROPERTY ...>);
-        - pattern: |
-            "..." + (<... $X.$METHOD(...) ...>);
-        - pattern: |
-            "..." + (<... $X.$PROPERTY.$METHOD(...) ...>);
-        - pattern: |
-            (<... $X ...>) + "...";
-        - pattern: |
-            (<... $X[...] ...>) + "...";
-        - pattern: |
-            (<... $X.$PROPERTY ...>) + "...";
-        - pattern: |
-            (<... $X.$METHOD(...) ...>) + "...";
-        - pattern: |-
-            (<... $X.$PROPERTY.$METHOD(...) ...>) + "...";
+        - pattern: "\"...\" + (<... $X ...>);\n"
+        - pattern: "\"...\" + (<... $X[...] ...>);\n"
+        - pattern: "\"...\" + (<... $X.$PROPERTY ...>);\n"
+        - pattern: "\"...\" + (<... $X.$METHOD(...) ...>);\n"
+        - pattern: "\"...\" + (<... $X.$PROPERTY.$METHOD(...) ...>);\n"
+        - pattern: "(<... $X ...>) + \"...\";\n"
+        - pattern: "(<... $X[...] ...>) + \"...\";\n"
+        - pattern: "(<... $X.$PROPERTY ...>) + \"...\";\n"
+        - pattern: "(<... $X.$METHOD(...) ...>) + \"...\";\n"
+        - pattern: (<... $X.$PROPERTY.$METHOD(...) ...>) + "...";
+  severity: WARNING

--- a/javascript/browser/security/wildcard-postmessage-configuration.yaml
+++ b/javascript/browser/security/wildcard-postmessage-configuration.yaml
@@ -1,14 +1,14 @@
 rules:
 - id: wildcard-postmessage-configuration
-  patterns:
-  - pattern-either:
-    - pattern: |
-        $OBJECT.postMessage(...,'*')
-  message: |
-    The target origin of the window.postMessage() API is set to "*". This could allow for information disclosure due to the possibility of any origin allowed to receive the message.
   languages:
   - javascript
-  severity: WARNING
+  - typescript
+  message: "The target origin of the window.postMessage() API is set to \"*\". This could allow for information disclosure\
+    \ due to the possibility of any origin allowed to receive the message.\n"
   metadata:
-    owasp: 'A6: Sensitive Data Exposure'
     cwe: 'CWE-345: Insufficient Verification of Data Authenticity'
+    owasp: 'A6: Sensitive Data Exposure'
+  patterns:
+  - pattern-either:
+    - pattern: "$OBJECT.postMessage(...,'*')\n"
+  severity: WARNING

--- a/javascript/lang/best-practice/assigned-undefined.yaml
+++ b/javascript/lang/best-practice/assigned-undefined.yaml
@@ -2,6 +2,7 @@ rules:
 - id: assigned-undefined
   languages:
   - javascript
+  - typescript
   message: '`undefined` is not a reserved keyword in Javascript, so this is "valid" Javascript but highly confusing and likely
     to result in bugs.'
   pattern-either:

--- a/javascript/lang/best-practice/leftover_debugging.yaml
+++ b/javascript/lang/best-practice/leftover_debugging.yaml
@@ -1,28 +1,36 @@
 rules:
 - id: javascript-alert
+  languages:
+  - javascript
+  - typescript
+  message: found alert() call; should this be in production code?
   patterns:
   - pattern-either:
     - pattern: alert()
     - pattern: alert($X)
-  message: found alert() call; should this be in production code?
-  languages: [javascript]
   severity: WARNING
 - id: javascript-debugger
-  pattern: debugger;
+  languages:
+  - javascript
+  - typescript
   message: found debugger call; should this be in production code?
-  languages: [javascript]
+  pattern: debugger;
   severity: WARNING
 - id: javascript-confirm
-  pattern: confirm(...)
+  languages:
+  - javascript
+  - typescript
   message: found conform() call; should this be in production code?
-  languages: [javascript]
+  pattern: confirm(...)
   severity: WARNING
 - id: javascript-prompt
+  languages:
+  - javascript
+  - typescript
+  message: found prompt() call; should this be in production code?
   patterns:
   - pattern-either:
     - pattern: prompt()
     - pattern: prompt($X)
     - pattern: prompt($X, $Y)
-  message: found prompt() call; should this be in production code?
-  languages: [javascript]
   severity: WARNING

--- a/javascript/lang/correctness/no-replaceall.yaml
+++ b/javascript/lang/correctness/no-replaceall.yaml
@@ -1,10 +1,11 @@
 rules:
 - id: no-replaceall
-  patterns:
-  - pattern: $STRING.replaceAll("...",$NEW)
-  message: |
-    The string method replaceAll is not supported in all versions of javascript, and is not supported by older browser versions. Consider using replace() with a regex as the first argument instead like mystring.replace(/bad/g, "good") instead of mystring.replaceAll("bad", "good") (https://discourse.threejs.org/t/replaceall-is-not-a-function/14585)
-  severity: WARNING
   languages:
   - javascript
   - typescript
+  message: "The string method replaceAll is not supported in all versions of javascript, and is not supported by older browser\
+    \ versions. Consider using replace() with a regex as the first argument instead like mystring.replace(/bad/g, \"good\"\
+    ) instead of mystring.replaceAll(\"bad\", \"good\") (https://discourse.threejs.org/t/replaceall-is-not-a-function/14585)\n"
+  patterns:
+  - pattern: $STRING.replaceAll("...",$NEW)
+  severity: WARNING

--- a/javascript/lang/correctness/useless-assign.yaml
+++ b/javascript/lang/correctness/useless-assign.yaml
@@ -1,21 +1,13 @@
 rules:
 - id: useless-assignment
-  patterns:
-  - pattern-not: |
-      $X = $Y;
-      $X = $X.$METHOD(...);
-  - pattern-not: |
-      $X = $Y;
-      $X = $FUNC(..., <... $X ...>, ...);
-  - pattern-not: |
-      $X = $Y;
-      $X = $PREPEND + $X;
-  - pattern-not: |
-      $X = $Y;
-      $X = $X + $POSTPEND;
-  - pattern: |
-      $X = $Y;
-      $X = $Z;
+  languages:
+  - javascript
+  - typescript
   message: '`$X` is assigned twice; the first assignment is useless'
-  languages: [javascript]
+  patterns:
+  - pattern-not: "$X = $Y;\n$X = $X.$METHOD(...);\n"
+  - pattern-not: "$X = $Y;\n$X = $FUNC(..., <... $X ...>, ...);\n"
+  - pattern-not: "$X = $Y;\n$X = $PREPEND + $X;\n"
+  - pattern-not: "$X = $Y;\n$X = $X + $POSTPEND;\n"
+  - pattern: "$X = $Y;\n$X = $Z;\n"
   severity: WARNING

--- a/javascript/lang/correctness/useless-eqeq.yaml
+++ b/javascript/lang/correctness/useless-eqeq.yaml
@@ -1,15 +1,14 @@
 rules:
 - id: eqeq-is-bad
+  languages:
+  - javascript
+  - typescript
+  message: "Detected a useless comparison operation `$X == $X` or `$X != $X`. This\noperation is always true.\nIf testing\
+    \ for floating point NaN, use `math.isnan`, or\n`cmath.isnan` if the number is complex.\n"
   patterns:
   - pattern-not-inside: assert(...)
   - pattern-either:
     - pattern: $X == $X
     - pattern: $X != $X
   - pattern-not: 1 == 1
-  message: |
-    Detected a useless comparison operation `$X == $X` or `$X != $X`. This
-    operation is always true.
-    If testing for floating point NaN, use `math.isnan`, or
-    `cmath.isnan` if the number is complex.
-  languages: [javascript]
   severity: ERROR

--- a/javascript/lang/security/audit/non-constant-sql-query.yaml
+++ b/javascript/lang/security/audit/non-constant-sql-query.yaml
@@ -1,14 +1,13 @@
 rules:
 - id: non-constant-sql-query
+  languages:
+  - javascript
+  - typescript
+  message: "Non-constant SQL query detected. Ensure this is not controlled\nby external data, otherwise this is a SQL injection.\n"
+  metadata:
+    cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+    owasp: 'A1: Injection'
   patterns:
   - pattern: $SQL.query(...)
   - pattern-not: $SQL.query("...")
-  message: |
-    Non-constant SQL query detected. Ensure this is not controlled
-    by external data, otherwise this is a SQL injection.
-  metadata:
-    owasp: 'A1: Injection'
-    cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
   severity: INFO
-  languages:
-  - javascript

--- a/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.yaml
+++ b/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.yaml
@@ -1,10 +1,14 @@
 rules:
 - id: path-join-resolve-traversal
+  languages:
+  - javascript
+  - typescript
+  message: "Possible writing outside of the destination,\nmake sure that the target path is nested in the intended destination\n"
+  metadata:
+    cwe: 'CWE-22: Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)'
+    owasp: 'A5: Broken Access Control'
   patterns:
-  - pattern-inside: |
-      ...
-      $PATH = require('path');
-      ...
+  - pattern-inside: "...\n$PATH = require('path');\n...\n"
   - pattern-either:
     - pattern-inside: function $FUNC(...,$INPUT,...) {...}
     - pattern-inside: function (...,$INPUT,...) {...}
@@ -12,38 +16,13 @@ rules:
     - pattern: $PATH.join(...,<... $INPUT ...>,...)
     - pattern: $PATH.join(...,<... $INPUT.$FOO ...>,...)
     - pattern: $PATH.join(...,<... $INPUT.$FOO.$BAR ...>,...)
-    - pattern: |
-        $VAR = <... $INPUT ...>;
-        ...
-        $PATH.join(...,<... $VAR ...>,...);
-    - pattern: |
-        $VAR = <... $INPUT.$FOO ...>;
-        ...
-        $PATH.join(...,<... $VAR ...>,...);
-    - pattern: |
-        $VAR = <... $INPUT.$FOO.$BAR ...>;
-        ...
-        $PATH.join(...,<... $VAR ...>,...);
+    - pattern: "$VAR = <... $INPUT ...>;\n...\n$PATH.join(...,<... $VAR ...>,...);\n"
+    - pattern: "$VAR = <... $INPUT.$FOO ...>;\n...\n$PATH.join(...,<... $VAR ...>,...);\n"
+    - pattern: "$VAR = <... $INPUT.$FOO.$BAR ...>;\n...\n$PATH.join(...,<... $VAR ...>,...);\n"
     - pattern: $PATH.resolve(...,<... $INPUT ...>,...)
     - pattern: $PATH.resolve(...,<... $INPUT.$FOO ...>,...)
     - pattern: $PATH.resolve(...,<... $INPUT.$FOO.$BAR ...>,...)
-    - pattern: |
-        $VAR = <... $INPUT ...>;
-        ...
-        $PATH.resolve(...,<... $VAR ...>,...);
-    - pattern: |
-        $VAR = <... $INPUT.$FOO ...>;
-        ...
-        $PATH.resolve(...,<... $VAR ...>,...);
-    - pattern: |
-        $VAR = <... $INPUT.$FOO.$BAR ...>;
-        ...
-        $PATH.resolve(...,<... $VAR ...>,...);
-  message: |
-    Possible writing outside of the destination,
-    make sure that the target path is nested in the intended destination
-  languages: [javascript]
-  metadata:
-    owasp: 'A5: Broken Access Control'
-    cwe: 'CWE-22: Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)'
+    - pattern: "$VAR = <... $INPUT ...>;\n...\n$PATH.resolve(...,<... $VAR ...>,...);\n"
+    - pattern: "$VAR = <... $INPUT.$FOO ...>;\n...\n$PATH.resolve(...,<... $VAR ...>,...);\n"
+    - pattern: "$VAR = <... $INPUT.$FOO.$BAR ...>;\n...\n$PATH.resolve(...,<... $VAR ...>,...);\n"
   severity: WARNING

--- a/javascript/lang/security/audit/unknown-value-with-script-tag.yaml
+++ b/javascript/lang/security/audit/unknown-value-with-script-tag.yaml
@@ -1,21 +1,17 @@
 rules:
 - id: unknown-value-with-script-tag
-  patterns:
-  - pattern-inside: |
-      $UNK = $ANYFUNC(...);
-      ...
-      $OTHERFUNC(..., <... $UNK ...>, ...);
-  - pattern: $OTHERFUNC(..., <... "=~/.*<script.*/" ...>, ...)
-  message: |
-    Cannot determine what '$UNK' is and it is used with a '<script>' tag. This
-    could be susceptible to cross-site scripting (XSS). Ensure '$UNK' is not
-    externally controlled, or sanitize this data.
+  languages:
+  - javascript
+  - typescript
+  message: "Cannot determine what '$UNK' is and it is used with a '<script>' tag. This\ncould be susceptible to cross-site\
+    \ scripting (XSS). Ensure '$UNK' is not\nexternally controlled, or sanitize this data.\n"
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
     references:
     - https://www.developsec.com/2017/11/09/xss-in-a-script-tag/
     - https://github.com/bkimminich/juice-shop/blob/master/routes/videoHandler.js#L64
+  patterns:
+  - pattern-inside: "$UNK = $ANYFUNC(...);\n...\n$OTHERFUNC(..., <... $UNK ...>, ...);\n"
+  - pattern: $OTHERFUNC(..., <... "=~/.*<script.*/" ...>, ...)
   severity: WARNING
-  languages:
-  - javascript

--- a/javascript/lang/security/audit/vm-injection.yaml
+++ b/javascript/lang/security/audit/vm-injection.yaml
@@ -1,446 +1,179 @@
 rules:
 - id: vm-runincontext-context-injection
-  message: |
-    Make sure that unverified user data can not reach vm.runInContext.
-  severity: WARNING
-  languages: [javascript]
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.runInContext.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern-either:
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = <... {$NAME:$INPUT} ...>;
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $CONTEXT = <... {$NAME:$INPUT} ...>;
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $VM.runInContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $VM.runInContext($CODE,<... $CONTEXT\
+        \ ...>,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $VM.runInContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = <... {$NAME:$INPUT} ...>;\n  ...\n  $VM.runInContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR ...>};\n\
+        \  ...\n  $VM.runInContext($CODE,<... $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $VM.runInContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $CONTEXT = <... {$NAME:$INPUT} ...>;\n  ...\n  $VM.runInContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $VM.runInContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR\
+        \ ...>};\n  ...\n  $VM.runInContext($CODE,<... $CONTEXT ...>,...);\n  ...\n}\n"
+  severity: WARNING
 - id: vm-runinnewcontext-context-injection
-  message: |
-    Make sure that unverified user data can not reach vm.runInNewContext.
-  severity: WARNING
-  languages: [javascript]
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.runInNewContext.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern-either:
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $VM.runInNewContext($CODE,<... $INPUT ...>,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = <... {$NAME:$INPUT} ...>;
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $VM.runInNewContext($CODE,<... $INPUT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $CONTEXT = <... {$NAME:$INPUT} ...>;
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
-    - pattern: |
-        function $FUNC(...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);
-          ...
-        }
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $VM.runInNewContext($CODE,<... $INPUT ...>,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $VM.runInNewContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $VM.runInNewContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = <... {$NAME:$INPUT} ...>;\n  ...\n  $VM.runInNewContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR ...>};\n\
+        \  ...\n  $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $VM.runInNewContext($CODE,<... $INPUT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $VM.runInNewContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $CONTEXT = <... {$NAME:$INPUT} ...>;\n  ...\n  $VM.runInNewContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $VM.runInNewContext($CODE,<...\
+        \ $CONTEXT ...>,...);\n  ...\n}\n"
+    - pattern: "function $FUNC(...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR\
+        \ ...>};\n  ...\n  $VM.runInNewContext($CODE,<... $CONTEXT ...>,...);\n  ...\n}\n"
+  severity: WARNING
 - id: vm-compilefunction-context-injection
-  message: |
-    Make sure that unverified user data can not reach vm.compileFunction.
-  severity: WARNING
-  languages: [javascript]
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.compileFunction.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern-either:
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $INPUT ...>},...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = <... {$NAME:$INPUT} ...>;
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $OPTS = {parsingContext: <... $INPUT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $OPTS = {parsingContext: <... $CONTEXT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $OPTS = {parsingContext: <... $CONTEXT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-    - pattern: |
-        function (...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $OPTS = {parsingContext: <... $CONTEXT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $INPUT ...>},...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $CONTEXT = <... {$NAME:$INPUT} ...>;
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $OPTS = {parsingContext: <... $INPUT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $CONTEXT = <... $INPUT ...>;
-          ...
-          $OPTS = {parsingContext: <... $CONTEXT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $CONTEXT = {$NAME: <... $INPUT ...>};
-          ...
-          $OPTS = {parsingContext: <... $CONTEXT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-    - pattern: |
-        function $F(...,$INPUT,...) {
-          ...
-          $VAR = <... $INPUT ...>;
-          ...
-          $CONTEXT = {$NAME: <... $VAR ...>};
-          ...
-          $OPTS = {parsingContext: <... $CONTEXT ...>};
-          ...
-          $VM.compileFunction($CODE,$PARAMS,$OPTS,...);
-          ...
-        }
-- id: vm-script-code-injection
-  message: |
-    Make sure that unverified user data can not reach vm.Script.
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $INPUT ...>},...);\n\
+        \  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext:\
+        \ <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = <... {$NAME:$INPUT} ...>;\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext:\
+        \ <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext:\
+        \ <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR ...>};\n\
+        \  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $OPTS = {parsingContext: <... $INPUT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n\
+        \  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $OPTS = {parsingContext: <...\
+        \ $CONTEXT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $OPTS = {parsingContext:\
+        \ <... $CONTEXT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n  ...\n}\n"
+    - pattern: "function (...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR ...>};\n\
+        \  ...\n  $OPTS = {parsingContext: <... $CONTEXT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n\
+        \  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $INPUT ...>},...);\n\
+        \  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext:\
+        \ <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $CONTEXT = <... {$NAME:$INPUT} ...>;\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext:\
+        \ <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext:\
+        \ <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR ...>};\n\
+        \  ...\n  $VM.compileFunction($CODE,$PARAMS,{parsingContext: <... $CONTEXT ...>},...);\n  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $OPTS = {parsingContext: <... $INPUT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n\
+        \  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $CONTEXT = <... $INPUT ...>;\n  ...\n  $OPTS = {parsingContext: <...\
+        \ $CONTEXT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $CONTEXT = {$NAME: <... $INPUT ...>};\n  ...\n  $OPTS = {parsingContext:\
+        \ <... $CONTEXT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n  ...\n}\n"
+    - pattern: "function $F(...,$INPUT,...) {\n  ...\n  $VAR = <... $INPUT ...>;\n  ...\n  $CONTEXT = {$NAME: <... $VAR ...>};\n\
+        \  ...\n  $OPTS = {parsingContext: <... $CONTEXT ...>};\n  ...\n  $VM.compileFunction($CODE,$PARAMS,$OPTS,...);\n\
+        \  ...\n}\n"
   severity: WARNING
-  languages: [javascript]
+- id: vm-script-code-injection
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.Script.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern: new $VM.Script($CODE,...)
   - pattern-not-inside: new $VM.Script("...",...)
-  - pattern-not-inside: |-
-      $CODE = "...";
-      ...
-      new $VM.Script($CODE,...);
-- id: vm-runincontext-code-injection
-  message: |
-    Make sure that unverified user data can not reach vm.runInContext.
+  - pattern-not-inside: "$CODE = \"...\";\n...\nnew $VM.Script($CODE,...);"
   severity: WARNING
-  languages: [javascript]
+- id: vm-runincontext-code-injection
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.runInContext.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern: $VM.runInContext($CODE,...)
   - pattern-not-inside: $VM.runInContext("...",...)
-  - pattern-not-inside: |
-      $CODE = "...";
-      ...
-      $VM.runInContext($CODE,...);
-- id: vm-runinnewcontext-code-injection
-  message: |
-    Make sure that unverified user data can not reach vm.runInNewContext.
+  - pattern-not-inside: "$CODE = \"...\";\n...\n$VM.runInContext($CODE,...);\n"
   severity: WARNING
-  languages: [javascript]
+- id: vm-runinnewcontext-code-injection
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.runInNewContext.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern: $VM.runInNewContext($CODE,...)
   - pattern-not-inside: $VM.runInNewContext("...",...)
-  - pattern-not-inside: |
-      $CODE = "...";
-      ...
-      $VM.runInNewContext($CODE,...);
-- id: vm-runinthiscontext-code-injection
-  message: |
-    Make sure that unverified user data can not reach vm.runInThisContext.
+  - pattern-not-inside: "$CODE = \"...\";\n...\n$VM.runInNewContext($CODE,...);\n"
   severity: WARNING
-  languages: [javascript]
+- id: vm-runinthiscontext-code-injection
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.runInThisContext.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern: $VM.runInThisContext($CODE,...)
   - pattern-not-inside: $VM.runInThisContext("...",...)
-  - pattern-not-inside: |
-      $CODE = "...";
-      ...
-      $VM.runInThisContext($CODE,...);
-- id: vm-compilefunction-code-injection
-  message: |
-    Make sure that unverified user data can not reach vm.compileFunction.
+  - pattern-not-inside: "$CODE = \"...\";\n...\n$VM.runInThisContext($CODE,...);\n"
   severity: WARNING
-  languages: [javascript]
+- id: vm-compilefunction-code-injection
+  languages:
+  - javascript
+  - typescript
+  message: "Make sure that unverified user data can not reach vm.compileFunction.\n"
   metadata:
-    owasp: 'A1: Injection'
     cwe: 'CWE-94: Improper Control of Generation of Code (Code Injection)'
+    owasp: 'A1: Injection'
   patterns:
-  - pattern-inside: |
-      ...
-      $VM = require('vm');
-      ...
+  - pattern-inside: "...\n$VM = require('vm');\n...\n"
   - pattern: $VM.compileFunction($CODE,...)
   - pattern-not-inside: $VM.compileFunction("...",...)
-  - pattern-not-inside: |-
-      $CODE = "...";
-      ...
-      $VM.compileFunction($CODE,...);
+  - pattern-not-inside: "$CODE = \"...\";\n...\n$VM.compileFunction($CODE,...);"
+  severity: WARNING

--- a/javascript/lang/security/detect-buffer-noassert.yaml
+++ b/javascript/lang/security/detect-buffer-noassert.yaml
@@ -1,11 +1,13 @@
 rules:
 - id: detect-buffer-noassert
+  languages:
+  - javascript
+  - typescript
+  message: "Detected usage of noassert in Buffer API, which allows the offset the be beyond the\nend of the buffer. This could\
+    \ result in writing or reading beyond the end of the buffer.\n"
   metadata:
     cwe: 'CWE-119: Improper Restriction of Operations within the Bounds of a Memory Buffer'
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-buffer-noassert.js
-  message: |
-    Detected usage of noassert in Buffer API, which allows the offset the be beyond the
-    end of the buffer. This could result in writing or reading beyond the end of the buffer.
   pattern-either:
   - pattern: $OBJ.readUInt8(..., true)
   - pattern: $OBJ.readUInt16LE(..., true)
@@ -36,5 +38,3 @@ rules:
   - pattern: $OBJ.writeDoubleLE(..., true)
   - pattern: $OBJ.writeDoubleBE(..., true)
   severity: WARNING
-  languages:
-  - javascript

--- a/javascript/lang/security/detect-child-process.yaml
+++ b/javascript/lang/security/detect-child-process.yaml
@@ -1,15 +1,14 @@
 rules:
 - id: detect-child-process
+  languages:
+  - javascript
+  - typescript
+  message: "Detected non-literal calls to child_process.exec(). This could lead to a command\ninjection vulnerability.\n"
   metadata:
     cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
     owasp: 'A1: Injection'
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-child-process.js
-  message: |
-    Detected non-literal calls to child_process.exec(). This could lead to a command
-    injection vulnerability.
   patterns:
   - pattern: child_process.exec(...)
   - pattern-not: child_process.exec('...')
   severity: WARNING
-  languages:
-  - javascript

--- a/javascript/lang/security/detect-disable-mustache-escape.yaml
+++ b/javascript/lang/security/detect-disable-mustache-escape.yaml
@@ -1,13 +1,13 @@
 rules:
 - id: detect-disable-mustache-escape
+  languages:
+  - javascript
+  - typescript
+  message: "Markup escaping disabled. This can be used with some template engines to escape\ndisabling of HTML entities, which\
+    \ can lead to XSS attacks.\n"
   metadata:
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
     owasp: 'A7: Cross-Site Scripting XSS'
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-disable-mustache-escape.js
-  message: |
-    Markup escaping disabled. This can be used with some template engines to escape
-    disabling of HTML entities, which can lead to XSS attacks.
   pattern: $OBJ.escapeMarkup = false
   severity: WARNING
-  languages:
-  - javascript

--- a/javascript/lang/security/detect-eval-with-expression.yaml
+++ b/javascript/lang/security/detect-eval-with-expression.yaml
@@ -1,14 +1,14 @@
 rules:
 - id: detect-eval-with-expression
+  languages:
+  - javascript
+  - typescript
+  message: "Detected eval(variable), which could allow a malicious actor to run arbitrary code.\n"
   metadata:
     cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
     owasp: 'A1: Injection'
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-eval-with-expression.js
-  message: |
-    Detected eval(variable), which could allow a malicious actor to run arbitrary code.
   patterns:
   - pattern: eval($OBJ)
   - pattern-not: eval("...")
   severity: WARNING
-  languages:
-  - javascript

--- a/javascript/lang/security/detect-no-csrf-before-method-override.yaml
+++ b/javascript/lang/security/detect-no-csrf-before-method-override.yaml
@@ -1,17 +1,14 @@
 rules:
 - id: detect-no-csrf-before-method-override
-  metadata:
-    cwe: 'CWE-352: Cross-Site Request Forgery (CSRF)'
-    source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-no-csrf-before-method-override.js
-    references:
-    - https://github.com/nodesecurity/eslint-plugin-security/blob/master/docs/bypass-connect-csrf-protection-by-abusing.md
-  message: |
-    Detected use of express.csrf() middleware before express.methodOverride(). This can
-    allow GET requests (which are not checked by csrf) to turn into POST requests later.
-  pattern: |
-    express.csrf();
-    ...
-    express.methodOverride();
-  severity: WARNING
   languages:
   - javascript
+  - typescript
+  message: "Detected use of express.csrf() middleware before express.methodOverride(). This can\nallow GET requests (which\
+    \ are not checked by csrf) to turn into POST requests later.\n"
+  metadata:
+    cwe: 'CWE-352: Cross-Site Request Forgery (CSRF)'
+    references:
+    - https://github.com/nodesecurity/eslint-plugin-security/blob/master/docs/bypass-connect-csrf-protection-by-abusing.md
+    source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-no-csrf-before-method-override.js
+  pattern: "express.csrf();\n...\nexpress.methodOverride();\n"
+  severity: WARNING

--- a/javascript/lang/security/detect-non-literal-require.yaml
+++ b/javascript/lang/security/detect-non-literal-require.yaml
@@ -1,15 +1,15 @@
 rules:
 - id: detect-non-literal-require
+  languages:
+  - javascript
+  - typescript
+  message: "Detected the use of require(variable). Calling require with a non-literal argument might\nallow an attacker to\
+    \ load an run arbitrary code, or access arbitrary files.\n"
   metadata:
     cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
     owasp: 'A1: Injection'
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-non-literal-require.js
-  message: |
-    Detected the use of require(variable). Calling require with a non-literal argument might
-    allow an attacker to load an run arbitrary code, or access arbitrary files.
   patterns:
   - pattern: require($OBJ)
   - pattern-not: require('...')
   severity: WARNING
-  languages:
-  - javascript

--- a/javascript/lang/security/detect-pseudoRandomBytes.yaml
+++ b/javascript/lang/security/detect-pseudoRandomBytes.yaml
@@ -1,12 +1,12 @@
 rules:
 - id: detect-pseudoRandomBytes
+  languages:
+  - javascript
+  - typescript
+  message: "Detected usage of crypto.pseudoRandomBytes, which does not produce secure random numbers.\n"
   metadata:
     cwe: 'CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)'
     owasp: 'A9: Using Components with Known Vulnerabilities'
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-pseudoRandomBytes.js
-  message: |
-    Detected usage of crypto.pseudoRandomBytes, which does not produce secure random numbers.
   pattern: crypto.pseudoRandomBytes
   severity: WARNING
-  languages:
-  - javascript

--- a/javascript/lang/security/spawn-git-clone.yaml
+++ b/javascript/lang/security/spawn-git-clone.yaml
@@ -1,14 +1,14 @@
 rules:
 - id: spawn-git-clone
-  message: |
-    Git allows shell commands to be specified in ext URLs for remote repositories.
-    For example, git clone 'ext::sh -c whoami% >&2' will execute the whoami command to try to connect to a remote repository.
-    Make sure that the URL is not controlled by external input.
+  languages:
+  - javascript
+  - typescript
+  message: "Git allows shell commands to be specified in ext URLs for remote repositories.\nFor example, git clone 'ext::sh\
+    \ -c whoami% >&2' will execute the whoami command to try to connect to a remote repository.\nMake sure that the URL is\
+    \ not controlled by external input.\n"
   metadata:
     cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
     owasp: 'A1: Injection'
-  languages: [javascript]
-  severity: ERROR
   patterns:
   - pattern-either:
     - pattern: spawn('git', ['clone',...,$F])
@@ -19,3 +19,4 @@ rules:
   - pattern-not: $X.spawn('git', ['clone',...,"..."])
   - pattern-not: spawn('git', ['clone',...,"...","..."])
   - pattern-not: $X.spawn('git', ['clone',...,"...","..."])
+  severity: ERROR


### PR DESCRIPTION
```
✗ semgrep -f javascript/lang/ ~/r2c/semgrep-app/frontend/src  
running 27 rules...
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████|27/27
/Users/grayson/r2c/semgrep-app/frontend/src/screens/deployment/policies/operations.ts
severity:warning rule:javascript.lang.best-practice.javascript-prompt: found prompt() call; should this be in production code?
55:  let policyName = prompt("New Policy Name:");

/Users/grayson/r2c/semgrep-app/frontend/src/screens/editor/EditorScreen.tsx
severity:warning rule:javascript.lang.best-practice.javascript-prompt: found prompt() call; should this be in production code?
558:    const loadThisUrl = prompt(
559:      `enter the URL to a ${this.state.language} file: `
560:    );
ran 27 rules on 164 files: 2 findings
6 files could not be analyzed; run with --verbose for details or run with --strict to exit non-zero if any file cannot be analyzed
```