### PR TITLE
disable auto updating rules

### DIFF
--- a/.github/workflows/update-semgrep-dev.yml
+++ b/.github/workflows/update-semgrep-dev.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: update dev.semgrep.dev
       run: curl --fail -X POST -L https://dev.semgrep.dev/api/admin/update-registry
-    - name: update staging.semgrep.dev
-      run: curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry
-    - name: update semgrep.dev
-      run: curl --fail -X POST -L https://semgrep.dev/api/admin/update-registry
+#     - name: update staging.semgrep.dev
+#       run: curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry
+#     - name: update semgrep.dev
+#       run: curl --fail -X POST -L https://semgrep.dev/api/admin/update-registry


### PR DESCRIPTION
just for launch to minimize number of ways the state can change