### PR TITLE
create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+“Commons Clause” License Condition v1.0
+
+The Software is provided to you by the Licensor under the License, as defined below, subject to the following condition.
+
+Without limiting other conditions in the License, the grant of rights under the License will not include, and the License does not grant to you, the right to Sell the Software.
+
+For purposes of the foregoing, “Sell” means practicing any or all of the rights granted to you under the License to provide to third parties, for a fee or other consideration (including without limitation fees for hosting or consulting/ support services related to the Software), a product or service whose value derives, entirely or substantially, from the functionality of the Software. Any license notice or attribution required by the License must also include this Commons Clause License Condition notice.
+
+Software: semgrep-rules (https://github.com/returntocorp/semgrep-rules)
+License: LGPL 2.1 (GNU Lesser General Public License, Version 2.1)
+Licensor: Return To Corporation (https://r2c.dev)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you want to create your own collection of Semgrep rules, feel free to make yo
 
 We also welcome rule contributions directly to this repository! Since this repo is maintained by r2c, there are some extra benefits—for example, if there are bug reports for your rule, we’ll also take responsibility to help fix it. If you are submitting to the semgrep-rules repo (rather than your own, separate repository as mentioned above) we’ll ask you to make r2c a joint owner of your contributions. While you still own copyright rights to your rule, joint ownership allows r2c to license these contributions to other [Semgrep Registry](https://semgrep.dev/r) users pursuant to the LGPL 2.1 under the [Commons Clause](https://commonsclause.com/).
 
-If you have more questions, please see the [FAQ section in the Semgrep docs](https://semgrep.dev/docs/faq)
+If you have more questions, please see the [FAQ section in the Semgrep docs](https://semgrep.dev/docs/faq).
 
 ## Security Coverage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@
 | `develop` | `returntocorp/semgrep:develop`  | [![semgrep-rules-test-develop](https://github.com/returntocorp/semgrep-rules/workflows/semgrep-develop/badge.svg)](https://github.com/returntocorp/semgrep-rules/actions?query=workflow%3Asemgrep-develop+branch%3Adevelop) |
 
 
-This is an repository containing rules written for [semgrep](https://semgrep.dev), organized by language. Go to the [main semgrep documentation for details on semgrep](https://semgrep.live) and the syntax for the yaml files in this repository. You can also [browse these rules online](https://semgrep.live/registry).
+This repository is the “standard library” for Semgrep rules, but there are many more written by r2c and other contributors available in the [Semgrep Registry](https://semgrep.dev/r).
+
+## Contributing
+
+If you want to create your own collection of Semgrep rules, feel free to make your own repository and then make a PR adding it to the [list of repositories with Semgrep rules](https://github.com/returntocorp/semgrep-docs/blob/main/docs/awesome.md). This list automatically gets pulled into the [Semgrep Registry](https://semgrep.dev/r) so that lots of Semgrep users can find your rules!
+
+We also welcome rule contributions directly to this repository! Since this repo is maintained by r2c, there are some extra benefits—for example, if there are bug reports for your rule, we’ll also take responsibility to help fix it. If you are submitting to the semgrep-rules repo (rather than your own, separate repository as mentioned above) we’ll ask you to make r2c a joint owner of your contributions. While you still own copyright rights to your rule, joint ownership allows r2c to license these contributions to other [Semgrep Registry](https://semgrep.dev/r) users pursuant to the LGPL 2.1 under the [Commons Clause](https://commonsclause.com/).
+
+If you have more questions, please see the [FAQ section in the Semgrep docs](https://semgrep.dev/docs/faq)
 
 ## Security Coverage
 
@@ -19,9 +27,6 @@ This is an repository containing rules written for [semgrep](https://semgrep.dev
     <img src="https://web-assets.r2c.dev/semgrep-rules-owasp-coverage-20200520.png" width="500" />
 </p>
 
-## Contributing
-
-We welcome contributions to this repo! Please fork and make a pull request; we'll contact you about signing our CLA.
 
 ### Rule Namespacing
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | `develop` | `returntocorp/semgrep:develop`  | [![semgrep-rules-test-develop](https://github.com/returntocorp/semgrep-rules/workflows/semgrep-develop/badge.svg)](https://github.com/returntocorp/semgrep-rules/actions?query=workflow%3Asemgrep-develop+branch%3Adevelop) |
 
 
-This repository is the “standard library” for Semgrep rules, but there are many more written by r2c and other contributors available in the [Semgrep Registry](https://semgrep.dev/r).
+This repository is the “standard library” for Semgrep rules, but there are many more written by r2c and other contributors available in the [Semgrep Registry](https://semgrep.dev/explore).
 
 ## Contributing
 


### PR DESCRIPTION
As pointed out in #899, previously we didn't have a license for this repository which meant that technically no one was allowed to use the rules. 

We discussed this a lot internally and decided on LGPL 2.1 (just like semgrep) but under the [Commons Clause](https://commonsclause.com/) makes the most sense. We're new to figuring out licensing, so we'd love feedback from the community on what we've picked. From the [FAQ text landing concurrently](https://github.com/returntocorp/semgrep-docs/pull/20):

> The source for many of r2c’s rules is available at returntocorp/semgrep-rules. These are licensed as LGPL 2.1 under the Commons Clause. This means the source for the rules is available, but they can’t be resold without r2c’s permission. Although the Commons Clause and related licenses like the BSL/SSPL are embraced by many great open-source projects (Sentry, Cockroach, Mongo), they are not technically open-source under the OSI definition. Why do we have this restriction if we love open source software so much? Since r2c offers a paid, hosted version at Semgrep.dev, it’s important for us to have this restriction so other companies like major cloud providers can’t just resell our rules as a competing service.

> If the LGPL + Common Clause license is an issue for you as a contributor, please give us feedback! r2c may be able to offer you semgrep-rules under a separate license on a case-by-case basis.

> #### Is it ok to run Semgrep or the r2c rules on my work projects?
> Yes! Semgrep is safe to run on your private code. The Common Clause restriction only comes into effect if you are selling the rules provided in the semgrep-rules repository. If that’s the case, you’ll need to talk with r2c first to get permission.

> #### I’m a security professional and want to use the semgrep-rules project with my clients as part of my paid services. Is that ok?
> Probably! If you have a typical consulting service and running semgrep-rules is just part of your assessments, that’s great—and of course feel free to refer your clients to the hosted Semgrep.dev. But if your entire service is about scanning code and you want to charge for running the semgrep-rules repo that r2c did the work to create and maintain, that’s something you’d need to reach out to us about.

Closes #899