### PR TITLE
Fix python string-concat-in-list f-string compatibility and improve robustness

### DIFF
--- a/python/lang/correctness/common-mistakes/string-concat-in-list.py
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.py
@@ -2,6 +2,9 @@
 bad = ["123" "456" "789"]
 
 # ruleid:string-concat-in-list
+bad = ["123" f"{456}" "789"]
+
+# ruleid:string-concat-in-list
 bad = [
     "abc"
     "cde"
@@ -17,6 +20,17 @@ bad = [
     "hijk"
 ]
 
+# ruleid:string-concat-in-list
+bad = [
+    "abc",
+    "cde"
+    f"efg"
+    "hijk"
+]
+
 good = ["123"]
 good = [123, 456]
 good = ["123", "456"]
+good = [f"123"]
+good = [f"{123}"]
+good = ["123", f"{456}"]

--- a/python/lang/correctness/common-mistakes/string-concat-in-list.py
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.py
@@ -9,6 +9,14 @@ bad = [
     "hijk"
 ]
 
+# ruleid:string-concat-in-list
+bad = [
+    "abc",
+    "cde"
+    "efg"
+    "hijk"
+]
+
 good = ["123"]
 good = [123, 456]
 good = ["123", "456"]

--- a/python/lang/correctness/common-mistakes/string-concat-in-list.py
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.py
@@ -4,25 +4,25 @@ bad = ["123" "456" "789"]
 # ruleid:string-concat-in-list
 bad = ["123" f"{456}" "789"]
 
-# ruleid:string-concat-in-list
 bad = [
+# ruleid:string-concat-in-list
     "abc"
     "cde"
     "efg",
     "hijk"
 ]
 
-# ruleid:string-concat-in-list
 bad = [
     "abc",
+# ruleid:string-concat-in-list
     "cde"
     "efg"
     "hijk"
 ]
 
-# ruleid:string-concat-in-list
 bad = [
     "abc",
+# ruleid:string-concat-in-list
     "cde"
     f"efg"
     "hijk"

--- a/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
@@ -2,7 +2,7 @@ rules:
 - id: string-concat-in-list
   patterns:
   - pattern: |
-      ["..." "...", ...]
+      [..., "..." "...", ...]
   message: |
     Detected strings implicitly concatenated inside a list.
     Python will implicitly concatenate strings when not explicitly delimited.

--- a/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
@@ -6,7 +6,7 @@ rules:
   message: |
     Detected strings implicitly concatenated inside a list.
     Python will implicitly concatenate strings when not explicitly delimited.
-    Was this supposed to be individual elements of th list?
+    Was this supposed to be individual elements of the list?
   severity: WARNING
   languages:
   - python

--- a/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
@@ -1,8 +1,12 @@
 rules:
 - id: string-concat-in-list
   patterns:
+  - pattern-inside: |
+      [...]
   - pattern: |
-      [..., "..." "...", ...]
+      "..." "..."
+  - pattern-not-inside: |
+      f"..."
   message: |
     Detected strings implicitly concatenated inside a list.
     Python will implicitly concatenate strings when not explicitly delimited.


### PR DESCRIPTION
Just started using Semgrep after reading the r2c HN article yesterday, really good stuff! After throwing the kitchen sink at one of my Python projects, I found two small bugs in the [`string-concat-in-list`](https://github.com/returntocorp/semgrep-rules/blob/develop/python/lang/correctness/common-mistakes/string-concat-in-list.yaml) rule which caused it to:

1. incorrectly flag single f-strings as pairs of implicitly concatenated strings.
- Note: **this may actually be a bug with the Semgrep parsing itself.**
2. miss implicitly concatenated strings when they don't occur at the beginning of the list. 

This PR fixes both issues, albeit with a change to the match reporting output granularity (see the [b9d2a5b commit message](https://github.com/returntocorp/semgrep-rules/commit/b9d2a5bc6d9e5a20128e02218dc2d33eed45fc57) 
for a before/after output comparison for [`string-concat-in-list.py`](https://github.com/returntocorp/semgrep-rules/blob/develop/python/lang/correctness/common-mistakes/string-concat-in-list..py)).