### PR TITLE
Avoid 'set-env' and use automatic caching

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,15 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - name: set PY
-      run: echo "::set-env name=PY::$(python --version --version | sha256sum | cut -d' ' -f1)"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - uses: pre-commit/action@v2.0.0
       env:
         SKIP: yamlfmt


### PR DESCRIPTION
Remove `set-env` due to https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w. The latest `pre-commit` Action also automatically handles caching (https://github.com/pre-commit/action/releases/tag/v2.0.0), so we don't need this anyway.