### PR TITLE
Add spacegrep rules for Hugo TOML config files.

### DIFF
--- a/generic/hugo/best-practice/invalid-base-url.toml
+++ b/generic/hugo/best-practice/invalid-base-url.toml
@@ -1,0 +1,18 @@
+# ruleid: invalid-base-url
+baseURL = "example.com"
+languageCode = "en-us"
+title = "Example"
+theme = "ananke"
+uglyurls = true
+
+MetaDataFormat = "yaml"
+DefaultContentLanguage = "en"
+Paginate = 10
+enableRobotsTXT = true
+
+[menu]
+[[menu.main]]
+identifer = "about"
+name = "About"
+url = "/about.html"
+weight = -110

--- a/generic/hugo/best-practice/invalid-base-url.yaml
+++ b/generic/hugo/best-practice/invalid-base-url.yaml
@@ -1,0 +1,10 @@
+rules:
+- id: invalid-base-url
+  patterns:
+  - pattern: baseURL = "..."
+  - pattern-regex: (?!.*http).*
+  severity: WARNING
+  message: |-
+    The 'baseURL' is invalid. This may cause links to not work if deployed.
+    Include the scheme (e.g., https://).
+  languages: [generic]

--- a/generic/hugo/best-practice/localhost-base-url.toml
+++ b/generic/hugo/best-practice/localhost-base-url.toml
@@ -1,0 +1,18 @@
+# ruleid: localhost-base-url
+baseURL = "http://localhost:1313/"
+languageCode = "en-us"
+title = "Example"
+theme = "ananke"
+uglyurls = true
+
+MetaDataFormat = "yaml"
+DefaultContentLanguage = "en"
+Paginate = 10
+enableRobotsTXT = true
+
+[menu]
+[[menu.main]]
+identifer = "about"
+name = "About"
+url = "/about.html"
+weight = -110

--- a/generic/hugo/best-practice/localhost-base-url.yaml
+++ b/generic/hugo/best-practice/localhost-base-url.yaml
@@ -1,0 +1,8 @@
+rules:
+- id: localhost-base-url
+  patterns:
+  - pattern: baseURL = "..."
+  - pattern-regex: .*(localhost|127\.0\.0\.1).*
+  severity: WARNING
+  message: The 'baseURL' is set to localhost. This may cause links to not work if deployed.
+  languages: [generic]


### PR DESCRIPTION
I work on another project that uses Hugo, the static site generator.
I kept getting bitten by this issue when developing when I would forget to change the baseURL back to its correct URL. I came up with a few Semgrep/spacegrep rules while working on it over the weekend to help me do this. 💪  Contributing them in case they're useful elsewhere.