### PR TITLE
change pre-commit python version to python3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
   rev: 0.0.13
   hooks:
   - id: yamlfmt
-    language_version: python3.7
+    language_version: python3
         # NOTE: If you change these settings, be sure to also
         # change the semgrep.live YAML settings, otherwise diffs will fail
         # to lint


### PR DESCRIPTION
change `pre-commit` to `python3` instead of `python3.7` so it worked on distros with different versions of Python