### PR TITLE
Add rules for Angular DomSanitizer methods

### DIFF
--- a/typescript/angular/security/audit/angular-domsanitizer.ts
+++ b/typescript/angular/security/audit/angular-domsanitizer.ts
@@ -1,0 +1,23 @@
+import { DomSanitizer, SecurityContext } from '@angular/platform-browser'
+
+class SomeClass {
+    constructor(private sanitizer: DomSanitizer){}
+
+    bypass(value: string){
+        // ruleid:angular-bypasssecuritytrust
+        let html = this.sanitizer.bypassSecurityTrustHtml(value);
+        // ruleid:angular-bypasssecuritytrust
+        let style = this.sanitizer.bypassSecurityTrustStyle(value);
+        // ruleid:angular-bypasssecuritytrust
+        let script = this.sanitizer.bypassSecurityTrustScript(value);
+        // ruleid:angular-bypasssecuritytrust
+        let resource_url = this.sanitizer.bypassSecurityTrustResourceUrl(value);
+        // ruleid:angular-bypasssecuritytrust
+        let url = this.sanitizer.bypassSecurityTrustUrl(value);
+
+        // ok:angular-sanitize-none-context
+        let sanitized = this.sanitizer.sanitize(SecurityContext.HTML, value);
+        // ruleid:angular-sanitize-none-context
+        let unsanitized = this.sanitizer.sanitize(SecurityContext.NONE, value);
+    }
+}

--- a/typescript/angular/security/audit/angular-domsanitizer.yaml
+++ b/typescript/angular/security/audit/angular-domsanitizer.yaml
@@ -1,0 +1,28 @@
+rules:
+- id: angular-bypasssecuritytrust
+  patterns:
+  - pattern-either:
+    - pattern: $X.bypassSecurityTrustHtml(...)
+    - pattern: $X.bypassSecurityTrustStyle(...)
+    - pattern: $X.bypassSecurityTrustScript(...)
+    - pattern: $X.bypassSecurityTrustUrl(...)
+    - pattern: $X.bypassSecurityTrustResourceUrl(...)
+  message: >-
+    Bypassing the built-in sanitization could expose the application to cross-site scripting (XSS).
+  languages:
+  - typescript
+  severity: WARNING
+  metadata:
+    references:
+    - https://angular.io/api/platform-browser/DomSanitizer
+- id: angular-sanitize-none-context
+  patterns:
+  - pattern: $X.sanitize(SecurityContext.NONE, ...)
+  message: >-
+    The output is not sanitized when calling with SecurityContext.NONE.
+  languages:
+  - typescript
+  severity: WARNING
+  metadata:
+    references:
+    - https://angular.io/api/platform-browser/DomSanitizer


### PR DESCRIPTION
This rule flags calls to bypassSecurityTrust*() methods as well as DomSanitizer.sanitize() with SecurityContext.NONE, which does not sanitize content.

https://angular.io/api/platform-browser/DomSanitizer

To be on the safer side we could check that $X is of type DomSanitizer but the method names are probably distinct enough.