### PR TITLE
Add space between keyword argument in Ruby

### DIFF
--- a/ruby/lang/security/nested-attributes-bypass.rb
+++ b/ruby/lang/security/nested-attributes-bypass.rb
@@ -3,10 +3,10 @@ def bad_nested_attributes_bypass
     accepts_nested_attributes_for allow_destroy: false
 
     # ruleid: nested-attributes-bypass
-    accepts_nested_attributes_for :avatar, :book, allow_destroy:false
+    accepts_nested_attributes_for :avatar, :book, allow_destroy: false
 
     # ruleid: nested-attributes-bypass
-    accepts_nested_attributes_for :avatar, :book, allow_destroy:false, :name
+    accepts_nested_attributes_for :avatar, :book, allow_destroy: false, :name
 end
 
 def ok_nested_attributes_bypass


### PR DESCRIPTION
This was causing regression when updating to the latest tree-sitter-ruby
https://github.com/returntocorp/semgrep/pull/2058

Without the space, this is parsed as a nested call
to allow_destroy with the :false atom as an argument.

test plan:
install latest semgrep-core
make test