### PR TITLE
avoid-pyyaml-load: Match only on PyYAML

### DIFF
--- a/python/lang/security/deserialization/avoid-pyyaml-load.yaml
+++ b/python/lang/security/deserialization/avoid-pyyaml-load.yaml
@@ -15,7 +15,8 @@ rules:
   fix: yaml.safe_load($FOO)
   severity: ERROR
   patterns:
-  - pattern-not-inside: |
-      yaml = $X
+  - pattern-inside: |
+      import yaml
       ...
+      yaml.load($FOO)
   - pattern: yaml.load($FOO)


### PR DESCRIPTION
There was an exception for ruamel.yaml before as that library is safe,
but there can be many other safe yaml variables.
In our case, `from semgrep_app.util import yaml` yielded FPs.