### PR TITLE
Update xss regex rules with 'generic'

### DIFF
--- a/go/lang/security/audit/xss/no-interpolation-in-tag.html
+++ b/go/lang/security/audit/xss/no-interpolation-in-tag.html
@@ -2,9 +2,11 @@
 <h4>To: {{.recipient}}</h4>
 <h4>Subject: {{.subject}}</h4>
 <div class="email" style="display: block;">
+    <!-- ok:no-interpolation-in-tag -->
     {{.message}}
 </div>
 <div class="email-text" style="display: none;">
+    <!-- ok:no-interpolation-in-tag -->
     <pre>{{.body}}</pre>
     <a href="https://example.com/">
         <!-- ruleid:no-interpolation-in-tag -->

--- a/go/lang/security/audit/xss/no-interpolation-in-tag.html
+++ b/go/lang/security/audit/xss/no-interpolation-in-tag.html
@@ -13,6 +13,15 @@
         <{{.HeaderSize}} class="upper">
             {{.link_text}}
         </{{.HeaderSize}}>
+
+        <!-- ruleid:no-interpolation-in-tag -->
+        <{{.HeaderSize}}
+            class="lower"
+            style="font-size: 1.5em"
+        >
+            {{.paragraph_text}}
+        </{{.HeaderSize}}>
+
     </a>
 </div>
 <hr>

--- a/go/lang/security/audit/xss/no-interpolation-in-tag.yaml
+++ b/go/lang/security/audit/xss/no-interpolation-in-tag.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: no-interpolation-in-tag
-  message: |
+  message: >-
     Detected template variable interpolation in an HTML tag.
     This is potentially vulnerable to cross-site scripting (XSS)
     attacks because a malicious actor has control over HTML
@@ -13,8 +13,7 @@ rules:
     - https://github.com/golang/go/issues/19669
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/
   languages:
-  - none
+  - generic
   severity: WARNING
   patterns:
-  - pattern-regex: |-
-      <[a-zA-Z]*{{.*}}.*>
+  - pattern: <{{ ... }} ... >

--- a/go/lang/security/audit/xss/no-interpolation-js-template-string.html
+++ b/go/lang/security/audit/xss/no-interpolation-js-template-string.html
@@ -2,12 +2,15 @@
 <h4>To: {{.recipient}}</h4>
 <h4>Subject: {{.subject}}</h4>
 <div class="email" style="display: block;">
+    <!-- ok:no-interpolation-js-template-string -->
     {{.message}}
 </div>
 <div class="email-text" style="display: none;">
+    <!-- ok:no-interpolation-js-template-string -->
     <pre>{{.body}}</pre>
     <a href="https://example.com/">
         <h2 class="upper">
+            <!-- ok:no-interpolation-js-template-string -->
             {{.link_text}}
         </h2>
     </a>

--- a/go/lang/security/audit/xss/no-interpolation-js-template-string.yaml
+++ b/go/lang/security/audit/xss/no-interpolation-js-template-string.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: no-interpolation-js-template-string
-  message: |
+  message: >-
     Detected template variable interpolation in a JavaScript
     template string. This is potentially vulnerable to
     cross-site scripting (XSS) attacks because a malicious
@@ -15,8 +15,8 @@ rules:
     - https://github.com/golang/go/issues/9200#issuecomment-66100328
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/
   languages:
-  - none
+  - generic
   severity: WARNING
   patterns:
-  - pattern-regex: |-
-      `.*{{.*}}.*`
+  - pattern-inside: <script ...> ... ... ... ... ... </script>
+  - pattern: '` ... {{ ... }} ...`'

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
@@ -29,6 +29,7 @@
     var message = <%= message %>;
     console.log(message);
     console.log("more statements here");
+    <!-- ruleid: var-in-script-tag -->
     var message2 = <%= message2 %>;
     var flash = document.getElementById("flash");
     flash.text = message;

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: var-in-script-tag
-  message: |
+  message: >-
     Detected a template variable used in a script tag.
     Although template variables are HTML escaped, HTML
     escaping does not always prevent cross-site scripting (XSS)
@@ -16,11 +16,12 @@ rules:
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
     - https://github.com/ESAPI/owasp-esapi-js
   languages:
-  - none
+  - generic
   paths:
     include:
     - '*.ejs'
     - '*.html'
   severity: WARNING
   patterns:
-  - pattern-regex: <%.*?%>((?!(<\s*script[^>]*>))(.|\n))*?<\s*/\s*script>
+  - pattern-inside: <script ...> ... </script>
+  - pattern: <% ... >

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.mustache
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.mustache
@@ -29,6 +29,7 @@
     var message = {{ message }};
     console.log(message);
     console.log("more statements here");
+    <!-- ruleid: var-in-script-tag -->
     var message2 = {{ message2 }};
     var flash = document.getElementById("flash");
     flash.text = message;

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: var-in-script-tag
-  message: |
+  message: >-
     Detected a template variable used in a script tag.
     Although template variables are HTML escaped, HTML
     escaping does not always prevent cross-site scripting (XSS)
@@ -16,7 +16,7 @@ rules:
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
     - https://github.com/ESAPI/owasp-esapi-js
   languages:
-  - none
+  - generic
   paths:
     include:
     - '*.mustache'
@@ -24,4 +24,5 @@ rules:
     - '*.html'
   severity: WARNING
   patterns:
-  - pattern-regex: '{{.*?}}((?!(<\s*script[^>]*>))(.|\n))*?<\s*/\s*script>'
+  - pattern-inside: <script ...> ... </script>
+  - pattern: '{{ ... }}'

--- a/python/django/security/audit/xss/var-in-script-tag.yaml
+++ b/python/django/security/audit/xss/var-in-script-tag.yaml
@@ -2,7 +2,7 @@ rules:
 - id: var-in-script-tag
   languages: [generic]
   severity: ERROR
-  message: |-
+  message: >-
     Detected a template variable used in a script tag.
     Although template variables are HTML escaped, HTML
     escaping does not always prevent cross-site scripting (XSS)

--- a/python/flask/security/xss/audit/template-autoescape-off.yaml
+++ b/python/flask/security/xss/audit/template-autoescape-off.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: template-autoescape-off
-  message: |
+  message: >-
     Detected a segment of a Flask template where autoescaping is explicitly
     disabled with '{% autoescape off %}'. This allows rendering of raw HTML
     in this segment. Ensure no user data is rendered here, otherwise this

--- a/python/flask/security/xss/audit/template-href-var.html
+++ b/python/flask/security/xss/audit/template-href-var.html
@@ -14,6 +14,14 @@
     <a href='{{ link }}'>{{ link_text }}</a>
     <!-- ruleid: template-href-var -->
     <a href = '{{ link }}' >{{ link_text }}</a>
+    <!-- ruleid: template-href-var -->
+    <a href = "{{ link }}" >{{ link_text }}</a>
+    <a
+        // ruleid: template-href-var
+        href = "{{ link }}"
+    >
+        {{ link_text }}
+    </a>
     <!-- ok: template-href-var -->
     <a href="{{ url_for('index') }}">{{ link_text }}</a>
     <!-- ok: template-href-var -->

--- a/python/flask/security/xss/audit/template-href-var.yaml
+++ b/python/flask/security/xss/audit/template-href-var.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: template-href-var
-  message: |
+  message: >-
     Detected a template variable used in an anchor tag with
     the 'href' attribute. This allows a malicious actor to
     input the 'javascript:' URI and is subject to cross-
@@ -14,10 +14,17 @@ rules:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
     - https://content-security-policy.com/
   languages:
-  - none
+  - generic
   paths:
     include:
     - '*.html'
   severity: WARNING
-  pattern-regex: |-
-    .*href\s*=\s*[\"\']?{{\s*(?!.*url_for).*
+  patterns:
+  - pattern-inside: <a ...>
+  - pattern-either:
+    - pattern: href = {{ ... }}
+    - pattern: href = "{{ ... }}"
+    - pattern: href = '{{ ... }}'
+  - pattern-not-inside: href = {{ url_for(...) ... }}
+  - pattern-not-inside: href = "{{ url_for(...) ... }}"
+  - pattern-not-inside: href = '{{ url_for(...) ... }}'

--- a/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
+++ b/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: template-unescaped-with-safe
-  message: |
+  message: >-
     Detected a segment of a Flask template where autoescaping is explicitly
     disabled with '| safe' filter. This allows rendering of raw HTML
     in this segment. Ensure no user data is rendered here, otherwise this

--- a/python/flask/security/xss/audit/template-unquoted-attribute-var.html
+++ b/python/flask/security/xss/audit/template-unquoted-attribute-var.html
@@ -59,3 +59,27 @@
 <div class="upper">
      {{ paragraph_text }}
 </div>
+
+{% if scan_url %}
+    <h2>Semgrep Scan Results for <a href="{{scan_url}}"> {{scan_title}} </a></h2>
+{% else %}
+    <h2>Semgrep Scan Results for {{scan_title}} </h2>
+{% endif %}
+{% for check_id, findings in findings_by_id.items() %}
+    <!-- ok: template-unquoted-attribute-var -->
+    <h3> rule: <a href="https://semgrep.dev/r?q={{check_id}}"> {{check_id}} </a> </h3>
+    <ul>
+        {% for finding in findings %}
+        <li>
+            {% if repo_url %}
+            <!-- ok: template-unquoted-attribute-var -->
+            <a href="{{repo_url}}/blob/{{commit}}/{{finding['path']}}#L{{finding['line']}}"> {{finding["path"]}}:{{finding["line"]}} </a>
+            {% else %}
+            {{finding["path"]}}:{{finding["line"]}}
+            {% endif %}
+            <p> Finding Message: {{finding["message"]}} </p>
+        </li>
+        {% endfor %}
+    </ul>
+    <hr/>
+{% endfor %}

--- a/python/flask/security/xss/audit/template-unquoted-attribute-var.html
+++ b/python/flask/security/xss/audit/template-unquoted-attribute-var.html
@@ -36,11 +36,26 @@
 <!-- ruleid: template-unquoted-attribute-var -->
 <script async type="text/javascript" src= {{ link }}
      id="_carbonads_js"></script>
+<script
+     async
+     type="text/javascript"
+     // ruleid: template-unquoted-attribute-var
+     src= {{ link }}
+     id="_carbonads_js">
+</script>
+
 
 <!-- ok: template-unquoted-attribute-var -->
 <script async type="text/javascript" src=" {{ link }}" id="_carbonads_js"></script>
+<!-- ok: template-unquoted-attribute-var -->
+<script async type="text/javascript" src=' {{ link }}' id="_carbonads_js"></script>
 <!-- ok: template-unquoted-attribute-var -->
 <script async type="text/javascript" src="{{ link }}" id="_carbonads_js"></script>
 <!-- ok: template-unquoted-attribute-var -->
 <script async type="text/javascript" src="{{ link }}"
      id="_carbonads_js"></script>
+
+<!-- ok: template-unquoted-attribute-var -->
+<div class="upper">
+     {{ paragraph_text }}
+</div>

--- a/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
+++ b/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: template-unquoted-attribute-var
-  message: |
+  message: >-
     Detected a unquoted template variable as an attribute. If unquoted, a
     malicious actor could inject custom JavaScript handlers. To fix this,
     add quotes around the template expression, like this: "{{ expr }}".
@@ -10,12 +10,17 @@ rules:
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
   languages:
-  - none
+  - generic
   paths:
     include:
     - '*.html'
   severity: WARNING
-  pattern-regex: <.*=.*{{.*?}}(\s+|>).*
+  patterns:
+  - pattern-inside: <$TAG ...>
+  - pattern-inside: = ...>
+  - pattern-not-inside: "'...'"
+  - pattern-not-inside: '"..."'
+  - pattern: '{{ ... }}'
   fix-regex:
     regex: '{{(.*?)}}'
     replacement: '"{{\1}}"'

--- a/ruby/rails/security/audit/xss/templates/var-in-script-tag.yaml
+++ b/ruby/rails/security/audit/xss/templates/var-in-script-tag.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: var-in-script-tag
-  message: |
+  message: >-
     Detected a template variable used in a script tag.
     Although template variables are HTML escaped, HTML
     escaping does not always prevent cross-site scripting (XSS)
@@ -14,9 +14,14 @@ rules:
     - https://www.netsparker.com/blog/web-security/preventing-xss-ruby-on-rails-web-applications/
     - https://www.youtube.com/watch?v=yYTkLUEdIyE
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
-  languages: [none]
+  languages:
+  - generic
   paths:
     include:
     - '*.erb'
   severity: WARNING
-  pattern-regex: <%(?!.*(j\b|escape_javascript\b)).*?%>([^\/]|\n)*?<\/script>
+  patterns:
+  - pattern-inside: <script ...> ... </script>
+  - pattern-not: <%= j ... >
+  - pattern-not: <%= escape_javascript ... >
+  - pattern: <%= ... >


### PR DESCRIPTION
Updates some XSS regex-only rules to use the 'generic' matcher instead. This expands some of these rules to account for whitespace/newlines and reduces FP rate.