### PR TITLE
Add nginx 7 security rules

### DIFF
--- a/generic/nginx/security/dynamic-proxy-host.conf
+++ b/generic/nginx/security/dynamic-proxy-host.conf
@@ -1,0 +1,41 @@
+server {
+  listen              443 ssl;
+  server_name         www.example.com;
+  keepalive_timeout   70;
+
+  ssl_certificate     www.example.com.crt;
+  ssl_certificate_key www.example.com.key;
+
+  location ~ /proxy2/(.*)/(.*)/(.*)$ {
+    # ruleid: dynamic-proxy-host
+    proxy_pass $1://$2/$3;
+  }
+
+  location ~* ^/internal-proxy/(?<proxy_proto>https?)/(?<proxy_host>.*?)/(?<proxy_path>.*)$ {
+    internal;
+
+    # ruleid: dynamic-proxy-host
+    proxy_pass $proxy_proto://$proxy_host/$proxy_path ;
+    proxy_set_header Host $proxy_host;
+}
+
+  location ~ /proxy3/(.*)/(.*)/(.*)$ {
+    # ruleid: dynamic-proxy-host
+    proxy_pass http://$2/$3/$1;
+  }
+
+  location ~ /proxy4/(.*)/(.*)/(.*)$ {
+    # ruleid: dynamic-proxy-host
+    proxy_pass https://$1/$2/$3;
+  }
+
+  location ~ /proxy5/(.*)/(.*)/(.*)$ {
+    # ok: dynamic-proxy-host
+    proxy_pass http://blah.com/$3/$1;
+  }
+
+  location ~ /proxy6/(.*)/(.*)/(.*)$ {
+    # ok: dynamic-proxy-host
+    proxy_pass https://blah.com/$2/$3;
+  }
+}

--- a/generic/nginx/security/dynamic-proxy-host.yaml
+++ b/generic/nginx/security/dynamic-proxy-host.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: dynamic-proxy-host
+  patterns:
+  - pattern-either:
+    - pattern: proxy_pass $SCHEME://$$HOST ...;
+    - pattern: proxy_pass $$SCHEME://$$HOST ...;
+  languages:
+  - generic
+  severity: WARNING
+  message: >-
+    The host for this proxy URL is dynamically determined. This can be dangerous if the host can be injected by an
+    attacker because it may forcibly alter destination of the proxy.
+    Consider hardcoding acceptable destinations and retrieving them with 'map' or something similar.
+  metadata:
+    references:
+    - https://github.com/yandex/gixy/blob/master/docs/en/plugins/ssrf.md
+    - https://nginx.org/en/docs/http/ngx_http_map_module.html

--- a/generic/nginx/security/dynamic-proxy-scheme.conf
+++ b/generic/nginx/security/dynamic-proxy-scheme.conf
@@ -1,0 +1,31 @@
+server {
+  listen              443 ssl;
+  server_name         www.example.com;
+  keepalive_timeout   70;
+
+  ssl_certificate     www.example.com.crt;
+  ssl_certificate_key www.example.com.key;
+
+  location ~ /proxy/(.*)/(.*)/(.*)$ {
+    # ruleid: dynamic-proxy-scheme
+    proxy_pass $1://$2/$3;
+  }
+
+  location ~* ^/internal-proxy/(?<proxy_proto>https?)/(?<proxy_host>.*?)/(?<proxy_path>.*)$ {
+    internal;
+
+    # ruleid: dynamic-proxy-scheme
+    proxy_pass $proxy_proto://$proxy_host/$proxy_path ;
+    proxy_set_header Host $proxy_host;
+}
+
+  location ~ /proxy/(.*)/(.*)/(.*)$ {
+    # ok: dynamic-proxy-scheme
+    proxy_pass http://$2/$3/$1;
+  }
+
+  location ~ /proxy/(.*)/(.*)/(.*)$ {
+    # ok: dynamic-proxy-scheme
+    proxy_pass https://$1/$2/$3;
+  }
+}

--- a/generic/nginx/security/dynamic-proxy-scheme.yaml
+++ b/generic/nginx/security/dynamic-proxy-scheme.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: dynamic-proxy-scheme
+  patterns:
+  - pattern: proxy_pass $$SCHEME:// ...;
+  languages:
+  - generic
+  severity: WARNING
+  message: >-
+    The protocol shceme for this proxy is dynamically determined. This can be dangerous if the scheme can be injected by an
+    attacker because it may forcibly alter the connection scheme.
+    Consider hardcoding a scheme for this proxy.
+  metadata:
+    references:
+    - https://github.com/yandex/gixy/blob/master/docs/en/plugins/ssrf.md

--- a/generic/nginx/security/header-injection.conf
+++ b/generic/nginx/security/header-injection.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80 default;
+
+
+    # ruleid: header-injection
+    location ~ /v1/((?<action>[^.]*)\.json)?$ {
+        add_header X-Action $action;
+        return 200 "OK";
+    }
+
+    # ok: header-injection
+    location ~ /v1/((?<action>[^.]*)\.json)?$ {
+        add_header X-Action $request_uri;
+        return 200 "OK";
+    }
+}

--- a/generic/nginx/security/header-injection.yaml
+++ b/generic/nginx/security/header-injection.yaml
@@ -1,0 +1,20 @@
+rules:
+- id: header-injection
+  pattern: |
+    location ... <$VARIABLE> ... {
+      ...
+      add_header ... $$VARIABLE
+      ...
+    }
+  languages:
+  - generic
+  severity: ERROR
+  message: >-
+    The $$VARIABLE path parameter is added as a header in the response.
+    This could allow an attacker to inject a newline and add a new header into the response.
+    This is called HTTP response splitting.
+    To fix, do not allow whitespace in the path parameter: '[^\s]+'.
+  metadata:
+    references:
+    - https://github.com/yandex/gixy/blob/master/docs/en/plugins/httpsplitting.md
+    - https://owasp.org/www-community/attacks/HTTP_Response_Splitting

--- a/generic/nginx/security/header-redefinition.conf
+++ b/generic/nginx/security/header-redefinition.conf
@@ -1,0 +1,18 @@
+server {
+  listen 80;
+  # ok: header-redefinition
+  add_header X-Frame-Options "DENY" always;
+  location / {
+      return 200 "index";
+  }
+
+  location /new-headers {
+    # Add special cache control
+    # ruleid: header-redefinition
+    add_header Cache-Control "no-cache, no-store, max-age=0, must-revalidate" always;
+    # ruleid: header-redefinition
+    add_header Pragma "no-cache" always;
+
+    return 200 "new-headers";
+  }
+}

--- a/generic/nginx/security/header-redefiniton.yaml
+++ b/generic/nginx/security/header-redefiniton.yaml
@@ -1,0 +1,27 @@
+rules:
+- id: header-redefinition
+  patterns:
+  - pattern-inside: |
+      server {
+        ...
+        add_header ...;
+        ...
+        ...
+      }
+  - pattern-inside: |
+      location ... {
+        ...
+        ...
+      }
+  - pattern: add_header ...;
+  languages:
+  - generic
+  severity: WARNING
+  message: >-
+    The 'add_header' directive is called in a 'location' block after headers have been set
+    at the server block. Calling 'add_header' in the location block will actually overwrite the headers
+    defined in the server block, no matter which headers are set.
+    To fix this, explicitly set all headers or set all headers in the server block.
+  metadata:
+    references:
+    - https://github.com/yandex/gixy/blob/master/docs/en/plugins/addheaderredefinition.md

--- a/generic/nginx/security/insecure-ssl-version.conf
+++ b/generic/nginx/security/insecure-ssl-version.conf
@@ -1,0 +1,31 @@
+server {
+  listen              443 ssl;
+  server_name         www.example.com;
+  keepalive_timeout   70;
+
+  ssl_certificate     www.example.com.crt;
+  ssl_certificate_key www.example.com.key;
+  # ruleid: insecure-ssl-version
+  ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers         HIGH:!aNULL:!MD5;
+
+  location /i/ {
+    alias /data/w3/images/;
+  }
+}
+
+server {
+  listen              443 ssl;
+  server_name         www.example.com;
+  keepalive_timeout   70;
+
+  ssl_certificate     www.example.com.crt;
+  ssl_certificate_key www.example.com.key;
+  # ok: insecure-ssl-version
+  ssl_protocols       TLSv1.2;
+  ssl_ciphers         HIGH:!aNULL:!MD5;
+
+  location /i/ {
+    alias /data/w3/images/;
+  }
+}

--- a/generic/nginx/security/insecure-ssl-version.yaml
+++ b/generic/nginx/security/insecure-ssl-version.yaml
@@ -1,0 +1,19 @@
+rules:
+- id: insecure-ssl-version
+  patterns:
+  - pattern-not: ssl_protocols TLSv1.2 TLSv1.3;
+  - pattern-not: ssl_protocols TLSv1.3 TLSv1.2;
+  - pattern-not: ssl_protocols TLSv1.2;
+  - pattern-not: ssl_protocols TLSv1.3;
+  - pattern: ssl_protocols ...;
+  languages:
+  - generic
+  severity: WARNING
+  message: >-
+    Detected use of an insecure SSL version. Secure SSL versions are
+    TLSv1.2 and TLS1.3; older versions are known to be broken and are
+    susceptible to attacks. Prefer use of TLSv1.2 or later.
+  metadata:
+    references:
+    - https://www.acunetix.com/blog/web-security-zone/hardening-nginx/
+    - https://www.acunetix.com/blog/articles/tls-ssl-cipher-hardening/

--- a/generic/nginx/security/missing-ssl-version.conf
+++ b/generic/nginx/security/missing-ssl-version.conf
@@ -1,0 +1,40 @@
+# ruleid: missing-ssl-version
+server {
+  listen              443 ssl;
+  server_name         www.example.com;
+  keepalive_timeout   70;
+
+  ssl_certificate     www.example.com.crt;
+  ssl_certificate_key www.example.com.key;
+
+  location /i/ {
+    alias /data/w3/images/;
+  }
+}
+
+# ok: missing-ssl-version
+server {
+  listen              80;
+  server_name         www.example.com;
+  keepalive_timeout   70;
+
+  location /i/ {
+    alias /data/w3/images/;
+  }
+}
+
+# ok: missing-ssl-version
+server {
+  listen              443 ssl;
+  server_name         www.example.com;
+  keepalive_timeout   70;
+
+  ssl_certificate     www.example.com.crt;
+  ssl_certificate_key www.example.com.key;
+  ssl_protocols       TLSv1.2;
+  ssl_ciphers         HIGH:!aNULL:!MD5;
+
+  location /i/ {
+    alias /data/w3/images/;
+  }
+}

--- a/generic/nginx/security/missing-ssl-version.yaml
+++ b/generic/nginx/security/missing-ssl-version.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: missing-ssl-version
+  patterns:
+  - pattern: server { ... listen $PORT ssl; ... }
+  - pattern-not-inside: server { ... ssl_protocols ... }
+  languages:
+  - generic
+  severity: WARNING
+  message: >-
+    This server configuration is missing the 'ssl_protocols' directive. By default,
+    this server will use 'ssl_protocols TLSv1 TLSv1.1 TLSv1.2', and versions older
+    than TLSv1.2 are known to be broken. Explicitly specify 'ssl_protocols TLSv1.2 TLSv1.3'
+    to use secure TLS versions.
+  metadata:
+    references:
+    - https://www.acunetix.com/blog/web-security-zone/hardening-nginx/
+    - https://nginx.org/en/docs/http/configuring_https_servers.html

--- a/generic/nginx/security/request-host-used.conf
+++ b/generic/nginx/security/request-host-used.conf
@@ -1,0 +1,9 @@
+server {
+  listen 80;
+
+  location @app {
+    # ruleid: request-host-used
+    proxy_set_header Host $http_host;
+    proxy_pass http://backend;
+  }
+}

--- a/generic/nginx/security/request-host-used.yaml
+++ b/generic/nginx/security/request-host-used.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: request-host-used
+  pattern: $http_host
+  languages:
+  - generic
+  severity: WARNING
+  message: >-
+    '$http_host' uses the 'Host' request header which could be controlled by an attacker. Use the '$host'
+    variable instead, which will use server names listed in the 'server_name' directive.
+  metadata:
+    references:
+    - https://github.com/yandex/gixy/blob/master/docs/en/plugins/hostspoofing.md


### PR DESCRIPTION
- SSRF via proxy_pass
- scheme injection
- insecure ssl version
- missing ssl version (which defaults to insecure versions)
- prefer $host to $request_host to guard against SSRF
- header redefinition
- header injection