### PR TITLE
Add back in paths key to template-unquoted-attribute-var

### DIFF
--- a/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
+++ b/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
@@ -11,6 +11,9 @@ rules:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
   languages:
   - generic
+  paths:
+    include:
+    - '*.html'
   severity: WARNING
   patterns:
   - pattern-inside: <$TAG ...>


### PR DESCRIPTION
Fixes slack notifications going haywire