### PR TITLE
* contrib/nodejsscan/xss_node.yaml: Fix use of metavar ellipsis

### DIFF
--- a/contrib/nodejsscan/xss_node.yaml
+++ b/contrib/nodejsscan/xss_node.yaml
@@ -79,25 +79,25 @@ rules:
     - pattern: |
         $LOCALVAR = <... $REQ.$QUERY ...>;
         ...
-        $ARR.push(<...$LOCALVAR...>);
+        $ARR.push(<... $LOCALVAR ...>);
         ...
         $RES.write(..., <... $ARR ...>, ...);
     - pattern: |
         $LOCALVAR = <... $REQ.$QUERY.$FOO ...>;
         ...
-        $ARR.push(<...$LOCALVAR...>);
+        $ARR.push(<... $LOCALVAR ...>);
         ...
         $RES.write(..., <... $ARR ...>, ...);
     - pattern: |
         $LOCALVAR = <... $REQ.$QUERY.$VAR ...>;
         ...
-        $ARR.push(<...$LOCALVAR...>);
+        $ARR.push(<... $LOCALVAR ...>);
         ...
         $RES.send(..., <... $ARR ...>, ...);
     - pattern: |
         $LOCALVAR = <... $REQ.$QUERY ...>;
         ...
-        $ARR.push(<...$LOCALVAR...>);
+        $ARR.push(<... $LOCALVAR ...>);
         ...
         $RES.send(..., <... $ARR ...>, ...);
     - pattern: |


### PR DESCRIPTION
With https://github.com/returntocorp/semgrep/pull/2151,
the use of <...$XXX...> will generate a parse error because
$X... is now parsed as a varargs metavariable (or metavariable ellipsis).

We need extra space between the metavar and the ... if we don't want
to use a metavar ellipsis

test plan:
CI