### PR TITLE
Add mb_ereg_replace PHP rule like preg_replace

### DIFF
--- a/php/lang/security/mb-ereg-replace-eval.php
+++ b/php/lang/security/mb-ereg-replace-eval.php
@@ -1,0 +1,10 @@
+<?php
+
+// ruleid: mb-ereg-replace-eval
+mb_ereg_replace($pattern, $replacement, $string, $user_input_options);
+
+// ok: mb-ereg-replace-eval
+mb_ereg_replace($pattern, $replacement, $string, "msr");
+
+// ok: mb-ereg-replace-eval
+mb_ereg_replace($pattern, $replacement, $string);

--- a/php/lang/security/mb-ereg-replace-eval.yaml
+++ b/php/lang/security/mb-ereg-replace-eval.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: mb-ereg-replace-eval
+  patterns:
+  - pattern: mb_ereg_replace($PATTERN, $REPL, $STR, $OPTIONS);
+  - pattern-not: mb_ereg_replace($PATTERN, $REPL, $STR, "...");
+  message: |
+    Calling mb_ereg_replace with user input in the options can lead to arbitrary
+    code execution. The eval modifier (`e`) evaluates the replacement argument
+    as code.
+  metadata:
+    references:
+    - https://www.php.net/manual/en/function.mb-ereg-replace.php
+    - https://www.php.net/manual/en/function.mb-regex-set-options.php
+  languages: [php]
+  severity: ERROR


### PR DESCRIPTION
Found looking at https://dustri.org/b/php8-from-a-security-point-of-view.html. This behavior has been removed in PHP 8, but remains in everything prior.