### PR TITLE
Include 'set' detection in implicit string concatenation rule

### DIFF
--- a/python/lang/correctness/common-mistakes/string-concat-in-list.py
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.py
@@ -28,6 +28,14 @@ bad = [
     "hijk"
 ]
 
+bad = {
+# ruleid:string-concat-in-list
+    "abc"
+    "cde"
+    "efg",
+    "hijk"
+}
+
 good = ["123"]
 good = [123, 456]
 good = ["123", "456"]

--- a/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
@@ -1,8 +1,11 @@
 rules:
 - id: string-concat-in-list
   patterns:
-  - pattern-inside: |
-      [...]
+  - pattern-either:
+    - pattern-inside: |
+        [...]
+    - pattern-inside: |
+        {...}
   - pattern: |
       "..." "..."
   - pattern-not-inside: |


### PR DESCRIPTION
Allows us to remove this manually specified rule: https://github.com/returntocorp/semgrep/blob/develop/semgrep.yml#L29