### PR TITLE
Improve regex in python system-wildcard-detected.yaml

### DIFF
--- a/python/lang/security/audit/system-wildcard-detected.yaml
+++ b/python/lang/security/audit/system-wildcard-detected.yaml
@@ -8,7 +8,7 @@ rules:
     - pattern-inside: os.popen3("...")
     - pattern-inside: os.popen4("...")
     - pattern-inside: subprocess.$W(..., shell=True, ...)
-  - pattern-regex: (.*?)[tar|chmod|chown|rsync](.*?)\*
+  - pattern-regex: (tar|chmod|chown|rsync)(.*?)\*
   message: |
     Detected use of the wildcard character in a system call that spawns a shell.
     This subjects the wildcard to normal shell expansion, which can have unintended consequences


### PR DESCRIPTION
The square brackets created a union not of the four commands, but of all the characters in them, making many more matches possible. The leading group was not needed.

Should fix #970. I tested it on DefectDojo and it completed quickly.