### PR TITLE
exit: Fix a false positive

### DIFF
--- a/python/lang/correctness/exit.py
+++ b/python/lang/correctness/exit.py
@@ -16,3 +16,9 @@ def check_db(user):
         print(user)
         # ok: use-sys-exit
         sys.exit(0)
+
+if False:
+    # ok: use-sys-exit
+    from sys import exit
+
+    exit(0)

--- a/python/lang/correctness/exit.yaml
+++ b/python/lang/correctness/exit.yaml
@@ -6,4 +6,5 @@ rules:
     be available on all Python implementations. https://stackoverflow.com/questions/6501121/difference-between-exit-and-sys-exit-in-python
   patterns:
   - pattern: exit(...)
+  - pattern-not: sys.exit(...)
   severity: WARNING


### PR DESCRIPTION
`exit()` can be used as-is when imported via `from sys import exit`.