### PR TITLE
Fix FP for ruby on rails var-in-href rule. 

### DIFF
--- a/ruby/rails/security/audit/xss/templates/var-in-href.erb
+++ b/ruby/rails/security/audit/xss/templates/var-in-href.erb
@@ -16,6 +16,9 @@
 
     <!-- ok: var-in-href -->
     <div class="alert lead alert-<%= key %>"><%= value %> </div>
+
+    <!-- ok: var-in-href -->
+    <a class="restore" href="#" style="display: none;"><%= I18n.t("gws/reminder.links.restore_reminder") %></a>
 </div>
 
 </html>

--- a/ruby/rails/security/audit/xss/templates/var-in-href.yaml
+++ b/ruby/rails/security/audit/xss/templates/var-in-href.yaml
@@ -15,9 +15,11 @@ rules:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
     - https://github.com/pugjs/pug/issues/2952
   languages:
-  - none
+  - generic
   paths:
     include:
     - '*.erb'
   severity: WARNING
-  pattern-regex: <a.*href\s*=[^>]*?[^\/&=]<%.*?%>.*?>
+  pattern-either:
+  - pattern: <a ... href = "<%= ... %>" ... >
+  - pattern: <a ... href = '<%= ... %>' ... >


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep-rules/issues/1060.

Switched to use generic instead of regex.