### PR TITLE
Patch eqeq check for Go

### DIFF
--- a/go/lang/correctness/useless-eqeq.go
+++ b/go/lang/correctness/useless-eqeq.go
@@ -3,7 +3,7 @@ import "fmt"
 
 func main() {
     fmt.Println("hello world")
-    var y = 1;
+    var y = "hello";
     // ruleid:eqeq-is-bad
     fmt.Println(y == y)
     // ok:eqeq-is-bad


### PR DESCRIPTION
Patch eqeq check for Go which was failing on tests now with the new contsant propagation. This should maintain the rule but allow tests to pass.