### PR TITLE
Adapt test files for the new constant propagation

### DIFF
--- a/contrib/nodejsscan/header_cors_star.js
+++ b/contrib/nodejsscan/header_cors_star.js
@@ -31,6 +31,7 @@ app.get('/', function (req, res) {
     // ruleid:express_cors
     res.writeHead(200, { 'Access-Control-Allow-Origin': '*' })
 
+    // ruleid:express_cors
     res.set('access-control-allow-origin', x);
 
     // do not detect - sgrep bug

--- a/contrib/nodejsscan/header_xss_protection.js
+++ b/contrib/nodejsscan/header_xss_protection.js
@@ -47,6 +47,7 @@ app.get('/', function (req, res) {
     //sgrep bug - https://github.com/returntocorp/sgrep/issues/512
     // ruleid:header_xss_generic
     res.writeHead(200, { 'x-xss-protection': 0 })
+    // ruleid:header_xss_generic
     res.set('X-XSS-Protection', x);
 
     // do not detect

--- a/java/lang/correctness/hardcoded-conditional.java
+++ b/java/lang/correctness/hardcoded-conditional.java
@@ -1,11 +1,13 @@
 class Bar {
-    void main() {
+    void main(boolean arg) {
         boolean myBoolean;
 
         // ruleid:hardcoded-conditional
         if (myBoolean = true) {
             continue;
         }
+        // note that with new constant propagation, myBoolean is assumed
+        // to true below
 
         // ruleid:hardcoded-conditional
         if (true) {
@@ -17,10 +19,14 @@ class Bar {
             continue;
         }
 
-        // ok:hardcoded-conditional
+        // the dataflow constant-propagation now kicks in! this is true!
+        // ruleid:hardcoded-conditional
         if (myBoolean) {
 
         }
+        // to prevent constant propagation to assumes
+        // myBoolean is true below
+        myBoolean = arg;
 
         // ok:hardcoded-conditional
         if (myBoolean == myBoolean) {

--- a/problem-based-packs/insecure-transport/go-stdlib/ftp-request.go
+++ b/problem-based-packs/insecure-transport/go-stdlib/ftp-request.go
@@ -16,18 +16,21 @@ func bad3() {
 func bad4() {
     // ruleid: ftp-request
     url = "ftp://example.com"
+    // ruleid: ftp-request
     ftp.Dial(url, ftp.DialWithTimeout(5*time.Second))
 }
 
 func bad5() {
     // ruleid: ftp-request
     url = "ftp://example.com"
+    // ruleid: ftp-request
     ftp.DialTimeout(url, 5*time.Second)
 }
 
 func bad6() {
     // ruleid: ftp-request
     url = "ftp://example.com"
+    // ruleid: ftp-request
     ftp.Connect(url)
 }
 

--- a/problem-based-packs/insecure-transport/ruby-stdlib/http-client-requests.rb
+++ b/problem-based-packs/insecure-transport/ruby-stdlib/http-client-requests.rb
@@ -9,6 +9,7 @@ end
 def bad2
   # ruleid: http-client-requests
   str = 'http://example.com'
+  # ruleid: http-client-requests
   response = HTTParty.get(str, format: :plain)
   JSON.parse response, symbolize_names: true
 end

--- a/python/flask/security/audit/directly-returned-format-string.py
+++ b/python/flask/security/audit/directly-returned-format-string.py
@@ -11,8 +11,7 @@ from jinja2 import Template
 app = Flask(__name__)
 
 @app.route("/loginpage")
-def render_login_page():
-    thing = "blah"
+def render_login_page(thing):
     # ruleid:directly-returned-format-string
     return '''
 <p>{}</p>
@@ -24,8 +23,7 @@ def render_login_page():
     '''.format(thing)
 
 @app.route("/loginpage2")
-def render_login_page2():
-    thing = "blah"
+def render_login_page2(thing):
     # ruleid:directly-returned-format-string
     return '''
 <p>%s</p>
@@ -37,8 +35,7 @@ def render_login_page2():
     ''' % thing
 
 @app.route("/loginpage3")
-def render_login_page3():
-    thing = "blah"
+def render_login_page3(thing):
     # ruleid:directly-returned-format-string
     return '''
 <p>%s</p>
@@ -52,7 +49,9 @@ def render_login_page3():
 @app.route("/loginpage4")
 def render_login_page4():
     thing = "blah"
-    # ruleid:directly-returned-format-string
+    # the string below is now detected as a literal string after constant
+    # propagation
+    # ok:directly-returned-format-string
     return thing + '''
 <form method="POST" style="margin: 60px auto; width: 140px;">
     <p><input name="username" type="text" /></p>
@@ -64,6 +63,19 @@ def render_login_page4():
 @app.route("/loginpage5")
 def render_login_page5():
     thing = "blah"
+    # same, now ok thx to the constant propagation
+    # ok:directly-returned-format-string
+    return f'''
+{thing}
+<form method="POST" style="margin: 60px auto; width: 140px;">
+    <p><input name="username" type="text" /></p>
+    <p><input name="password" type="password" /></p>
+    <p><input value="Login" type="submit" /></p>
+</form>
+    '''
+
+@app.route("/loginpage5")
+def render_login_page5(thing):
     # ruleid:directly-returned-format-string
     return f'''
 {thing}

--- a/python/jwt/security/jwt-hardcode.py
+++ b/python/jwt/security/jwt-hardcode.py
@@ -16,6 +16,7 @@ def bad2():
 def bad3():
     # ruleid: jwt-python-hardcoded-secret
     secret = 'secret'
+    # ruleid: jwt-python-hardcoded-secret
     encoded = jwt.encode({'some': 'payload'}, secret, algorithm='HS256')
     return encoded
 

--- a/python/lang/security/audit/insecure-transport/requests/request-session-with-http.py
+++ b/python/lang/security/audit/insecure-transport/requests/request-session-with-http.py
@@ -14,6 +14,7 @@ def test2():
     session = requests.Session()
     # ruleid: request-session-with-http
     url = "http://example.com"
+    # ruleid: request-session-with-http
     session.post(url)
 
 def test2_ok():

--- a/python/lang/security/audit/insecure-transport/requests/request-with-http.py
+++ b/python/lang/security/audit/insecure-transport/requests/request-with-http.py
@@ -11,6 +11,7 @@ def test1_ok():
 def test2():
     # ruleid: request-with-http
     url = "http://example.com"
+    # ruleid: request-with-http
     requests.post(url)
 
 def test2_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open-ftp.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open-ftp.py
@@ -14,6 +14,7 @@ def test2():
     od = OpenerDirector()
     # ruleid: insecure-openerdirector-open-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-openerdirector-open-ftp
     od.open(url)
 
 def test2_ok():
@@ -33,6 +34,7 @@ def test3_ok():
 def test4():
     # ruleid: insecure-openerdirector-open-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-openerdirector-open-ftp
     OpenerDirector().open(url)
 
 def test4_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open.py
@@ -14,6 +14,7 @@ def test2():
     od = OpenerDirector()
     # ruleid: insecure-openerdirector-open
     url = "http://example.com"
+    # ruleid: insecure-openerdirector-open
     od.open(url)
 
 def test2_ok():
@@ -33,6 +34,7 @@ def test3_ok():
 def test4():
     # ruleid: insecure-openerdirector-open
     url = "http://example.com"
+    # ruleid: insecure-openerdirector-open
     OpenerDirector().open(url)
 
 def test4_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-request-object-ftp.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-request-object-ftp.py
@@ -11,6 +11,7 @@ def test1_ok():
 def test2():
     # ruleid: insecure-request-object-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-request-object-ftp
     Request(url)
 
 def test2_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-request-object.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-request-object.py
@@ -11,6 +11,7 @@ def test1_ok():
 def test2():
     # ruleid: insecure-request-object
     url = "http://example.com"
+    # ruleid: insecure-request-object
     Request(url)
 
 def test2_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen-ftp.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen-ftp.py
@@ -11,6 +11,7 @@ def test1_ok():
 def test2():
     # ruleid: insecure-urlopen-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-urlopen-ftp
     urlopen(url)
 
 def test2_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen.py
@@ -11,6 +11,7 @@ def test1_ok():
 def test2():
     # ruleid: insecure-urlopen
     url = "http://example.com"
+    # ruleid: insecure-urlopen
     urlopen(url)
 
 def test2_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open-ftp.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open-ftp.py
@@ -14,6 +14,7 @@ def test2():
     od = URLopener()
     # ruleid: insecure-urlopener-open-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-urlopener-open-ftp
     od.open(url)
 
 def test2_ok():
@@ -33,6 +34,7 @@ def test3_ok():
 def test4():
     # ruleid: insecure-urlopener-open-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-urlopener-open-ftp
     URLopener().open(url)
 
 def test4_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open.py
@@ -14,6 +14,7 @@ def test2():
     od = URLopener()
     # ruleid: insecure-urlopener-open
     url = "http://example.com"
+    # ruleid: insecure-urlopener-open
     od.open(url)
 
 def test2_ok():
@@ -33,6 +34,7 @@ def test3_ok():
 def test4():
     # ruleid: insecure-urlopener-open
     url = "http://example.com"
+    # ruleid: insecure-urlopener-open
     URLopener().open(url)
 
 def test4_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve-ftp.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve-ftp.py
@@ -14,6 +14,7 @@ def test2():
     od = URLopener()
     # ruleid: insecure-urlopener-retrieve-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-urlopener-retrieve-ftp
     od.retrieve(url)
 
 def test2_ok():
@@ -33,6 +34,7 @@ def test3_ok():
 def test4():
     # ruleid: insecure-urlopener-retrieve-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-urlopener-retrieve-ftp
     URLopener().retrieve(url)
 
 def test4_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve.py
@@ -14,6 +14,7 @@ def test2():
     od = URLopener()
     # ruleid: insecure-urlopener-retrieve
     url = "http://example.com"
+    # ruleid: insecure-urlopener-retrieve
     od.retrieve(url)
 
 def test2_ok():
@@ -33,6 +34,7 @@ def test3_ok():
 def test4():
     # ruleid: insecure-urlopener-retrieve
     url = "http://example.com"
+    # ruleid: insecure-urlopener-retrieve
     URLopener().retrieve(url)
 
 def test4_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve-ftp.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve-ftp.py
@@ -11,6 +11,7 @@ def test1_ok():
 def test2():
     # ruleid: insecure-urlretrieve-ftp
     url = "ftp://example.com"
+    # ruleid: insecure-urlretrieve-ftp
     urlretrieve(url)
 
 def test2_ok():

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve.py
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve.py
@@ -11,6 +11,7 @@ def test1_ok():
 def test2():
     # ruleid: insecure-urlretrieve
     url = "http://example.com"
+    # ruleid: insecure-urlretrieve
     urlretrieve(url)
 
 def test2_ok():

--- a/python/requests/security/no-auth-over-http.py
+++ b/python/requests/security/no-auth-over-http.py
@@ -17,6 +17,7 @@ def test1():
     # ruleid:no-auth-over-http
     bad_url = "http://www.github.com"
     print("something")
+    # ruleid:no-auth-over-http
     r = requests.get(bad_url, auth=('user', 'pass'))
 
 def test2():
@@ -42,4 +43,5 @@ def from_import_test1(url):
     from requests import get, post
     # ruleid:no-auth-over-http
     bad_url = "http://www.github.com"
+    # ruleid:no-auth-over-http
     r = get(bad_url, timeout=3, auth=('user', 'pass'))

--- a/ruby/jwt/security/jwt-hardcode.rb
+++ b/ruby/jwt/security/jwt-hardcode.rb
@@ -6,6 +6,7 @@ secret_const = 'secret-yo'
 def bad1
     # ruleid: ruby-jwt-hardcoded-secret
     hmac_secret = 'my$ecretK3y'
+    # ruleid: ruby-jwt-hardcoded-secret
     token = JWT.encode payload, hmac_secret, 'HS256'
     puts token
 end

--- a/ruby/lang/security/divide-by-zero.rb
+++ b/ruby/lang/security/divide-by-zero.rb
@@ -8,5 +8,6 @@
     oops = variable / 0
     # ruleid: divide-by-zero
     zero = 0
+    # ruleid: divide-by-zero
     bad = variable/zero
  end


### PR DESCRIPTION
With https://github.com/returntocorp/semgrep/pull/2386, we now better
propagate constant using a dataflow-based analysis.

Before, one had to manually encode some constant propagation via extra
patterns, for instance:
 - patterns:
   - pattern-either: foo("constant")
   - pattern-either:
     $X = "constant"
     ...
     foo($X)

and the test file usually contained test code like:
  def test1():
   #ruleid: blah
   x = "constant"
   foo(x)

but now we actually propagate the constant x, so the first
pattern also match the code so I've updated the test file to:
  def test1():
   #ruleid: blah
   x = "constant"
   #ruleid: blah
   foo(x)

Note that the right fix is actually to simplfy the yaml file and removing
those manually-encoded-constant-propagation patterns that are now automatically
handled by the engine.

test plan:
compile semgrep-core with latest develop, make install
make test in semgrep-rules