### PR TITLE
grpc-server-insecure-connection: Remove OWASP classification

### DIFF
--- a/go/grpc/security/grpc-client-insecure-connection.yaml
+++ b/go/grpc/security/grpc-client-insecure-connection.yaml
@@ -1,7 +1,6 @@
 rules:
 - id: grpc-client-insecure-connection
   metadata:
-    owasp: 'A8: Insecure Deserialization'
     cwe: 'CWE-300: Channel Accessible by Non-Endpoint'
     references:
     - https://blog.gopheracademy.com/advent-2019/go-grps-and-tls/#connection-without-encryption

--- a/go/grpc/security/grpc-server-insecure-connection.yaml
+++ b/go/grpc/security/grpc-server-insecure-connection.yaml
@@ -1,7 +1,6 @@
 rules:
 - id: grpc-server-insecure-connection
   metadata:
-    owasp: 'A8: Insecure Deserialization'
     cwe: 'CWE-300: Channel Accessible by Non-Endpoint'
     references:
     - https://blog.gopheracademy.com/advent-2019/go-grps-and-tls/#connection-without-encryption


### PR DESCRIPTION
The OWASP tag was added cause 'CWE-502: Deserialization of Untrusted Data',
but as we later found out that CWE just sounded similar to this issue,
and was not the correct one.
We updated to 'CWE-300: Channel Accessible by Non-Endpoint'
which has no OWASP top 10 classification, so this commit removes the old one.