### PR TITLE
Consolidate template rules

### DIFF
--- a/generic/html-templates/security/unquoted-attribute-var.html
+++ b/generic/html-templates/security/unquoted-attribute-var.html
@@ -1,0 +1,85 @@
+{% extends "container.html" %}
+
+{% block opengraph %}
+
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="semgrep" />
+<meta property="og:description" content="content" />
+<!-- ruleid: unquoted-attribute-var -->
+<meta property="og:image" content={{ url_for('static', filename='picture.jpg', _external=True) }} />
+<meta property="og:image:type" content="image/jpeg" />
+<meta property="og:image:width" content="600" />
+<meta property="og:image:height" content="600" />
+<!-- ok -->
+<meta property="not-real-only-for-testing" content="{{ safe }}" />
+
+<!-- Google OAuth sign-in -->
+<meta name="google-signin-scope" content="profile email openid">
+<!-- ruleid: unquoted-attribute-var -->
+<meta name="google-signin-client_id" content={{ client_id  }}>
+<!-- ok: unquoted-attribute-var -->
+<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve={{ carbonad_serve }}&placement={{ carbonad_placement }}" id="_carbonads_js"></script>
+
+{% endblock %}
+
+
+<!-- extra tests -->
+
+<!-- ok: unquoted-attribute-var -->
+<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve={{carbonad_serve}}&placement={{carbonad_placement}}" id="_carbonads_js"></script>
+
+<!-- ruleid: unquoted-attribute-var -->
+<script async type="text/javascript" src= {{ link }} id="_carbonads_js"></script>
+<!-- ruleid: unquoted-attribute-var -->
+<script async type="text/javascript" src={{ link }} id="_carbonads_js"></script>
+<!-- ruleid: unquoted-attribute-var -->
+<script async type="text/javascript" src= {{ link }}
+     id="_carbonads_js"></script>
+<script
+     async
+     type="text/javascript"
+     // ruleid: unquoted-attribute-var
+     src= {{ link }}
+     id="_carbonads_js">
+</script>
+
+
+<!-- ok: unquoted-attribute-var -->
+<script async type="text/javascript" src=" {{ link }}" id="_carbonads_js"></script>
+<!-- ok: unquoted-attribute-var -->
+<script async type="text/javascript" src=' {{ link }}' id="_carbonads_js"></script>
+<!-- ok: unquoted-attribute-var -->
+<script async type="text/javascript" src="{{ link }}" id="_carbonads_js"></script>
+<!-- ok: unquoted-attribute-var -->
+<script async type="text/javascript" src="{{ link }}"
+     id="_carbonads_js"></script>
+
+<!-- ok: unquoted-attribute-var -->
+<div class="upper">
+     {{ paragraph_text }}
+</div>
+
+{% if scan_url %}
+    <h2>Semgrep Scan Results for <a href="{{scan_url}}"> {{scan_title}} </a></h2>
+{% else %}
+    <h2>Semgrep Scan Results for {{scan_title}} </h2>
+{% endif %}
+{% for check_id, findings in findings_by_id.items() %}
+    <!-- ok: unquoted-attribute-var -->
+    <h3> rule: <a href="https://semgrep.dev/r?q={{check_id}}"> {{check_id}} </a> </h3>
+    <ul>
+        {% for finding in findings %}
+        <li>
+            {% if repo_url %}
+            <!-- ok: unquoted-attribute-var -->
+            <a href="{{repo_url}}/blob/{{commit}}/{{finding['path']}}#L{{finding['line']}}"> {{finding["path"]}}:{{finding["line"]}} </a>
+            {% else %}
+            {{finding["path"]}}:{{finding["line"]}}
+            {% endif %}
+            <p> Finding Message: {{finding["message"]}} </p>
+        </li>
+        {% endfor %}
+    </ul>
+    <hr/>
+{% endfor %}

--- a/generic/html-templates/security/unquoted-attribute-var.yaml
+++ b/generic/html-templates/security/unquoted-attribute-var.yaml
@@ -1,0 +1,27 @@
+rules:
+- id: unquoted-attribute-var
+  message: >-
+    Detected a unquoted template variable as an attribute. If unquoted, a
+    malicious actor could inject custom JavaScript handlers. To fix this,
+    add quotes around the template expression, like this: "{{ expr }}".
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
+  languages:
+  - generic
+  paths:
+    include:
+    - '*.html'
+    - '*.mustache'
+    - '*.hbs'
+  severity: WARNING
+  patterns:
+  - pattern-inside: <$TAG ...>
+  - pattern-not-inside: ="..."
+  - pattern-not-inside: ='...'
+  - pattern: '{{ ... }}'
+  fix-regex:
+    regex: '{{(.*?)}}'
+    replacement: '"{{\1}}"'

--- a/generic/html-templates/security/var-in-href.html
+++ b/generic/html-templates/security/var-in-href.html
@@ -1,0 +1,59 @@
+<!-- FLASK TESTS -->
+
+<h4>From: {{ from_email }}</h4>
+<h4>To:
+    {% for recipient in recipients %}
+    {{ recipient }}&nbsp;
+    {% endfor %}
+</h4>
+<h4>Subject: {{subject}}</h4>
+<div class="email" style="display: block;">
+    {{ message }}
+</div>
+<div class="email-text" style="display: none;">
+    <pre>{{ body }}</pre>
+    <!-- ruleid: var-in-href -->
+    <a href='{{ link }}'>{{ link_text }}</a>
+    <!-- ruleid: var-in-href -->
+    <a href = '{{ link }}' >{{ link_text }}</a>
+    <!-- ruleid: var-in-href -->
+    <a href = "{{ link }}" >{{ link_text }}</a>
+    <a
+        // ruleid: var-in-href
+        href = "{{ link }}"
+    >
+        {{ link_text }}
+    </a>
+    <!-- ok: var-in-href -->
+    <a href="{{ url_for('index') }}">{{ link_text }}</a>
+    <!-- ok: var-in-href -->
+    <a href="https://example.com/">{{ link_text }}</a>
+    <!-- ok: var-in-href -->
+    <a href="https://example.com/{{ link_path }}">{{ link_text }}</a>
+</div>
+<hr>
+
+<!-- DJANGO TESTS -->
+
+<h4>From: {{ from_email }}</h4>
+<h4>To:
+    {% for recipient in recipients %}
+    {{ recipient }}&nbsp;
+    {% endfor %}
+</h4>
+<h4>Subject: {{subject}}</h4>
+<div class="email" style="display: block;">
+    {{ message }}
+</div>
+<div class="email-text" style="display: none;">
+    <pre>{{ body }}</pre>
+    <!-- ruleid: var-in-href -->
+    <a href='{{ link }}'>{{ link_text }}</a>
+    <!-- ruleid: var-in-href -->
+    <a href = '{{ link }}' >{{ link_text }}</a>
+    <!-- ok: var-in-href -->
+    <a href="{% url 'login' %}">{{ link_text }}</a>
+    <!-- ok: var-in-href -->
+    <a href="https://example.com/">{{ link_text }}</a>
+</div>
+<hr>

--- a/generic/html-templates/security/var-in-href.mustache
+++ b/generic/html-templates/security/var-in-href.mustache
@@ -1,0 +1,62 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<body onload="carregarDemo();">
+    <div class="content">
+        <div id="mustache-header"></div>
+        <div id="mustache-cards"></div>
+    </div>
+
+    <!-- ok: var-in-href -->
+    <p class="navbar-text navbar-right">Singed in as: <a href=/profile>{{ val }}</a></p>
+</body>
+
+<script id="template-header" type="x-tmpl-mustache">
+    <div class="jumbotron text-center">
+        <h1 class="display-4">Oi, meu nome é {{autor.nome}} {{autor.sobrenome}}!</h1>
+        <p class="lead">Isso é apenas uma demonstração de como utilizar o Mustache.JS</p>
+        <!-- ruleid: var-in-href -->
+        <a href="{{ link }}" class="text-center">Click me</a>
+        <!-- ok: var-in-href -->
+        <a href="/{{ link }}" class="text-center">Click me</a>
+    </div>
+</script>
+
+<script id="template-cards" type="x-tmpl-mustache">
+    <div class="text-center">
+        <h2>Apresentando o time da <b>{{time.nome}}</b></h2>
+        <h6>Predio {{time.predio}}</h6>
+    </div>
+    {{#time}}
+    <div class="container" style="margin-top: 30px;">
+        <div class="row">
+            {{#squads}}
+            <div class="col-sm-6">
+                <div class="card">
+                    <div class="card-header text-center">
+                        <b>{{nome}}</b>
+                    </div>
+                    <div class="card-body">
+                        {{! Partial de tabela de membros do Squad }}
+                        {{> template-table}}
+                    </div>
+                </div>
+            </div>
+            {{/squads}}
+        </div>
+    </div>
+    {{/time}}
+</script>
+
+</html>

--- a/generic/html-templates/security/var-in-href.yaml
+++ b/generic/html-templates/security/var-in-href.yaml
@@ -1,0 +1,41 @@
+rules:
+- id: var-in-href
+  message: >-
+    Detected a template variable used in an anchor tag with
+    the 'href' attribute. This allows a malicious actor to
+    input the 'javascript:' URI and is subject to cross-
+    site scripting (XSS) attacks. 
+    If using Flask, use 'url_for()' to safely generate a URL.
+    If using Django, use the 'url' filter to safely generate a URL.
+    If using Mustache, use a URL encoding library, or prepend a slash '/' to the
+    variable for relative links (`href="/{{link}}"`).
+    You may also consider setting the Content Security Policy (CSP) header.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
+    - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#url
+    - https://github.com/pugjs/pug/issues/2952
+    - https://content-security-policy.com/
+  languages:
+  - generic
+  paths:
+    include:
+    - '*.html'
+    - '*.mustache'
+    - '*.hbs'
+  severity: WARNING
+  patterns:
+  - pattern-inside: <a ...>
+  - pattern-either:
+    - pattern: href = {{ ... }}
+    - pattern: href = "{{ ... }}"
+    - pattern: href = '{{ ... }}'
+  # OK for Flask
+  - pattern-not-inside: href = {{ url_for(...) ... }}
+  - pattern-not-inside: href = "{{ url_for(...) ... }}"
+  - pattern-not-inside: href = '{{ url_for(...) ... }}'
+  # OK for all templates
+  - pattern-not-inside: href = "/{{ ... }}"
+  - pattern-not-inside: href = '/{{ ... }}' 

--- a/generic/html-templates/security/var-in-href.yaml
+++ b/generic/html-templates/security/var-in-href.yaml
@@ -4,7 +4,7 @@ rules:
     Detected a template variable used in an anchor tag with
     the 'href' attribute. This allows a malicious actor to
     input the 'javascript:' URI and is subject to cross-
-    site scripting (XSS) attacks. 
+    site scripting (XSS) attacks.
     If using Flask, use 'url_for()' to safely generate a URL.
     If using Django, use the 'url' filter to safely generate a URL.
     If using Mustache, use a URL encoding library, or prepend a slash '/' to the
@@ -38,4 +38,4 @@ rules:
   - pattern-not-inside: href = '{{ url_for(...) ... }}'
   # OK for all templates
   - pattern-not-inside: href = "/{{ ... }}"
-  - pattern-not-inside: href = '/{{ ... }}' 
+  - pattern-not-inside: href = '/{{ ... }}'

--- a/generic/html-templates/security/var-in-script-tag.html
+++ b/generic/html-templates/security/var-in-script-tag.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+        <script>
+            // ruleid: var-in-script-tag
+            const mydata = {{ mydata_json|safe }};
+            // ruleid: var-in-script-tag
+            const moredata = {{ mydata_json }};
+        </script>
+        <div>
+            <!-- ok: var-in-script-tag -->
+            <p>{{ this_is_fine }}</p>
+        </div>
+    </body>
+</html>

--- a/generic/html-templates/security/var-in-script-tag.mustache
+++ b/generic/html-templates/security/var-in-script-tag.mustache
@@ -1,0 +1,67 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<body onload="carregarDemo();">
+    <div class="content">
+        <div id="mustache-header"></div>
+        <div id="mustache-cards"></div>
+    </div>
+</body>
+
+<script type="text/javascript">
+    <!-- ruleid: var-in-script-tag -->
+    var message = {{ message }};
+</script>
+
+<script type="text/javascript">
+    <!-- ruleid: var-in-script-tag -->
+    var message = {{ message }};
+    console.log(message);
+    console.log("more statements here");
+    <!-- ruleid: var-in-script-tag -->
+    var message2 = {{ message2 }};
+    var flash = document.getElementById("flash");
+    flash.text = message;
+</script>
+
+<script type="text/javascript" src="mustache.js"></script>
+<!-- ok: var-in-script-tag -->
+{{ message }}
+<script type="text/javascript" src="demo.js"></script>
+
+<div class="text-center">
+    <h2>Apresentando o time da <b>{{time.nome}}</b></h2>
+    <h6>Predio {{time.predio}}</h6>
+</div>
+{{#time}}
+<div class="container" style="margin-top: 30px;">
+    <div class="row">
+        {{#squads}}
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="card-header text-center">
+                    <b>{{nome}}</b>
+                </div>
+                <div class="card-body">
+                    {{! Partial de tabela de membros do Squad }}
+                    {{> template-table}}
+                </div>
+            </div>
+        </div>
+        {{/squads}}
+    </div>
+</div>
+{{/time}}
+
+</html>

--- a/generic/html-templates/security/var-in-script-tag.yaml
+++ b/generic/html-templates/security/var-in-script-tag.yaml
@@ -1,0 +1,31 @@
+rules:
+- id: var-in-script-tag
+  message: >-
+    Detected a template variable used in a script tag.
+    Although template variables are HTML escaped, HTML
+    escaping does not always prevent cross-site scripting (XSS)
+    attacks when used directly in JavaScript.
+    If you need this data on the rendered page, consider placing it in the HTML
+    portion (outside of a script tag).
+    Alternatively, use a JavaScript-specific encoder, such as the one available
+    in OWASP ESAPI.
+    For Django, you may also consider using the 'json_script' template tag and
+    retrieving the data in your script by using the element ID (e.g., `document.getElementById`).
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://adamj.eu/tech/2020/02/18/safely-including-data-for-javascript-in-a-django-template/?utm_campaign=Django%2BNewsletter&utm_medium=rss&utm_source=Django_Newsletter_12A
+    - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
+    - https://github.com/ESAPI/owasp-esapi-js
+  languages:
+  - generic
+  paths:
+    include:
+    - '*.mustache'
+    - '*.hbs'
+    - '*.html'
+  severity: WARNING
+  patterns:
+  - pattern-inside: <script ...> ... </script>
+  - pattern: '{{ ... }}'


### PR DESCRIPTION
This PR combines several HTML template rules for different engines (Flask/Jinja2, Django, and Mustache) that follow the same syntax.

These will be the official rules used in `p/xss`, to replace many variants that resulted in duplicate findings. See https://github.com/returntocorp/semgrep-rule-packs/issues/67 for more information.

Closes https://github.com/returntocorp/semgrep-rule-packs/issues/67 and https://github.com/returntocorp/enterprise/issues/548.