### PR TITLE
Update rule - python.django.correctness.nontext-field-must-set-null-true

### DIFF
--- a/python/django/correctness/nontext-field-must-set-null-true.py
+++ b/python/django/correctness/nontext-field-must-set-null-true.py
@@ -13,6 +13,10 @@ class FakeModel(models.Model):
     # ok: nontext-field-must-set-null-true
     fieldEmail = models.EmailField(blank=True)
     # ok: nontext-field-must-set-null-true
+    fieldFile = models.FileField(blank=True)
+    # ok: nontext-field-must-set-null-true
+    fieldImage = models.ImageField(blank=True)
+    # ok: nontext-field-must-set-null-true
     fieldURL = models.URLField(blank=True)
     # ok: nontext-field-must-set-null-true
     fieldUUID = models.UUIDField(blank=True)

--- a/python/django/correctness/nontext-field-must-set-null-true.yaml
+++ b/python/django/correctness/nontext-field-must-set-null-true.yaml
@@ -8,6 +8,8 @@ rules:
   - pattern-not: $F = django.db.models.TextField(...)
   - pattern-not: $F = django.db.models.SlugField(...)
   - pattern-not: $F = django.db.models.EmailField(...)
+  - pattern-not: $F = django.db.models.FileField(...)
+  - pattern-not: $F = django.db.models.ImageField(...)
   - pattern-not: $F = django.db.models.URLField(...)
   - pattern-not: $F = django.db.models.UUIDField(...)
   - pattern-not: $F = django.db.models.ManyToManyField(...)


### PR DESCRIPTION
Adds [`FileField`](https://docs.djangoproject.com/en/3.1/ref/models/fields/#django.db.models.FileField) and [`ImageField`](https://docs.djangoproject.com/en/3.1/ref/models/fields/#django.db.models.ImageField) to the list of text fields.