### PR TITLE
Fix flask injection rules

### DIFF
--- a/python/flask/security/injection/os-system-injection.py
+++ b/python/flask/security/injection/os-system-injection.py
@@ -1,4 +1,6 @@
+import os
 import flask
+import hashlib
 
 app = flask.Flask(__name__)
 
@@ -8,14 +10,66 @@ def route_param(route_param):
     # ruleid: os-system-injection
     return os.system(route_param)
 
+@app.route("/route_param_concat/<route_param>")
+def route_param_concat(route_param):
+    print("blah")
+    # ruleid: os-system-injection
+    return os.system("echo " + route_param)
+
+@app.route("/route_param_format/<route_param>")
+def route_param_format(route_param):
+    print("blah")
+    # ruleid: os-system-injection
+    return os.system("echo {}".format(route_param))
+
+@app.route("/route_param_percent_format/<route_param>")
+def route_param_percent_format(route_param):
+    print("blah")
+    # ruleid: os-system-injection
+    return os.system("echo %s" % route_param)
+
+@app.route("/get_param_inline", methods=["GET"])
+def get_param_inline():
+    # ruleid: os-system-injection
+    os.system(flask.request.args.get("param"))
+
+@app.route("/get_param_inline_concat", methods=["GET"])
+def get_param_inline_concat():
+    # ruleid: os-system-injection
+    os.system("echo " + flask.request.args.get("param"))
+
 @app.route("/get_param", methods=["GET"])
 def get_param():
     param = flask.request.args.get("param")
     # ruleid: os-system-injection
     os.system(param)
 
+@app.route("/get_param_concat", methods=["GET"])
+def get_param_concat():
+    param = flask.request.args.get("param")
+    # ruleid: os-system-injection
+    os.system("echo " + param)
+
+@app.route("/get_param_format", methods=["GET"])
+def get_param_format():
+    param = flask.request.args.get("param")
+    # ruleid: os-system-injection
+    os.system("echo {}".format(param))
+
+@app.route("/get_param_percent_format", methods=["GET"])
+def get_param_percent_format():
+    param = flask.request.args.get("param")
+    # ruleid: os-system-injection
+    os.system("echo %s" % (param,))
+
 @app.route("/post_param", methods=["POST"])
 def post_param():
+    param = flask.request.form['param']
+    # ruleid: os-system-injection
+    os.system(param)
+
+@app.route("/post_param_branch", methods=["POST"])
+def post_param_branch():
     param = flask.request.form['param']
     if True:
         # ruleid: os-system-injection
@@ -28,6 +82,43 @@ def subexpression():
     # ruleid: os-system-injection
     os.system(param)
 
+@app.route("/subexpression_concat", methods=["POST"])
+def subexpression_concat():
+    param = "{}".format(flask.request.form['param'])
+    print("do things")
+    # ruleid: os-system-injection
+    os.system("echo " + param)
+
+@app.route("/subexpression_format", methods=["POST"])
+def subexpression_format():
+    param = "{}".format(flask.request.form['param'])
+    print("do things")
+    # ruleid: os-system-injection
+    os.system("echo {}".format(param))
+
+@app.route("/subexpression_percent_format", methods=["POST"])
+def subexpression_percent_format():
+    param = "{}".format(flask.request.form['param'])
+    print("do things")
+    # ruleid: os-system-injection
+    os.system("echo %s" % param)
+
+# Real world example
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if flask.request.method == 'GET':
+        return flask.render_template('index.html')
+    # check url first
+    url = flask.request.form.get('url', None)
+    if url != '':
+        md5 = hashlib.md5(url+app.config['MD5_SALT']).hexdigest()
+        fpath = join(join(app.config['MEDIA_ROOT'], 'upload'), md5+'.jpg')
+        # ruleid: os-system-injection
+        r = os.system('wget %s -O "%s"'%(url, fpath))
+        if r != 0: abort(403)
+        return flask.redirect(flask.url_for('landmark', hash=md5))
+
 @app.route("/ok")
 def ok():
+    # ok: os-system-injection
     os.system("This is fine")

--- a/python/flask/security/injection/os-system-injection.yaml
+++ b/python/flask/security/injection/os-system-injection.yaml
@@ -3,7 +3,8 @@ rules:
   languages:
   - python
   severity: ERROR
-  message: User data detected in os.system. This could be vulnerable to a command injection and should be avoided. If this
+  message: >-
+    User data detected in os.system. This could be vulnerable to a command injection and should be avoided. If this
     must be done, use the 'subprocess' module instead and pass the arguments as a list.
   metadata:
     cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
@@ -35,19 +36,23 @@ rules:
           - pattern-inside: |
               $INTERM = <... flask.request.$W.get(...) ...>
               ...
-          - pattern: os.system(..., <... $INTERM ...>, ...)
+              os.system(<... $INTERM ...>)
+          - pattern: os.system(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W[...] ...>
               ...
-          - pattern: os.system(..., <... $INTERM ...>, ...)
+              os.system(<... $INTERM ...>)
+          - pattern: os.system(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W(...) ...>
               ...
-          - pattern: os.system(..., <... $INTERM ...>, ...)
+              os.system(<... $INTERM ...>)
+          - pattern: os.system(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W ...>
               ...
-          - pattern: os.system(..., <... $INTERM ...>, ...)
+              os.system(<... $INTERM ...>)
+          - pattern: os.system(...)

--- a/python/flask/security/injection/path-traversal-open.py
+++ b/python/flask/security/injection/path-traversal-open.py
@@ -9,12 +9,49 @@ def route_param(route_param):
     # ruleid: path-traversal-open
     return open(route_param, 'r').read()
 
+@app.route("/route_param_with/<route_param>")
+def route_param_with(route_param):
+    print("blah")
+    # ruleid: path-traversal-open
+    with open(route_param, 'r') as fout:
+        return fout.read()
+
+@app.route("/route_param_with_concat/<route_param>")
+def route_param_with_concat(route_param):
+    print("blah")
+    # ruleid: path-traversal-open
+    with open(route_param + ".csv", 'r') as fout:
+        return fout.read()
+
 @app.route("/get_param", methods=["GET"])
 def get_param():
     param = flask.request.args.get("param")
     # ruleid: path-traversal-open
     f = open(param, 'w')
     f.write("hello world")
+
+@app.route("/get_param_inline_concat", methods=["GET"])
+def get_param_inline_concat():
+    # ruleid: path-traversal-open
+    return open("echo " + flask.request.args.get("param"), 'r').read()
+
+@app.route("/get_param_concat", methods=["GET"])
+def get_param_concat():
+    param = flask.request.args.get("param")
+    # ruleid: path-traversal-open
+    return open(param + ".csv", 'r').read()
+
+@app.route("/get_param_format", methods=["GET"])
+def get_param_format():
+    param = flask.request.args.get("param")
+    # ruleid: path-traversal-open
+    return open("{}.csv".format(param)).read()
+
+@app.route("/get_param_percent_format", methods=["GET"])
+def get_param_percent_format():
+    param = flask.request.args.get("param")
+    # ruleid: path-traversal-open
+    return open("echo %s" % (param,), 'r').read()
 
 @app.route("/post_param", methods=["POST"])
 def post_param():
@@ -23,6 +60,20 @@ def post_param():
         # ruleid: path-traversal-open
         with open(param, 'r') as fin:
             data = json.load(fin)
+    return data
+
+@app.route("/post_param", methods=["POST"])
+def post_param_with_inline():
+    # ruleid: path-traversal-open
+    with open(flask.request.form['param'], 'r') as fin:
+        data = json.load(fin)
+    return data
+
+@app.route("/post_param", methods=["POST"])
+def post_param_with_inline_concat():
+    # ruleid: path-traversal-open
+    with open(flask.request.form['param'] + '.csv', 'r') as fin:
+        data = json.load(fin)
     return data
 
 @app.route("/subexpression", methods=["POST"])

--- a/python/flask/security/injection/path-traversal-open.yaml
+++ b/python/flask/security/injection/path-traversal-open.yaml
@@ -3,7 +3,8 @@ rules:
   languages:
   - python
   severity: ERROR
-  message: Found request data in a call to 'open'. Ensure the request data is validated or sanitized, otherwise it could result
+  message: >-
+    Found request data in a call to 'open'. Ensure the request data is validated or sanitized, otherwise it could result
     in path traversal attacks.
   metadata:
     cwe: "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
@@ -35,19 +36,53 @@ rules:
           - pattern-inside: |
               $INTERM = <... flask.request.$W.get(...) ...>
               ...
-          - pattern: open(..., <... $INTERM ...>, ...)
+              open(<... $INTERM ...>, ...)
+          - pattern: open(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W[...] ...>
               ...
-          - pattern: open(..., <... $INTERM ...>, ...)
+              open(<... $INTERM ...>, ...)
+          - pattern: open(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W(...) ...>
               ...
-          - pattern: open(..., <... $INTERM ...>, ...)
+              open(<... $INTERM ...>, ...)
+          - pattern: open(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W ...>
               ...
-          - pattern: open(..., <... $INTERM ...>, ...)
+              open(<... $INTERM ...>, ...)
+          - pattern: open(...)
+    - patterns:
+      - pattern-either:
+        - patterns:
+          - pattern-inside: |
+              $INTERM = <... flask.request.$W.get(...) ...>
+              ...
+              with open(<... $INTERM ...>, ...) as $F:
+                ...
+          - pattern: open(...)
+        - patterns:
+          - pattern-inside: |
+              $INTERM = <... flask.request.$W[...] ...>
+              ...
+              with open(<... $INTERM ...>, ...) as $F:
+                ...
+          - pattern: open(...)
+        - patterns:
+          - pattern-inside: |
+              $INTERM = <... flask.request.$W(...) ...>
+              ...
+              with open(<... $INTERM ...>, ...) as $F:
+                ...
+          - pattern: open(...)
+        - patterns:
+          - pattern-inside: |
+              $INTERM = <... flask.request.$W ...>
+              ...
+              with open(<... $INTERM ...>, ...) as $F:
+                ...
+          - pattern: open(...)

--- a/python/flask/security/injection/ssrf-requests.py
+++ b/python/flask/security/injection/ssrf-requests.py
@@ -15,6 +15,29 @@ def get_param():
     # ruleid: ssrf-requests
     requests.post(param, timeout=10)
 
+@app.route("/get_param_inline_concat", methods=["GET"])
+def get_param_inline_concat():
+    # ruleid: ssrf-requests
+    requests.get(flask.request.args.get("param") + "/id")
+
+@app.route("/get_param_concat", methods=["GET"])
+def get_param_concat():
+    param = flask.request.args.get("param")
+    # ruleid: ssrf-requests
+    requests.get(param + "/id")
+
+@app.route("/get_param_format", methods=["GET"])
+def get_param_format():
+    param = flask.request.args.get("param")
+    # ruleid: ssrf-requests
+    requests.get("{}.csv".format(param))
+
+@app.route("/get_param_percent_format", methods=["GET"])
+def get_param_percent_format():
+    param = flask.request.args.get("param")
+    # ruleid: ssrf-requests
+    requests.get("%s/id" % (param,))
+
 @app.route("/post_param", methods=["POST"])
 def post_param():
     param = flask.request.form['param']

--- a/python/flask/security/injection/ssrf-requests.yaml
+++ b/python/flask/security/injection/ssrf-requests.yaml
@@ -36,19 +36,23 @@ rules:
           - pattern-inside: |
               $INTERM = <... flask.request.$W.get(...) ...>
               ...
-          - pattern: requests.$FUNC(..., <... $INTERM ...>, ...)
+              requests.$FUNC(<... $INTERM ...>, ...)
+          - pattern: requests.$FUNC(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W[...] ...>
               ...
-          - pattern: requests.$FUNC(..., <... $INTERM ...>, ...)
+              requests.$FUNC(<... $INTERM ...>, ...)
+          - pattern: requests.$FUNC(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W(...) ...>
               ...
-          - pattern: requests.$FUNC(..., <... $INTERM ...>, ...)
+              requests.$FUNC(<... $INTERM ...>, ...)
+          - pattern: requests.$FUNC(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W ...>
               ...
-          - pattern: requests.$FUNC(..., <... $INTERM ...>, ...)
+              requests.$FUNC(<... $INTERM ...>, ...)
+          - pattern: requests.$FUNC(...)

--- a/python/flask/security/injection/user-eval.py
+++ b/python/flask/security/injection/user-eval.py
@@ -14,6 +14,29 @@ def get_param():
     # ruleid: eval-injection
     eval(param)
 
+@app.route("/get_param_inline_concat", methods=["GET"])
+def get_param_inline_concat():
+    # ruleid: eval-injection
+    eval("import " + flask.request.args.get("param"))
+
+@app.route("/get_param_concat", methods=["GET"])
+def get_param_concat():
+    param = flask.request.args.get("param")
+    # ruleid: eval-injection
+    eval(param + "+ 'hello'")
+
+@app.route("/get_param_format", methods=["GET"])
+def get_param_format():
+    param = flask.request.args.get("param")
+    # ruleid: eval-injection
+    eval("import {}".format(param))
+
+@app.route("/get_param_percent_format", methods=["GET"])
+def get_param_percent_format():
+    param = flask.request.args.get("param")
+    # ruleid: eval-injection
+    eval("import %s" % (param,))
+
 @app.route("/post_param", methods=["POST"])
 def post_param():
     param = flask.request.form['param']

--- a/python/flask/security/injection/user-eval.yaml
+++ b/python/flask/security/injection/user-eval.yaml
@@ -34,19 +34,23 @@ rules:
           - pattern-inside: |
               $INTERM = <... flask.request.$W.get(...) ...>
               ...
-          - pattern: eval(..., <... $INTERM ...>, ...)
+              eval(..., <... $INTERM ...>, ...)
+          - pattern: eval(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W[...] ...>
               ...
-          - pattern: eval(..., <... $INTERM ...>, ...)
+              eval(..., <... $INTERM ...>, ...)
+          - pattern: eval(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W(...) ...>
               ...
-          - pattern: eval(..., <... $INTERM ...>, ...)
+              eval(..., <... $INTERM ...>, ...)
+          - pattern: eval(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W ...>
               ...
-          - pattern: eval(..., <... $INTERM ...>, ...)
+              eval(..., <... $INTERM ...>, ...)
+          - pattern: eval(...)

--- a/python/flask/security/injection/user-exec.py
+++ b/python/flask/security/injection/user-exec.py
@@ -14,6 +14,29 @@ def get_param():
     # ruleid: exec-injection
     exec(param)
 
+@app.route("/get_param_inline_concat", methods=["GET"])
+def get_param_inline_concat():
+    # ruleid: exec-injection
+    exec("import " + flask.request.args.get("param"))
+
+@app.route("/get_param_concat", methods=["GET"])
+def get_param_concat():
+    param = flask.request.args.get("param")
+    # ruleid: exec-injection
+    exec(param + "+ 'hello'")
+
+@app.route("/get_param_format", methods=["GET"])
+def get_param_format():
+    param = flask.request.args.get("param")
+    # ruleid: exec-injection
+    exec("import {}".format(param))
+
+@app.route("/get_param_percent_format", methods=["GET"])
+def get_param_percent_format():
+    param = flask.request.args.get("param")
+    # ruleid: exec-injection
+    exec("import %s" % (param,))
+
 @app.route("/post_param", methods=["POST"])
 def post_param():
     param = flask.request.form['param']
@@ -21,8 +44,8 @@ def post_param():
         # ruleid: exec-injection
         exec(param)
 
-@app.route("/subexpression", methods=["POST"])
-def subexpression():
+@app.route("/format", methods=["POST"])
+def format():
     param = "{}".format(flask.request.form['param'])
     print("do things")
     # ruleid: exec-injection

--- a/python/flask/security/injection/user-exec.yaml
+++ b/python/flask/security/injection/user-exec.yaml
@@ -3,14 +3,12 @@ rules:
   languages:
   - python
   severity: ERROR
-  message: |
-    Found user data in a call to 'exec'. This is extremely dangerous because
-    it can enable an attacker to execute remote code.
+  message: Detected user data flowing into exec. This is code injection and should be avoided.
   metadata:
     cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
     owasp: 'A1: Injection'
     references:
-    - https://owasp.org/www-community/attacks/Code_Injection
+    - https://nedbatchelder.com/blog/201206/exec_really_is_dangerous.html
   patterns:
   - pattern-either:
     - patterns:
@@ -36,19 +34,23 @@ rules:
           - pattern-inside: |
               $INTERM = <... flask.request.$W.get(...) ...>
               ...
-          - pattern: exec(..., <... $INTERM ...>, ...)
+              exec(..., <... $INTERM ...>, ...)
+          - pattern: exec(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W[...] ...>
               ...
-          - pattern: exec(..., <... $INTERM ...>, ...)
+              exec(..., <... $INTERM ...>, ...)
+          - pattern: exec(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W(...) ...>
               ...
-          - pattern: exec(..., <... $INTERM ...>, ...)
+              exec(..., <... $INTERM ...>, ...)
+          - pattern: exec(...)
         - patterns:
           - pattern-inside: |
               $INTERM = <... flask.request.$W ...>
               ...
-          - pattern: exec(..., <... $INTERM ...>, ...)
+              exec(..., <... $INTERM ...>, ...)
+          - pattern: exec(...)


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep-rules/issues/954.

The issue was that metavariable equivalence wasn't working across `pattern-inside` and `pattern` clauses when the deep expression operator `<... $THING ...>` was used.