### PR TITLE
Filter HTML attributes from var-in-script-tag rules.

### DIFF
--- a/generic/html-templates/security/var-in-script-src.html
+++ b/generic/html-templates/security/var-in-script-src.html
@@ -1,0 +1,46 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<!-- ok: var-in-script-src -->
+<script src="app.js"></script>
+<!-- ok: var-in-script-src -->
+<script src="script.js"></script>
+
+<div class="text-center">
+    <!-- ok: var-in-script-src -->
+    <h2>Apresentando o time da <b>{{ time.nome }}</b></h2>
+    <!-- ok: var-in-script-src -->
+    <h6>Predio {{ time.predio }}</h6>
+</div>
+<div class="container" style="margin-top: 30px;">
+    <div class="row">
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="card-header text-center">
+                    <!-- ok: var-in-script-src -->
+                    <b>{{ nome }}</b>
+                </div>
+                <div class="card-body">
+                    <!-- ok: var-in-script-src -->
+                    {{ template-table }}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ruleid: var-in-script-src -->
+<script src="./{{ reactDemoIndexBundleJs }}" crossOrigin="anonymous" integrity="{{ sri.reactDemoIndexBundleJs }}"></script>
+
+</html>

--- a/generic/html-templates/security/var-in-script-src.yaml
+++ b/generic/html-templates/security/var-in-script-src.yaml
@@ -1,0 +1,30 @@
+rules:
+- id: var-in-script-src
+  message: >-
+    Detected a template variable used as the 'src' in a script tag.
+    Although template variables are HTML escaped, HTML
+    escaping does not always prevent malicious URLs from being injected
+    and could results in a cross-site scripting (XSS) vulnerability.
+    Prefer not to dynamically generate the 'src' attribute and use static
+    URLs instead. If you must do this, carefully check URLs against an
+    allowlist and be sure to URL-encode the result.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://adamj.eu/tech/2020/02/18/safely-including-data-for-javascript-in-a-django-template/?utm_campaign=Django%2BNewsletter&utm_medium=rss&utm_source=Django_Newsletter_12A
+    - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
+    - https://github.com/ESAPI/owasp-esapi-js
+  languages:
+  - generic
+  paths:
+    include:
+    - '*.mustache'
+    - '*.hbs'
+    - '*.html'
+  severity: WARNING
+  patterns:
+  - pattern-inside: <script ...>
+  - pattern-not-inside: src = '...'
+  - pattern-not-inside: src = "..."
+  - pattern: '{{ ... }}'

--- a/generic/html-templates/security/var-in-script-tag.html
+++ b/generic/html-templates/security/var-in-script-tag.html
@@ -13,4 +13,8 @@
             <p>{{ this_is_fine }}</p>
         </div>
     </body>
+
+    <!-- ok: var-in-script-tag -->
+    <script src="./{{ reactDemoIndexBundleJs }}" crossOrigin="anonymous" integrity="{{ sri.reactDemoIndexBundleJs }}"></script>
+
 </html>

--- a/generic/html-templates/security/var-in-script-tag.mustache
+++ b/generic/html-templates/security/var-in-script-tag.mustache
@@ -64,4 +64,7 @@
 </div>
 {{/time}}
 
+<!-- ok: var-in-script-tag -->
+<script src="./{{ reactDemoIndexBundleJs }}" crossOrigin="anonymous" integrity="{{ sri.reactDemoIndexBundleJs }}"></script>
+
 </html>

--- a/generic/html-templates/security/var-in-script-tag.yaml
+++ b/generic/html-templates/security/var-in-script-tag.yaml
@@ -28,4 +28,6 @@ rules:
   severity: WARNING
   patterns:
   - pattern-inside: <script ...> ... </script>
+  - pattern-not-inside: <script ... $ATTR = "..." ...>
+  - pattern-not-inside: <script ... $ATTR = '...' ...>
   - pattern: '{{ ... }}'

--- a/javascript/express/security/audit/xss/ejs/var-in-script-src.ejs
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-src.ejs
@@ -1,0 +1,46 @@
+<!-- cf. https://github.com/caiomartini/mustache-demo/blob/97b9200ebd2d27953febff23e6718aa1aa9ee44d/demo-mustache.html -->
+<!DOCTYPE HTML>
+<html>
+
+<head>
+    <title>Demo Mustache.JS</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="node_modules\bootstrap\dist\css\bootstrap.min.css">
+    <script type="text/javascript" src="node_modules\jquery\dist\jquery.min.js"></script>
+    <script type="text/javascript" src="node_modules\bootstrap\dist\js\bootstrap.min.js"></script>
+    <script type="text/javascript" src="node_modules\mustache\mustache.min.js"></script>
+    <script type="text/javascript" src="demo-mustache.js"></script>
+</head>
+
+<!-- ok: var-in-script-src -->
+<script src="app.js"></script>
+<!-- ok: var-in-script-src -->
+<script src="script.js"></script>
+
+<div class="text-center">
+    <!-- ok: var-in-script-src -->
+    <h2>Apresentando o time da <b><%= time.nome %></b></h2>
+    <!-- ok: var-in-script-src -->
+    <h6>Predio <%= time.predio %></h6>
+</div>
+<div class="container" style="margin-top: 30px;">
+    <div class="row">
+        <div class="col-sm-6">
+            <div class="card">
+                <div class="card-header text-center">
+                    <!-- ok: var-in-script-src -->
+                    <b><%= nome %></b>
+                </div>
+                <div class="card-body">
+                    <!-- ok: var-in-script-src -->
+                    <%= template-table %>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- ruleid: var-in-script-tag -->
+<script src="./<%=reactDemoIndexBundleJs %>" crossOrigin="anonymous" integrity="<%=sri.reactDemoIndexBundleJs %>"></script>
+
+</html>

--- a/javascript/express/security/audit/xss/ejs/var-in-script-src.ejs
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-src.ejs
@@ -40,7 +40,7 @@
     </div>
 </div>
 
-<!-- ruleid: var-in-script-tag -->
+<!-- ruleid: var-in-script-src -->
 <script src="./<%=reactDemoIndexBundleJs %>" crossOrigin="anonymous" integrity="<%=sri.reactDemoIndexBundleJs %>"></script>
 
 </html>

--- a/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
@@ -1,5 +1,5 @@
 rules:
-- id: var-in-script-tag
+- id: var-in-script-src
   message: >-
     Detected a template variable used as the 'src' in a script tag.
     Although template variables are HTML escaped, HTML

--- a/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
@@ -1,0 +1,29 @@
+rules:
+- id: var-in-script-tag
+  message: >-
+    Detected a template variable used as the 'src' in a script tag.
+    Although template variables are HTML escaped, HTML
+    escaping does not always prevent malicious URLs from being injected
+    and could results in a cross-site scripting (XSS) vulnerability.
+    Prefer not to dynamically generate the 'src' attribute and use static
+    URLs instead. If you must do this, carefully check URLs against an
+    allowlist and be sure to URL-encode the result.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-site Scripting (XSS)'
+    references:
+    - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
+    - https://github.com/ESAPI/owasp-esapi-js
+  languages:
+  - generic
+  paths:
+    include:
+    - '*.ejs'
+    - '*.html'
+  severity: WARNING
+  patterns:
+  - pattern-inside: <script ...>
+  - pattern-either:
+    - pattern-inside: src = '...'
+    - pattern-inside: src = "..."
+  - pattern: <% ... >

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.ejs
@@ -59,4 +59,7 @@
     </div>
 </div>
 
+<!-- ok: var-in-script-tag -->
+<script src="./<%=reactDemoIndexBundleJs %>" crossOrigin="anonymous" integrity="<%=sri.reactDemoIndexBundleJs %>"></script>
+
 </html>

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
@@ -24,4 +24,6 @@ rules:
   severity: WARNING
   patterns:
   - pattern-inside: <script ...> ... </script>
+  - pattern-not-inside: <script ... $ATTR = "..." ...>
+  - pattern-not-inside: <script ... $ATTR = '...' ...>
   - pattern: <% ... >


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep-rules/issues/1107.

Removes HTML attributes from matches.

Adds a new rule that specifically checks for template variables in the `src` attribute.