### PR TITLE
Improve javascript assigned-undefined rule to not return duplicates

### DIFF
--- a/javascript/lang/best-practice/assigned-undefined.yaml
+++ b/javascript/lang/best-practice/assigned-undefined.yaml
@@ -10,5 +10,4 @@ rules:
   - pattern: var undefined = $X;
   - pattern: let undefined = $X;
   - pattern: const undefined = $X;
-  - pattern: undefined = $X
   severity: WARNING


### PR DESCRIPTION
**Rule ID:** `assigned-undefined`

It's reporting the same finding twice because of duplicated pattern statement. This PR remove an additional pattern definition to ensure that only a single line is reported without returning back duplicates.

**Before this PR:**

```shell
→ semgrep --verbose -f semgrep-rules/javascript/lang/best-practice/assigned-undefined.yaml ./project
running 1 rules...
project/foobar.js
severity:warning rule:semgrep-rules.javascript.lang.best-practice.assigned-undefined: `undefined` is not a reserved keyword in Javascript, so this is "valid" Javascript but highly confusing and likely to result in bugs.
49:    options = undefined;
--------------------------------------------------------------------------------
49:    options = undefined;
--------------------------------------------------------------------------------
163:    options = undefined;
--------------------------------------------------------------------------------
163:    options = undefined;
ran 1 rules on 13 files: 4 findings
```

**After this PR:**

```shell
→ semgrep --verbose -f semgrep-rules/javascript/lang/best-practice/assigned-undefined.yaml ./project
running 1 rules...
project/foobar.js
severity:warning rule:semgrep-rules.javascript.lang.best-practice.assigned-undefined: `undefined` is not a reserved keyword in Javascript, so this is "valid" Javascript but highly confusing and likely to result in bugs.
49:    options = undefined;
--------------------------------------------------------------------------------
163:    options = undefined;
ran 1 rules on 13 files: 2 findings
```