### PR TITLE
fix false positives in grpc-server-insecure-connection rule

### DIFF
--- a/go/grpc/security/grpc-server-insecure-connection.go
+++ b/go/grpc/security/grpc-server-insecure-connection.go
@@ -53,6 +53,7 @@ func startServerWithOpts() {
 	options := []grpc.ServerOption{
 		grpc.Creds(credentials.NewClientTLSFromCert(pool, addr)),
 	}
+	// ok:grpc-server-insecure-connection
 	grpcServer := grpc.NewServer(options...)
 	_ = grpcServer
 }
@@ -64,6 +65,7 @@ func startServerCredsVar() {
 		creds,
 		grpc.UnaryInterceptor(auth.GRPCInterceptor),
 	}
+	// ok:grpc-server-insecure-connection
 	grpcServer := grpc.NewServer(options...)
 	_ = grpcServer
 }

--- a/go/grpc/security/grpc-server-insecure-connection.yaml
+++ b/go/grpc/security/grpc-server-insecure-connection.yaml
@@ -5,13 +5,29 @@ rules:
     references:
     - https://blog.gopheracademy.com/advent-2019/go-grps-and-tls/#connection-without-encryption
   message: >-
-    Found an insecure gRPC server without 'grpc.Creds()'. This allows for a connection without encryption to this server.
+    Found an insecure gRPC server without 'grpc.Creds()' or options with credentials. This allows for a connection without encryption to this server.
     A malicious attacker could tamper with the gRPC message, which could compromise the machine. Include credentials derived
     from an SSL certificate in order to create a secure gRPC connection. You can create credentials using 'credentials.NewServerTLSFromFile("cert.pem",
     "cert.key")'.
   languages:
   - go
   severity: ERROR
-  patterns:
+  patterns:    
   - pattern-not: grpc.NewServer(..., grpc.Creds(...), ...)
+  - pattern-not-inside: |
+      $OPTS := []grpc.ServerOption{
+        ...,
+        grpc.Creds(credentials.NewClientTLSFromCert(...)),
+        ...,
+      }
+      grpc.NewServer($OPTS...)
+  - pattern-not-inside: |
+      $CREDS := credentials.NewClientTLSFromCert(...)
+      ...
+      $OPTS := []grpc.ServerOption{
+        ...,
+        $CREDS,
+        ...,
+      }
+      grpc.NewServer($OPTS...)      
   - pattern: grpc.NewServer(...)

--- a/go/grpc/security/grpc-server-insecure-connection.yaml
+++ b/go/grpc/security/grpc-server-insecure-connection.yaml
@@ -5,14 +5,15 @@ rules:
     references:
     - https://blog.gopheracademy.com/advent-2019/go-grps-and-tls/#connection-without-encryption
   message: >-
-    Found an insecure gRPC server without 'grpc.Creds()' or options with credentials. This allows for a connection without encryption to this server.
+    Found an insecure gRPC server without 'grpc.Creds()' or options with credentials. This allows for a connection without
+    encryption to this server.
     A malicious attacker could tamper with the gRPC message, which could compromise the machine. Include credentials derived
     from an SSL certificate in order to create a secure gRPC connection. You can create credentials using 'credentials.NewServerTLSFromFile("cert.pem",
     "cert.key")'.
   languages:
   - go
   severity: ERROR
-  patterns:    
+  patterns:
   - pattern-not: grpc.NewServer(..., grpc.Creds(...), ...)
   - pattern-not-inside: |
       $OPTS := []grpc.ServerOption{
@@ -29,5 +30,5 @@ rules:
         $CREDS,
         ...,
       }
-      grpc.NewServer($OPTS...)      
+      grpc.NewServer($OPTS...)
   - pattern: grpc.NewServer(...)


### PR DESCRIPTION
PR fixes the following false positive with gRPC server insecure connection rule:
```
	opts := []grpc.ServerOption{
		grpc.Creds(credentials.NewClientTLSFromCert(pool, addr)), grpc.UnaryInterceptor(auth.GRPCInterceptor)}
	grpcServer := grpc.NewServer(opts...)
```

The linked in the rule post https://blog.gopheracademy.com/advent-2019/go-grps-and-tls/#connection-without-encryption says (emphasis added):
> This, plus a Server **without any ServerOption** will result in an unencrypted connection.

When there are options with credentials, `grpc.NewServer` shouldn't be flagged.

I hope the spacing diffs in the .go file (autoformatted by the editor) are ok - if not, let me know and I'll try to remove them.