### PR TITLE
Avoid running string concat rule in Python dict

### DIFF
--- a/python/lang/correctness/common-mistakes/string-concat-in-list.py
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.py
@@ -5,7 +5,7 @@ bad = ["123" "456" "789"]
 bad = ["123" f"{456}" "789"]
 
 bad = [
-# ruleid:string-concat-in-list
+    # ruleid:string-concat-in-list
     "abc"
     "cde"
     "efg",
@@ -14,7 +14,7 @@ bad = [
 
 bad = [
     "abc",
-# ruleid:string-concat-in-list
+    # ruleid:string-concat-in-list
     "cde"
     "efg"
     "hijk"
@@ -22,23 +22,50 @@ bad = [
 
 bad = [
     "abc",
-# ruleid:string-concat-in-list
+    # ruleid:string-concat-in-list
     "cde"
     f"efg"
     "hijk"
 ]
 
 bad = {
-# ruleid:string-concat-in-list
+    # ruleid:string-concat-in-list
     "abc"
     "cde"
     "efg",
     "hijk"
 }
 
+good = {
+    "key1": "value1",
+    # ok:string-concat-in-list
+    "key2": "value2"
+    "value2 continuation",
+    "key3": "value3",
+}
+
+good = {
+    "key1": "value1",
+    # ok:string-concat-in-list
+    "key2": "value2 {}"
+    .format("value2 continuation"),
+    "key3": "value3",
+}
+
+# ok:string-concat-in-list
 good = ["123"]
+
+# ok:string-concat-in-list
 good = [123, 456]
+
+# ok:string-concat-in-list
 good = ["123", "456"]
+
+# ok:string-concat-in-list
 good = [f"123"]
+
+# ok:string-concat-in-list
 good = [f"{123}"]
+
+# ok:string-concat-in-list
 good = ["123", f"{456}"]

--- a/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
+++ b/python/lang/correctness/common-mistakes/string-concat-in-list.yaml
@@ -2,14 +2,11 @@ rules:
 - id: string-concat-in-list
   patterns:
   - pattern-either:
-    - pattern-inside: |
-        [...]
-    - pattern-inside: |
-        {...}
-  - pattern: |
-      "..." "..."
-  - pattern-not-inside: |
-      f"..."
+    - pattern-inside: '[...]'
+    - pattern-inside: '{...}'
+  - pattern: '"..." "..."'
+  - pattern-not-inside: f"..."
+  - pattern-not-inside: '{..., $KEY: $VALUE, ...}'
   message: |
     Detected strings that are implicitly concatenated inside a list.
     Python will implicitly concatenate strings when not explicitly delimited.


### PR DESCRIPTION
Python has the unfortunate syntax of `{...}` referring to both sets and dicts. This means we were incorrectly detecting implicit string concatenation inside dicts as well as the intended lists and sets. This PR removes these false positives :+1: 