### PR TITLE
Use ellipsis in JSON pattern in fields

### DIFF
--- a/json/aws/security/public-s3-policy-statement.yaml
+++ b/json/aws/security/public-s3-policy-statement.yaml
@@ -6,7 +6,8 @@ rules:
       "Principal": "*",
       "Resource": [
         ..., "=~/arn:aws:s3.*/", ...
-      ]
+      ],
+      ...
     }
   message: |
     Detected public s3 bucket policy. This policy allows anyone to access


### PR DESCRIPTION
In https://github.com/returntocorp/semgrep/pull/2741 we are converting
JSON records in a Dict, to be more consistent with what we do
with YAML, but a problem is that Record (and objects) allowed
the "..." to be ommitted, but Dict (and Set) require the "...".
This is yet another inconsistency. We should probably require
the "..." in object too, but in the mean time we can add it
for JSON so the semgrep PR above will pass.

test plan:
make test using semgrep-core of PR above.