### PR TITLE
Semgrep meta rules!

### DIFF
--- a/kubernetes/best-practice/no-fractional-cpu-limits.yaml
+++ b/kubernetes/best-practice/no-fractional-cpu-limits.yaml
@@ -8,7 +8,7 @@ rules:
       cpu: $CPU_LIMIT
   - metavariable-regex:
       metavariable: $CPU_LIMIT
-      regex: \d{,3}m
+      regex: \d{0,3}m
   fix: 'cpu: 1000m'
   message: |
     When you set a fractional CPU limit on a container,

--- a/meta/identical_id.yaml
+++ b/meta/identical_id.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: identical-id
+  message: |
+    you use multiple times the same id
+  severity: ERROR
+  #TODO: can't express it yet in yaml, some ... are not parsed correctly
+  languages: [json, yaml]
+  patterns:
+    - pattern-inside: |
+       [{id: $X, ...}, ..., {id: $X, ...}, ...]
+    - pattern: |
+       id: $X

--- a/meta/identical_pattern.yaml
+++ b/meta/identical_pattern.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: identical-pattern
+  message: |
+    you use multiple times the same pattern
+  severity: ERROR
+  languages: [yaml]
+  patterns:
+    - pattern-inside: |
+        ...
+        - pattern: $X
+        ...
+        - pattern: $X
+        ...
+    - pattern: |
+       pattern: $X

--- a/meta/unsatisfiable.yaml
+++ b/meta/unsatisfiable.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: unsatisfiable-rule
+  message: |
+    You can not use $A and not $A together; this will always be empty
+  severity: ERROR
+  languages: [yaml]
+  patterns:
+    - pattern-inside: |
+        ...
+        - pattern: $A
+        ...
+    - pattern: |
+       pattern-not: $A


### PR DESCRIPTION
test plan:
```
+ /home/pad/semgrep/_build/default/CLI/Main.exe -lang yaml -config meta/identical_pattern.yaml .
./contrib/nodejsscan/eval_vm_injection.yaml:62 with rule identical-pattern
     - pattern: |
         $VAR = <... $REQ.$BODY ...>;
         ...
         $CONTEXT = {$NAME: <... $VAR ...>};
         ...
         $VM.runInContext($CODE,<... $CONTEXT ...>,...);
   message: Untrusted user input in `vm.runInContext()` can result in code injection.
./contrib/nodejsscan/eval_vm_injection.yaml:58 with rule identical-pattern
     - pattern: |
         $CONTEXT = {$NAME: <... $REQ.$BODY ...>};
         ...
         $VM.runInContext($CODE,<... $CONTEXT ...>,...);
     - pattern: |
```