### PR TITLE
update dangerous-subprocess-use rule

### DIFF
--- a/python/lang/security/audit/dangerous-subprocess-use.py
+++ b/python/lang/security/audit/dangerous-subprocess-use.py
@@ -18,6 +18,11 @@ raise subprocess.SubprocessError("{}".format("foo"))
 # ruleid:dangerous-subprocess-use
 subprocess.call("grep -R {} .".format(sys.argv[1]))
 
+def foobar(user_input):
+  cmd = user_input.split()
+  # ruleid:dangerous-subprocess-use
+  subprocess.call([cmd[0], cmd[1], "some", "args"])
+
 # ruleid:dangerous-subprocess-use
 subprocess.call("grep -R {} .".format(sys.argv[1]), shell=True)
 

--- a/python/lang/security/audit/dangerous-subprocess-use.yaml
+++ b/python/lang/security/audit/dangerous-subprocess-use.yaml
@@ -2,7 +2,7 @@ rules:
 - id: dangerous-subprocess-use
   patterns:
   - pattern-not: subprocess.$FUNC("...", ...)
-  - pattern-not: subprocess.$FUNC([...], ...)
+  - pattern-not: subprocess.$FUNC(["...",...], ...)
   - pattern-not: subprocess.CalledProcessError(...)
   - pattern-not: subprocess.SubprocessError(...)
   - pattern: subprocess.$FUNC(...)


### PR DESCRIPTION
part of: https://github.com/returntocorp/enterprise/issues/507

@minusworld want to also catch non-static values inside arrays (e.g. `subprocess.call([user_input_cmd, "param"])`)