### PR TITLE
Update dict-modify-iterating rule

### DIFF
--- a/python/lang/correctness/dict-modify-iterating.py
+++ b/python/lang/correctness/dict-modify-iterating.py
@@ -1,19 +1,4 @@
-d = {'a': 1, 'b': 2}
+d = {"a": 1, "b": 2}
 # ruleid:dict-del-while-iterate
-for k,v in d.items():
+for k, v in d:
     del d[k]
-
-d = {'a': 1, 'b': 2}
-# ruleid:dict-del-while-iterate
-for k in d.keys():
-    del d[k]
-
-# ruleid:dict-del-while-iterate
-for k in d.keys():
-    print(d[k])
-    del d[k]
-
-# ok:dict-del-while-iterate
-for k in d.keys():
-    print(d[k])
-    x = d[k]

--- a/python/lang/correctness/dict-modify-iterating.yaml
+++ b/python/lang/correctness/dict-modify-iterating.yaml
@@ -1,15 +1,10 @@
 rules:
 - id: dict-del-while-iterate
   patterns:
-  - pattern-either:
-    - pattern: |
-        for $KEY, $VALUE in $DICT.items():
-            ...
-            del $DICT[$KEY]
-    - pattern: |
-        for $KEY in $DICT.keys():
-            ...
-            del $DICT[$KEY]
+  - pattern: |
+      for $KEY, $VALUE in $DICT:
+          ...
+          del $DICT[$KEY]
   message: 'It appears that `$DICT[$KEY]` is a dict with items being deleted while in a for loop. This is usually a bad idea
     and will likely lead to a RuntimeError: dictionary changed size during iteration'
   languages: [python]


### PR DESCRIPTION
Previously, this would trigger on loops over `dictVal.keys()` and `dictVal.items()` which doesn't actually raise a `RuntimeError` in my testing. Updating to only trigger for `for v in dictVal`.