### PR TITLE
Fix last-user-is-root

### DIFF
--- a/generic/dockerfile/security/last-user-is-root.yaml
+++ b/generic/dockerfile/security/last-user-is-root.yaml
@@ -1,15 +1,12 @@
 rules:
   - id: last-user-is-root
     patterns:
-      - pattern: USER $ROOT
+      - pattern: USER root
       - pattern-not-inside: |
-          USER $ROOT
+          USER root
           ...
           ...
-          USER $OTHER
-      - metavariable-regex:
-          metavariable: "$ROOT"
-          regex: "root"
+          USER
     message: >-
       The last user in the container is 'root'. This is a security
       hazard because if an attacker gains control of the container


### PR DESCRIPTION
This is motivated by a [fix in spacegrep](https://github.com/returntocorp/semgrep/pull/2803), which has to do with metavariables. The fix made the test fail, but the reasons are complicated. I'm not clear on why the rule appeared to work previously. The new rule is simpler as it doesn't rely on metavariables. It works with both the older and newer spacegrep.
