### PR TITLE
update dangerous-exec rule

### DIFF
--- a/ruby/lang/security/dangerous-exec.rb
+++ b/ruby/lang/security/dangerous-exec.rb
@@ -7,6 +7,12 @@ def test_calls(user_input)
 # ruleid: dangerous-exec
   Process.spawn([user_input, "smth"])
 
+# ruleid: dangerous-exec
+  output = exec(["sh", "-c", user_input])
+
+# ruleid: dangerous-exec
+  pid = spawn(["bash", user_input])
+
   commands = "ls -lah /raz/dva"
 # ok: dangerous-exec
   system(commands)

--- a/ruby/lang/security/dangerous-exec.yaml
+++ b/ruby/lang/security/dangerous-exec.yaml
@@ -1,20 +1,62 @@
 rules:
 - id: dangerous-exec
-  patterns:
-  - pattern-either:
+  pattern-either:
+  - patterns:
     - pattern: |
         $EXEC(...)
-  - pattern-not: |
-      $EXEC("...",...)
-  - pattern-not: |
-      $EXEC(["...",...],...)
-  - pattern-not: |
-      $EXEC({...},"...",...)
-  - pattern-not: |
-      $EXEC({...},["...",...],...)
-  - metavariable-regex:
-      metavariable: $EXEC
-      regex: ^(system|exec|Process.exec|Process.spawn|Open3.capture2|Open3.capture2e|Open3.capture3|Open3.popen2|Open3.popen2e|Open3.popen3|IO.popen|Gem::Util.popen|PTY.spawn)$
+    - pattern-not: |
+        $EXEC("...",...)
+    - pattern-not: |
+        $EXEC(["...",...],...)
+    - pattern-not: |
+        $EXEC({...},"...",...)
+    - pattern-not: |
+        $EXEC({...},["...",...],...)
+    - metavariable-regex:
+        metavariable: $EXEC
+        regex: ^(system|exec|spawn|Process.exec|Process.spawn|Open3.capture2|Open3.capture2e|Open3.capture3|Open3.popen2|Open3.popen2e|Open3.popen3|IO.popen|Gem::Util.popen|PTY.spawn)$
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          $EXEC("=~/(sh|bash|ksh|csh|tcsh|zsh)/",...)
+      - pattern: |
+          $EXEC({...},"=~/(sh|bash|ksh|csh|tcsh|zsh)/",...)
+      - pattern: |
+          $EXEC(["=~/(sh|bash|ksh|csh|tcsh|zsh)/",...],...)
+      - pattern: |
+          $EXEC({...},["=~/(sh|bash|ksh|csh|tcsh|zsh)/",...],...)
+    - pattern-not: |
+        $EXEC("...","...",...)
+    - pattern-not: |
+        $EXEC(["...","...",...],...)
+    - pattern-not: |
+        $EXEC({...},"...","...",...)
+    - pattern-not: |
+        $EXEC({...},["...","...",...],...)
+    - metavariable-regex:
+        metavariable: $EXEC
+        regex: ^(system|exec|spawn|Process.exec|Process.spawn|Open3.capture2|Open3.capture2e|Open3.capture3|Open3.popen2|Open3.popen2e|Open3.popen3|IO.popen|Gem::Util.popen|PTY.spawn)$
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          $EXEC("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",...)
+      - pattern: |
+          $EXEC({...},"=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",...)
+      - pattern: |
+          $EXEC(["=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",...],...)
+      - pattern: |
+          $EXEC({...},["=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",...],...)
+    - pattern-not: |
+        $EXEC("...","...","...",...)
+    - pattern-not: |
+        $EXEC(["...","...","...",...],...)
+    - pattern-not: |
+        $EXEC({...},"...","...","...",...)
+    - pattern-not: |
+        $EXEC({...},["...","...","...",...],...)
+    - metavariable-regex:
+        metavariable: $EXEC
+        regex: ^(system|exec|spawn|Process.exec|Process.spawn|Open3.capture2|Open3.capture2e|Open3.capture3|Open3.popen2|Open3.popen2e|Open3.popen3|IO.popen|Gem::Util.popen|PTY.spawn)$
   message: |
     Detected non-static command inside $EXEC. Audit the input to '$EXEC'.
     If unverified user data can reach this call site, this is a code injection


### PR DESCRIPTION
from https://github.com/returntocorp/enterprise/issues/507

the idea is to catch dynamic args if the command is "bash", "sh" etc