### PR TITLE
Add dockerfile rule to prefer copy over add

### DIFF
--- a/generic/dockerfile/best-practice/prefer-copy-over-add.dockerfile
+++ b/generic/dockerfile/best-practice/prefer-copy-over-add.dockerfile
@@ -1,3 +1,4 @@
 FROM busybox
 
+# ruleid: prefer-copy-over-add
 ADD foo bar

--- a/generic/dockerfile/best-practice/prefer-copy-over-add.dockerfile
+++ b/generic/dockerfile/best-practice/prefer-copy-over-add.dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+
+ADD foo bar

--- a/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
+++ b/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
@@ -5,9 +5,9 @@ rules:
   patterns:
   - pattern: ADD
   message: >-
-    The ADD command will accept and include files from a URL. 
+    The ADD command will accept and include files from a URL.
     This potentially exposes the container to a man-in-the-middle attack.
-    Since ADD can have this and other unexpected side effects, the use of 
+    Since ADD can have this and other unexpected side effects, the use of
     the more explicit COPY command is preferred.
   metadata:
     references:

--- a/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
+++ b/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
@@ -5,8 +5,10 @@ rules:
   patterns:
   - pattern: ADD
   message: >-
-    Since ADD can lead to unexpected side effects, the use of the more
-    explicit COPY command is preferred.
+    The ADD command will accept and include files from a URL. 
+    This potentially exposes the container to a man-in-the-middle attack.
+    Since ADD can have this and other unexpected side effects, the use of 
+    the more explicit COPY command is preferred.
   metadata:
     references:
     - https://snyk.io/blog/10-docker-image-security-best-practices/

--- a/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
+++ b/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
@@ -8,7 +8,6 @@ rules:
     Since ADD can lead to unexpected side effects, the use of the more
     explicit COPY command is preferred.
   metadata:
-    source-rule-url: https://snyk.io/blog/10-docker-image-security-best-practices/
     references:
     - https://snyk.io/blog/10-docker-image-security-best-practices/
   paths:

--- a/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
+++ b/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: prefer-copy-over-add
+  severity: INFO
+  languages: [generic]
+  patterns:
+  - pattern: ADD
+  message: >-
+    Since ADD can lead to unexpected side effects, the use of the more
+    explicit COPY command is preferred.
+  metadata:
+    source-rule-url: https://snyk.io/blog/10-docker-image-security-best-practices/
+    references:
+      - https://snyk.io/blog/10-docker-image-security-best-practices/
+  paths:
+    include:
+    - '*dockerfile*'
+    - '*Dockerfile*'

--- a/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
+++ b/generic/dockerfile/best-practice/prefer-copy-over-add.yaml
@@ -10,7 +10,7 @@ rules:
   metadata:
     source-rule-url: https://snyk.io/blog/10-docker-image-security-best-practices/
     references:
-      - https://snyk.io/blog/10-docker-image-security-best-practices/
+    - https://snyk.io/blog/10-docker-image-security-best-practices/
   paths:
     include:
     - '*dockerfile*'


### PR DESCRIPTION
I created a generic rule for Dockerfiles that checks if the ADD command is used instead of COPY, since ADD has some side effects, as also explained at https://snyk.io/blog/10-docker-image-security-best-practices/