### PR TITLE
Correct protocol names for Java SSLContext

### DIFF
--- a/java/lang/security/audit/weak-ssl-context.java
+++ b/java/lang/security/audit/weak-ssl-context.java
@@ -13,29 +13,39 @@ class Cls {
 
     public void test2() {
         // ruleid: weak-ssl-context
-        SSLContext ctx = SSLContext.getInstance("TLS1.0");
+        SSLContext ctx = SSLContext.getInstance("TLS");
     }
 
     public void test3() {
         // ruleid: weak-ssl-context
-        SSLContext ctx = SSLContext.getInstance("TLS1.1");
+        SSLContext ctx = SSLContext.getInstance("TLSv1");
     }
 
     public void test4() {
-        // ok: weak-ssl-context
-        SSLContext ctx = SSLContext.getInstance("TLS1.2");
+        // ruleid: weak-ssl-context
+        SSLContext ctx = SSLContext.getInstance("SSLv3");
     }
 
     public void test5() {
+        // ruleid: weak-ssl-context
+        SSLContext ctx = SSLContext.getInstance("TLSv1.1");
+    }
+
+    public void test6() {
         // ok: weak-ssl-context
-        SSLContext ctx = SSLContext.getInstance("TLS1.3");
+        SSLContext ctx = SSLContext.getInstance("TLSv1.2");
+    }
+
+    public void test7() {
+        // ok: weak-ssl-context
+        SSLContext ctx = SSLContext.getInstance("TLSv1.3");
     }
 
     public String getSslContext() {
         return "Anything";
     }
 
-    public void test5() {
+    public void test8() {
         // ok: weak-ssl-context
         SSLContext ctx = SSLContext.getInstance(getSslContext());
     }

--- a/java/lang/security/audit/weak-ssl-context.yaml
+++ b/java/lang/security/audit/weak-ssl-context.yaml
@@ -14,9 +14,9 @@ rules:
   severity: WARNING
   languages: [java]
   patterns:
-  - pattern-not: SSLContext.getInstance("TLS1.3")
-  - pattern-not: SSLContext.getInstance("TLS1.2")
+  - pattern-not: SSLContext.getInstance("TLSv1.3")
+  - pattern-not: SSLContext.getInstance("TLSv1.2")
   - pattern: SSLContext.getInstance("...")
   fix-regex:
     regex: (.*?)\.getInstance\(.*?\)
-    replacement: \1.getInstance("TLS1.2")
+    replacement: \1.getInstance("TLSv1.2")


### PR DESCRIPTION
The weak `SSLContext` warning would trigger for correct usage, even according to the message in the rule. Also expanded the tests to check all the known weak names.

Ref: https://github.com/openjdk/jdk/blob/2499ac3db5c4a336059263a929031b4eef2d0f0a/src/java.base/share/classes/sun/security/ssl/SunJSSE.java#L97-L108