### PR TITLE
Add JS rule for zlib async in a loop

### DIFF
--- a/javascript/lang/best-practice/zlib-async-loop.js
+++ b/javascript/lang/best-practice/zlib-async-loop.js
@@ -1,0 +1,16 @@
+const zlib = require('zlib');
+
+const payload = Buffer.from('This is some data');
+
+for (let i = 0; i < 30000; ++i) {
+    // ruleid: zlib-async-loop
+    zlib.deflate(payload, (err, buffer) => {});
+}
+
+for (let i = 0; i < 30000; ++i) {
+    // ok: zlib-async-loop
+    zlib.deflateSync(payload);
+}
+
+// ok: zlib-async-loop
+zlib.deflate(payload, (err, buffer) => {});

--- a/javascript/lang/best-practice/zlib-async-loop.js
+++ b/javascript/lang/best-practice/zlib-async-loop.js
@@ -7,6 +7,11 @@ for (let i = 0; i < 30000; ++i) {
     zlib.deflate(payload, (err, buffer) => {});
 }
 
+[1,2,3].forEach((el) => {
+    // ruleid: zlib-async-loop
+    zlib.deflate(payload, (err, buffer) => {});
+})
+
 for (let i = 0; i < 30000; ++i) {
     // ok: zlib-async-loop
     zlib.deflateSync(payload);

--- a/javascript/lang/best-practice/zlib-async-loop.yaml
+++ b/javascript/lang/best-practice/zlib-async-loop.yaml
@@ -1,0 +1,19 @@
+rules:
+- id: zlib-async-loop
+  patterns:
+  - pattern-inside: |
+      for (...) {
+          ...
+      }
+  - pattern: zlib.$METHOD(...);
+  - metavariable-regex:
+      metavariable: $METHOD
+      regex: ^.+$(?<!Sync)
+  message: |
+    Creating and using a large number of zlib objects simultaneously
+    can cause significant memory fragmentation.
+  metadata:
+    references:
+    - https://nodejs.org/api/zlib.html#zlib_threadpool_usage_and_performance_considerations
+  severity: WARNING
+  languages: [js]

--- a/javascript/lang/best-practice/zlib-async-loop.yaml
+++ b/javascript/lang/best-practice/zlib-async-loop.yaml
@@ -28,7 +28,9 @@ rules:
       regex: ^.+$(?<!Sync)
   message: |
     Creating and using a large number of zlib objects simultaneously
-    can cause significant memory fragmentation.
+    can cause significant memory fragmentation. It is strongly recommended
+    that the results of compression operations be cached or made synchronous
+    to avoid duplication of effort.
   metadata:
     references:
     - https://nodejs.org/api/zlib.html#zlib_threadpool_usage_and_performance_considerations

--- a/javascript/lang/best-practice/zlib-async-loop.yaml
+++ b/javascript/lang/best-practice/zlib-async-loop.yaml
@@ -1,10 +1,27 @@
 rules:
 - id: zlib-async-loop
   patterns:
-  - pattern-inside: |
-      for (...) {
-          ...
-      }
+  - pattern-either:
+    - pattern-inside: |
+        for (...) {
+            ...
+        }
+    - pattern-inside: |
+        while (...) {
+            ...
+        }
+    - pattern-inside: |
+        do {
+            ...
+        } while (...)
+    - pattern-inside: |
+        $SMTH.forEach(...)
+    - pattern-inside: |
+        $SMTH.map(...)
+    - pattern-inside: |
+        $SMTH.reduce(...)
+    - pattern-inside: |
+        $SMTH.reduceRight(...)
   - pattern: zlib.$METHOD(...);
   - metavariable-regex:
       metavariable: $METHOD


### PR DESCRIPTION
I was searching the [Node.js docs](https://nodejs.org/api/all.html) for instances of "warning" or "security" to look for new rule ideas, and this was the only thing I found that we don't already have. See here for more information: https://nodejs.org/api/zlib.html#zlib_threadpool_usage_and_performance_considerations. Note the explicit callout of synchronous calls:

> ... except those that are explicitly synchronous ...