### PR TITLE
Add basic docker-compose/k8s OWASP cheat sheet rules

### DIFF
--- a/yaml/docker-compose/security/exposing-docker-socket-volume.test.yaml
+++ b/yaml/docker-compose/security/exposing-docker-socket-volume.test.yaml
@@ -1,0 +1,12 @@
+version: '3.9'
+services:
+  web:
+    image: nginx:alpine
+  worker:
+    image: my-worker-image:latest
+  db:
+    image: mysql
+# ruleid: exposing-docker-socket-volume
+volumes:
+- /tmp/foo:/tmp/foo
+- /var/run/docker.sock:/var/run/docker.sock

--- a/yaml/docker-compose/security/exposing-docker-socket-volume.yaml
+++ b/yaml/docker-compose/security/exposing-docker-socket-volume.yaml
@@ -7,7 +7,8 @@ rules:
   message: |
     Exposing host's Docker socket to containers via a volume. The owner of this
     socket is root. Giving someone access to it is equivalent to giving
-    unrestricted root access to your host. Remove 'docker.sock' from volumes.
+    unrestricted root access to your host. Remove 'docker.sock' from volumes to
+    prevent this.
   metadata:
     references:
     - https://docs.docker.com/compose/compose-file/compose-file-v3/#volume-configuration-reference

--- a/yaml/docker-compose/security/exposing-docker-socket-volume.yaml
+++ b/yaml/docker-compose/security/exposing-docker-socket-volume.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: exposing-docker-socket-volume
+  pattern: |
+    volumes:
+      - ...
+      - /var/run/docker.sock:/var/run/docker.sock
+  message: |
+    Exposing host's Docker socket to containers via a volume. The owner of this
+    socket is root. Giving someone access to it is equivalent to giving
+    unrestricted root access to your host. Remove 'docker.sock' from volumes.
+  metadata:
+    references:
+    - https://docs.docker.com/compose/compose-file/compose-file-v3/#volume-configuration-reference
+    - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
+  languages: [yaml]
+  severity: WARNING

--- a/yaml/docker-compose/security/writable-filesystem-service.test.yaml
+++ b/yaml/docker-compose/security/writable-filesystem-service.test.yaml
@@ -1,0 +1,13 @@
+version: '3.9'
+services:
+  # ruleid: writable-filesystem-service
+  web:
+    image: nginx:alpine
+  # ruleid: writable-filesystem-service
+  worker:
+    image: my-worker-image:latest
+    read_only: false
+  # ok: writable-filesystem-service
+  db:
+    image: mysql
+    read_only: true

--- a/yaml/docker-compose/security/writable-filesystem-service.yaml
+++ b/yaml/docker-compose/security/writable-filesystem-service.yaml
@@ -1,0 +1,30 @@
+rules:
+- id: writable-filesystem-service
+  patterns:
+  - pattern-inside: |
+      services:
+        ...
+  - pattern: |
+      $SERVICE:
+        ...
+        image: ...
+        ...
+  - pattern-not: |
+      $SERVICE:
+        ...
+        image: ...
+        ...
+        read_only: true
+  message: |
+    Service '$SERVICE' is running with a writable root filesystem. This may
+    allow malicious applications to download and run additional payloads, or
+    modify container files. If an application inside a container has to save
+    something temporarily consider using a tmpfs. Add 'read_only: true' to this
+    service to prevent this.
+  metadata:
+    references:
+    - https://docs.docker.com/compose/compose-file/compose-file-v3/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir
+    - https://blog.atomist.com/security-of-docker-kubernetes/
+    - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only
+  languages: [yaml]
+  severity: WARNING

--- a/yaml/kubernetes/security/exposing-docker-socket-hostpath.test.yaml
+++ b/yaml/kubernetes/security/exposing-docker-socket-hostpath.test.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pd
+spec:
+  containers:
+  - image: gcr.io/google_containers/test-webserver
+    name: test-container
+    volumeMounts:
+    - mountPath: /var/run/docker.sock
+      name: docker-sock-volume
+  volumes:
+  - name: docker-sock-volume
+    # ruleid: exposing-docker-socket-hostpath
+    hostPath:
+      type: File
+      path: /var/run/docker.sock

--- a/yaml/kubernetes/security/exposing-docker-socket-hostpath.yaml
+++ b/yaml/kubernetes/security/exposing-docker-socket-hostpath.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: exposing-docker-socket-hostpath
+  patterns:
+  - pattern-inside: |
+      volumes:
+        ...
+  - pattern: |
+      hostPath:
+        ...
+        path: /var/run/docker.sock
+  message: |
+    Container is running with a writable root filesystem. This may
+    allow malicious applications to download and run additional payloads, or
+    modify container files. If an application inside a container has to save
+    something temporarily consider using a tmpfs. Add 'readOnlyRootFilesystem: true'
+    to this container to prevent this.
+  metadata:
+    references:
+    - https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+    - https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+    - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-1-do-not-expose-the-docker-daemon-socket-even-to-the-containers
+  languages: [yaml]
+  severity: WARNING

--- a/yaml/kubernetes/security/exposing-docker-socket-hostpath.yaml
+++ b/yaml/kubernetes/security/exposing-docker-socket-hostpath.yaml
@@ -9,11 +9,10 @@ rules:
         ...
         path: /var/run/docker.sock
   message: |
-    Container is running with a writable root filesystem. This may
-    allow malicious applications to download and run additional payloads, or
-    modify container files. If an application inside a container has to save
-    something temporarily consider using a tmpfs. Add 'readOnlyRootFilesystem: true'
-    to this container to prevent this.
+    Exposing host's Docker socket to containers via a volume. The owner of this
+    socket is root. Giving someone access to it is equivalent to giving
+    unrestricted root access to your host. Remove 'docker.sock' from hostpath to
+    prevent this.
   metadata:
     references:
     - https://kubernetes.io/docs/concepts/storage/volumes/#hostpath

--- a/yaml/kubernetes/security/run-as-non-root.test.yaml
+++ b/yaml/kubernetes/security/run-as-non-root.test.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  # ruleid: run-as-non-root
+  - name: nginx
+    image: nginx
+  # ruleid: run-as-non-root
+  - name: postgres
+    image: postgres
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
+  # ruleid: run-as-non-root
+  - name: redis
+    image: redis
+    securityContext:
+      runAsNonRoot: false
+  # ok: run-as-non-root
+  - name: haproxy
+    image: haproxy
+    securityContext:
+      runAsNonRoot: true

--- a/yaml/kubernetes/security/run-as-non-root.yaml
+++ b/yaml/kubernetes/security/run-as-non-root.yaml
@@ -1,0 +1,26 @@
+rules:
+- id: run-as-non-root
+  patterns:
+  - pattern-inside: |
+      containers:
+        ...
+  - pattern: |
+      image: ...
+      ...
+  - pattern-not: |
+      image: ...
+      ...
+      securityContext:
+        ...
+        runAsNonRoot: true
+  message: |
+    Container allows for running applications as root. This can result in
+    privilege escalation attacks. Add 'runAsNonRoot: true' in 'securityContext'
+    to prevent this.
+  metadata:
+    references:
+    - https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/
+    - https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+    - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user
+  languages: [yaml]
+  severity: WARNING

--- a/yaml/kubernetes/security/writable-filesystem-container.test.yaml
+++ b/yaml/kubernetes/security/writable-filesystem-container.test.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  # ruleid: writable-filesystem-container
+  - name: nginx
+    image: nginx
+  # ruleid: writable-filesystem-container
+  - name: postgres
+    image: postgres
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
+  # ruleid: writable-filesystem-container
+  - name: redis
+    image: redis
+    securityContext:
+      readOnlyRootFilesystem: false
+  # ok: writable-filesystem-container
+  - name: haproxy
+    image: haproxy
+    securityContext:
+      readOnlyRootFilesystem: true

--- a/yaml/kubernetes/security/writable-filesystem-container.yaml
+++ b/yaml/kubernetes/security/writable-filesystem-container.yaml
@@ -1,0 +1,29 @@
+rules:
+- id: writable-filesystem-container
+  patterns:
+  - pattern-inside: |
+      containers:
+        ...
+  - pattern: |
+      image: ...
+      ...
+  - pattern-not: |
+      image: ...
+      ...
+      securityContext:
+        ...
+        readOnlyRootFilesystem: true
+  message: |
+    Container is running with a writable root filesystem. This may
+    allow malicious applications to download and run additional payloads, or
+    modify container files. If an application inside a container has to save
+    something temporarily consider using a tmpfs. Add 'readOnlyRootFilesystem: true'
+    to this container to prevent this.
+  metadata:
+    references:
+    - https://kubernetes.io/docs/concepts/policy/pod-security-policy/#volumes-and-file-systems
+    - https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+    - https://blog.atomist.com/security-of-docker-kubernetes/
+    - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-8-set-filesystem-and-volumes-to-read-only
+  languages: [yaml]
+  severity: WARNING


### PR DESCRIPTION
Fixes #1162.

This doesn't have everything from [here](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html), but it's a good start for high signal/low noise findings that can easily be detected statically. The following rules from that cheat sheet are covered: 1, 2, 4, 6, 8.