### PR TITLE
Update target repos for benchmarking for typescript, generic, none/regex, and php

### DIFF
--- a/tests/performance/.test_public_repos.yaml
+++ b/tests/performance/.test_public_repos.yaml
@@ -16,3 +16,18 @@ javascript:
 c:
 - url: https://github.com/zlib-ng/zlib-ng
   commit: c71ca170224f31a219513aa470f82aa50a3ded48
+typesript:
+- url: https://github.com/apollographql/apollo-client
+  commit: 44b5415aa1eee8db20145827744a54a591d9e0e7
+generic:
+- url: https://github.com/theNewDynamic/gohugo-theme-ananke
+  commit: 8845854aa9ab5af79066e840d8c884fbbb8a269d
+none:
+- url: https://github.com/theNewDynamic/gohugo-theme-ananke
+  commit: 8845854aa9ab5af79066e840d8c884fbbb8a269d
+regex:
+- url: https://github.com/theNewDynamic/gohugo-theme-ananke
+  commit: 8845854aa9ab5af79066e840d8c884fbbb8a269d
+php:
+- url: https://github.com/laravel/laravel
+  commit: 5808129a1f702f973c7c31203d16db2066bd9030


### PR DESCRIPTION
We were still testing some of the `typescript` rules because they also run as JS. This explicitly tests the `typescript` rules on `typescript` now.
Also adds new testing for `generic` and `none`/`regex` rules