### PR TITLE
Speed up a few JS and TS rules

### DIFF
--- a/javascript/lang/security/detect-child-process.yaml
+++ b/javascript/lang/security/detect-child-process.yaml
@@ -8,23 +8,16 @@ rules:
     Detected non-literal calls to $EXEC(). This could lead to a command
     injection vulnerability.
   patterns:
-  - pattern: |
-      $EXEC($CMD,...)
-  - pattern-not: |
-      $EXEC("...",...)
+  - pattern-either:
+    - pattern: exec($CMD,...)
+    - pattern: execSync($CMD,...)
+    - pattern: spawn($CMD,...)
+    - pattern: spawnSync($CMD,...)
+  - pattern-not-inside: $EXEC("...",...)
   - pattern-not-inside: |
       $CMD = "..."
       ...
-  - pattern-either:
-    - pattern-inside: |
-        require('child_process')
-        ...
-    - pattern-inside: |
-        import 'child_process'
-        ...
-  - metavariable-regex:
-      metavariable: $EXEC
-      regex: (.*)(exec|spawn|spawnSync|execSync)
+      $EXEC($CMD, ...)
   severity: WARNING
   languages:
   - javascript

--- a/javascript/lang/security/detect-eval-with-expression.yaml
+++ b/javascript/lang/security/detect-eval-with-expression.yaml
@@ -19,6 +19,7 @@ rules:
   - pattern-not-inside: |
       $OBJ = "..."
       ...
+      $SOMETHING(..., $OBJ, ...)
   severity: WARNING
   languages:
   - javascript

--- a/typescript/react/security/react-insecure-request.yaml
+++ b/typescript/react/security/react-insecure-request.yaml
@@ -7,29 +7,42 @@ rules:
         - pattern-inside: |
             import $AXIOS from 'axios';
             ...
+            $AXIOS.$METHOD(...)
         - pattern-inside: |
             $AXIOS = require('axios');
             ...
+            $AXIOS.$METHOD(...)
       - pattern-either:
-        - pattern: $AXIOS.$METHOD($URL,...)
-        - pattern: |
-            $VAR = $URL;
+        - pattern: $AXIOS.get("=~/[Hh][Tt][Tt][Pp]:\/\/.*/",...)
+        - pattern: $AXIOS.post("=~/[Hh][Tt][Tt][Pp]:\/\/.*/",...)
+        - pattern: $AXIOS.delete("=~/[Hh][Tt][Tt][Pp]:\/\/.*/",...)
+        - pattern: $AXIOS.head("=~/[Hh][Tt][Tt][Pp]:\/\/.*/",...)
+        - pattern: $AXIOS.patch("=~/[Hh][Tt][Tt][Pp]:\/\/.*/",...)
+        - pattern: $AXIOS.put("=~/[Hh][Tt][Tt][Pp]:\/\/.*/",...)
+        - pattern: $AXIOS.options("=~/[Hh][Tt][Tt][Pp]:\/\/.*/",...)
+    - patterns:
+      - pattern-either:
+        - pattern-inside: |
+            import $AXIOS from 'axios';
             ...
-            $AXIOS.$METHOD($VAR,...);
-        - pattern: |
-            $AXIOS({url: $URL},...)
-        - pattern: |
-            $VAR = {url: $URL};
+            $AXIOS(...)
+        - pattern-inside: |
+            $AXIOS = require('axios');
             ...
-            $AXIOS($VAR,...);
-    - pattern: fetch($URL,...)
-    - pattern: |
-        $VAR = $URL;
-        ...
-        fetch($VAR,...);
-  - metavariable-regex:
-      metavariable: $URL
-      regex: "[\"'](http://).*['\"]"
+            $AXIOS(...)
+      - pattern-either:
+        - pattern: '$AXIOS({url: "=~/[Hh][Tt][Tt][Pp]:\/\/.*/"}, ...)'
+        - pattern: |
+            $OPTS = {url: "=~/[Hh][Tt][Tt][Pp]:\/\/.*/"}
+            ...
+            $AXIOS($OPTS, ...)
+    - patterns:
+      - pattern-either:
+        - pattern: fetch("=~/[Hh][Tt][Tt][Pp]:\/\/.*/", ...)
+        - pattern: |
+            $VAR = "=~/[Hh][Tt][Tt][Pp]:\/\/.*/"
+            ...
+            fetch($VAR, ...)
   message: |
     Unencrypted request over HTTP detected.
   metadata:


### PR DESCRIPTION
Tried to limit the number of patterns that look like:
```
import $SOMETHING
...
```

and

```
$LIB.$METHOD(...)
```