### PR TITLE
Fix FPs in route_var poritions of Flask injection rules

### DIFF
--- a/python/flask/security/injection/os-system-injection.py
+++ b/python/flask/security/injection/os-system-injection.py
@@ -10,6 +10,12 @@ def route_param(route_param):
     # ruleid: os-system-injection
     return os.system(route_param)
 
+@app.route("/route_param_ok/<route_param>")
+def route_param_ok(route_param):
+    print("blah")
+    # ok: os-system-injection
+    return os.system("ls -la")
+
 @app.route("/route_param_concat/<route_param>")
 def route_param_concat(route_param):
     print("blah")

--- a/python/flask/security/injection/os-system-injection.yaml
+++ b/python/flask/security/injection/os-system-injection.yaml
@@ -14,16 +14,20 @@ rules:
   patterns:
   - pattern-either:
     - patterns:
-      - pattern-inside: |
-          @$APP.route($ROUTE, ...)
-          def $FUNC(..., $ROUTEVAR, ...):
-            ...
+      - pattern: os.system(...)
       - pattern-either:
-        - pattern: os.system(..., <... $ROUTEVAR ...>, ...)
-        - pattern: |
-            $INTERM = <... $ROUTEVAR ...>
-            ...
-            os.system(..., <... $INTERM ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              os.system(..., <... $ROUTEVAR ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              $INTERM = <... $ROUTEVAR ...>
+              ...
+              os.system(..., <... $INTERM ...>, ...)
     - patterns:
       - pattern-either:
         - pattern: os.system(..., <... flask.request.$W.get(...) ...>, ...)

--- a/python/flask/security/injection/path-traversal-open.py
+++ b/python/flask/security/injection/path-traversal-open.py
@@ -9,11 +9,24 @@ def route_param(route_param):
     # ruleid: path-traversal-open
     return open(route_param, 'r').read()
 
+@app.route("/route_param_ok/<route_param>")
+def route_param_ok(route_param):
+    print("blah")
+    # ok: path-traversal-open
+    return open("this is safe", 'r').read()
+
 @app.route("/route_param_with/<route_param>")
 def route_param_with(route_param):
     print("blah")
     # ruleid: path-traversal-open
     with open(route_param, 'r') as fout:
+        return fout.read()
+
+@app.route("/route_param_with_ok/<route_param>")
+def route_param_with_ok(route_param):
+    print("blah")
+    # ok: path-traversal-open
+    with open("this is safe", 'r') as fout:
         return fout.read()
 
 @app.route("/route_param_with_concat/<route_param>")

--- a/python/flask/security/injection/path-traversal-open.yaml
+++ b/python/flask/security/injection/path-traversal-open.yaml
@@ -14,16 +14,26 @@ rules:
   patterns:
   - pattern-either:
     - patterns:
-      - pattern-inside: |
-          @$APP.route($ROUTE, ...)
-          def $FUNC(..., $ROUTEVAR, ...):
-            ...
+      - pattern: open(...)
       - pattern-either:
-        - pattern: open(..., <... $ROUTEVAR ...>, ...)
-        - pattern: |
-            $INTERM = <... $ROUTEVAR ...>
-            ...
-            open(..., <... $INTERM ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              open(..., <... $ROUTEVAR ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              with open(..., <... $ROUTEVAR ...>, ...) as $FD:
+                ...
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              $INTERM = <... $ROUTEVAR ...>
+              ...
+              open(..., <... $INTERM ...>, ...)
     - patterns:
       - pattern-either:
         - pattern: open(..., <... flask.request.$W.get(...) ...>, ...)

--- a/python/flask/security/injection/ssrf-requests.py
+++ b/python/flask/security/injection/ssrf-requests.py
@@ -9,11 +9,23 @@ def route_param(route_param):
     # ruleid: ssrf-requests
     return requests.get(route_param)
 
+@app.route("/route_param_ok/<route_param>")
+def route_param_ok(route_param):
+    print("blah")
+    # ok: ssrf-requests
+    return requests.get("this is safe")
+
 @app.route("/get_param", methods=["GET"])
 def get_param():
     param = flask.request.args.get("param")
     # ruleid: ssrf-requests
     requests.post(param, timeout=10)
+
+@app.route("/get_param_ok", methods=["GET"])
+def get_param_ok():
+    param = flask.request.args.get("param")
+    # ok: ssrf-requests
+    requests.post("this is safe", timeout=10)
 
 @app.route("/get_param_inline_concat", methods=["GET"])
 def get_param_inline_concat():

--- a/python/flask/security/injection/ssrf-requests.yaml
+++ b/python/flask/security/injection/ssrf-requests.yaml
@@ -4,8 +4,8 @@ rules:
   - python
   severity: ERROR
   message: Data from request object is passed to a new server-side request. This could lead to a server-side request forgery
-    (SSRF). To mitigate, ensure that schemes and hosts are validated against an allowlist, do not forward the response to the
-    user, and ensure proper authentication and transport-layer security in the proxied request.
+    (SSRF). To mitigate, ensure that schemes and hosts are validated against an allowlist, do not forward the response to
+    the user, and ensure proper authentication and transport-layer security in the proxied request.
   metadata:
     cwe: 'CWE-918: Server-Side Request Forgery (SSRF)'
     owasp: 'A1: Injection'
@@ -14,16 +14,22 @@ rules:
   patterns:
   - pattern-either:
     - patterns:
-      - pattern-inside: |
-          @$APP.route($ROUTE, ...)
-          def $ROUTE_FUNC(..., $ROUTEVAR, ...):
-            ...
+      # Written this way so that Semgrep only matches the requests call,
+      # not the whole function def
+      - pattern: requests.$FUNC(...)
       - pattern-either:
-        - pattern: requests.$FUNC(..., <... $ROUTEVAR ...>, ...)
-        - pattern: |
-            $INTERM = <... $ROUTEVAR ...>
-            ...
-            requests.$FUNC(..., <... $INTERM ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $ROUTE_FUNC(..., $ROUTEVAR, ...):
+              ...
+              requests.$FUNC(..., <... $ROUTEVAR ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $ROUTE_FUNC(..., $ROUTEVAR, ...):
+              ...
+              $INTERM = <... $ROUTEVAR ...>
+              ...
+              requests.$FUNC(..., <... $INTERM ...>, ...)
     - patterns:
       - pattern-either:
         - pattern: requests.$FUNC(..., <... flask.request.$W.get(...) ...>, ...)

--- a/python/flask/security/injection/user-eval.py
+++ b/python/flask/security/injection/user-eval.py
@@ -8,11 +8,23 @@ def route_param(route_param):
     # ruleid: eval-injection
     return eval(route_param)
 
+@app.route("/route_param/<route_param>")
+def route_param(route_param):
+    print("blah")
+    # ok: eval-injection
+    return eval("this is safe")
+
 @app.route("/get_param", methods=["GET"])
 def get_param():
     param = flask.request.args.get("param")
     # ruleid: eval-injection
     eval(param)
+
+@app.route("/get_param", methods=["GET"])
+def get_param():
+    param = flask.request.args.get("param")
+    # ok: eval-injection
+    eval("this is safe")
 
 @app.route("/get_param_inline_concat", methods=["GET"])
 def get_param_inline_concat():

--- a/python/flask/security/injection/user-eval.yaml
+++ b/python/flask/security/injection/user-eval.yaml
@@ -12,16 +12,20 @@ rules:
   patterns:
   - pattern-either:
     - patterns:
-      - pattern-inside: |
-          @$APP.route($ROUTE, ...)
-          def $FUNC(..., $ROUTEVAR, ...):
-            ...
+      - pattern: eval(...)
       - pattern-either:
-        - pattern: eval(..., <... $ROUTEVAR ...>, ...)
-        - pattern: |
-            $INTERM = <... $ROUTEVAR ...>
-            ...
-            eval(..., <... $INTERM ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              eval(..., <... $ROUTEVAR ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              $INTERM = <... $ROUTEVAR ...>
+              ...
+              eval(..., <... $INTERM ...>, ...)
     - patterns:
       - pattern-either:
         - pattern: eval(..., <... flask.request.$W.get(...) ...>, ...)

--- a/python/flask/security/injection/user-exec.py
+++ b/python/flask/security/injection/user-exec.py
@@ -8,11 +8,23 @@ def route_param(route_param):
     # ruleid: exec-injection
     return exec(route_param)
 
+@app.route("/route_param_ok/<route_param>")
+def route_param_ok(route_param):
+    print("blah")
+    # ok: exec-injection
+    return exec("this is safe")
+
 @app.route("/get_param", methods=["GET"])
 def get_param():
     param = flask.request.args.get("param")
     # ruleid: exec-injection
     exec(param)
+
+@app.route("/get_param_ok", methods=["GET"])
+def get_param_ok():
+    param = flask.request.args.get("param")
+    # ok: exec-injection
+    exec("this is safe")
 
 @app.route("/get_param_inline_concat", methods=["GET"])
 def get_param_inline_concat():

--- a/python/flask/security/injection/user-exec.yaml
+++ b/python/flask/security/injection/user-exec.yaml
@@ -12,16 +12,20 @@ rules:
   patterns:
   - pattern-either:
     - patterns:
-      - pattern-inside: |
-          @$APP.route($ROUTE, ...)
-          def $FUNC(..., $ROUTEVAR, ...):
-            ...
+      - pattern: exec(...)
       - pattern-either:
-        - pattern: exec(..., <... $ROUTEVAR ...>, ...)
-        - pattern: |
-            $INTERM = <... $ROUTEVAR ...>
-            ...
-            exec(..., <... $INTERM ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              exec(..., <... $ROUTEVAR ...>, ...)
+        - pattern-inside: |
+            @$APP.route($ROUTE, ...)
+            def $FUNC(..., $ROUTEVAR, ...):
+              ...
+              $INTERM = <... $ROUTEVAR ...>
+              ...
+              exec(..., <... $INTERM ...>, ...)
     - patterns:
       - pattern-either:
         - pattern: exec(..., <... flask.request.$W.get(...) ...>, ...)


### PR DESCRIPTION
This is due to a bug where metavariables are not propagating properly with deep expression operators.

This refactors the rules to put the route definition and the sink in the same pattern clause to get around this issue.