### PR TITLE
go database/sql sqli rule

### DIFF
--- a/go/lang/security/audit/sqli/gosql-sqli.go
+++ b/go/lang/security/audit/sqli/gosql-sqli.go
@@ -1,75 +1,72 @@
-package main
+ipackage main
 
 import "database/sql"
 import "fmt"
 
-func setup() {
+func bad1() {
     db, err := sql.Open("mysql", "theUser:thePassword@/theDbName")
     if err != nil {
         panic(err)
     }
-}
-
-func bad1() {
     query = "SELECT name FROM users WHERE age=" + req.FormValue("age")
     // ruleid: gosql-sqli
     db.Query(query)
 }
 
-func bad2() {
+func bad2(db *sql.DB) {
     query = "SELECT name FROM users WHERE age="
     query += req.FormValue("age")
     // ruleid: gosql-sqli
     db.QueryRow(query)
 }
 
-func bad3() {
+func bad3(db *sql.DB) {
     query = fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email)
     // ruleid: gosql-sqli
     db.Exec(query)
 }
 
-func bad4() {
+func bad4(db *sql.DB) {
     // ruleid: gosql-sqli
     db.Exec("SELECT name FROM users WHERE age=" + req.FormValue("age"))
 }
 
-func bad5() {
+func bad5(db *sql.DB) {
     // ruleid: gosql-sqli
     db.Exec(fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email))
 }
 
-func ok1() {
+func ok1(db *sql.DB) {
     query = fmt.Sprintf("SELECT * FROM users WHERE email=hello;")
     // ok: gosql-sqli
     db.Exec(query)
 }
 
-func ok2() {
+func ok2(db *sql.DB) {
     query = "SELECT name FROM users WHERE age=" + "3"
     // ok: gosql-sqli
     db.Query(query)
 }
 
-func ok3() {
+func ok3(db *sql.DB) {
     query = "SELECT name FROM users WHERE age="
     query += "3"
     // ok: gosql-sqli
     db.Query(query)
 }
 
-func ok4() {
+func ok4(db *sql.DB) {
     // ok: gosql-sqli
     db.Exec("INSERT INTO users(name, email) VALUES($1, $2)",
   "Jon Calhoun", "jon@calhoun.io")
 }
 
-func ok5() {
+func ok5(db *sql.DB) {
     // ok: gosql-sqli
     db.Exec("SELECT name FROM users WHERE age=" + "3")
 }
 
-func ok6() {
+func ok6(db *sql.DB) {
     // ok: gosql-sqli
     db.Exec(fmt.Sprintf("SELECT * FROM users WHERE email=hello;"))
 }

--- a/go/lang/security/audit/sqli/gosql-sqli.go
+++ b/go/lang/security/audit/sqli/gosql-sqli.go
@@ -1,4 +1,4 @@
-ipackage main
+package main
 
 import "database/sql"
 import "fmt"

--- a/go/lang/security/audit/sqli/gosql-sqli.go
+++ b/go/lang/security/audit/sqli/gosql-sqli.go
@@ -1,0 +1,75 @@
+package main
+
+import "database/sql"
+import "fmt"
+
+func setup() {
+    db, err := sql.Open("mysql", "theUser:thePassword@/theDbName")
+    if err != nil {
+        panic(err)
+    }
+}
+
+func bad1() {
+    query = "SELECT name FROM users WHERE age=" + req.FormValue("age")
+    // ruleid: gosql-sqli
+    db.Query(query)
+}
+
+func bad2() {
+    query = "SELECT name FROM users WHERE age="
+    query += req.FormValue("age")
+    // ruleid: gosql-sqli
+    db.QueryRow(query)
+}
+
+func bad3() {
+    query = fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email)
+    // ruleid: gosql-sqli
+    db.Exec(query)
+}
+
+func bad4() {
+    // ruleid: gosql-sqli
+    db.Exec("SELECT name FROM users WHERE age=" + req.FormValue("age"))
+}
+
+func bad5() {
+    // ruleid: gosql-sqli
+    db.Exec(fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email))
+}
+
+func ok1() {
+    query = fmt.Sprintf("SELECT * FROM users WHERE email=hello;")
+    // ok: gosql-sqli
+    db.Exec(query)
+}
+
+func ok2() {
+    query = "SELECT name FROM users WHERE age=" + "3"
+    // ok: gosql-sqli
+    db.Query(query)
+}
+
+func ok3() {
+    query = "SELECT name FROM users WHERE age="
+    query += "3"
+    // ok: gosql-sqli
+    db.Query(query)
+}
+
+func ok4() {
+    // ok: gosql-sqli
+    db.Exec("INSERT INTO users(name, email) VALUES($1, $2)",
+  "Jon Calhoun", "jon@calhoun.io")
+}
+
+func ok5() {
+    // ok: gosql-sqli
+    db.Exec("SELECT name FROM users WHERE age=" + "3")
+}
+
+func ok6() {
+    // ok: gosql-sqli
+    db.Exec(fmt.Sprintf("SELECT * FROM users WHERE email=hello;"))
+}

--- a/go/lang/security/audit/sqli/gosql-sqli.yaml
+++ b/go/lang/security/audit/sqli/gosql-sqli.yaml
@@ -24,6 +24,14 @@ rules:
           ...
     - pattern: $DB.$METHOD(..., $X + $Y, ...)
     - pattern: $DB.$METHOD(..., fmt.Sprintf("...", $PARAM1, ...), ...)
+  - pattern-either:
+    - pattern-inside: |
+        $DB, ... = sql.Open(...)
+        ...
+    - pattern-inside: |
+        func $FUNCNAME(..., $DB *sql.DB, ...) {
+          ...
+        }
   - pattern-not: $DB.$METHOD(..., "..." + "...", ...)
   - metavariable-regex:
       metavariable: $METHOD
@@ -34,6 +42,9 @@ rules:
     Detected string concatenation with a non-literal variable in a "database/sql"
     Go SQL statement. This could lead to SQL injection if the variable is user-controlled
     and not properly sanitized. In order to prevent SQL injection,
-    used parameterized queries instead. For postgresql, this is of the form
-    db.Exec("SELECT $1 FROM table", val1).
+    used parameterized queries instead or prepared statements instead.
+    You can use prepared statements with the 'Prepare' and 'PrepareContext' calls.
+  metadata:
+    references:
+    - https://golang.org/pkg/database/sql/
   severity: WARNING

--- a/go/lang/security/audit/sqli/gosql-sqli.yaml
+++ b/go/lang/security/audit/sqli/gosql-sqli.yaml
@@ -1,0 +1,39 @@
+rules:
+- id: gosql-sqli
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            $DB.$METHOD(...,$QUERY,...)
+      - pattern-either:
+        - pattern-inside: |
+            $QUERY = $X + $Y
+            ...
+        - pattern-inside: |
+            $QUERY += $X
+            ...
+        - pattern-inside: |
+            $QUERY = fmt.Sprintf("...", $PARAM1, ...)
+            ...
+      - pattern-not-inside: |
+          $QUERY += "..."
+          ...
+      - pattern-not-inside: |
+          $QUERY = "..." + "..."
+          ...
+    - pattern: $DB.$METHOD(..., $X + $Y, ...)
+    - pattern: $DB.$METHOD(..., fmt.Sprintf("...", $PARAM1, ...), ...)
+  - pattern-not: $DB.$METHOD(..., "..." + "...", ...)
+  - metavariable-regex:
+      metavariable: $METHOD
+      regex: ^(Exec|ExecContent|Query|QueryContext|QueryRow|QueryRowContext)$
+  languages:
+  - go
+  message: |
+    Detected string concatenation with a non-literal variable in a "database/sql"
+    Go SQL statement. This could lead to SQL injection if the variable is user-controlled
+    and not properly sanitized. In order to prevent SQL injection,
+    used parameterized queries instead. For postgresql, this is of the form
+    db.Exec("SELECT $1 FROM table", val1).
+  severity: WARNING

--- a/go/lang/security/audit/sqli/pg-orm-sqli.go
+++ b/go/lang/security/audit/sqli/pg-orm-sqli.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+    "fmt"
+
+    "github.com/go-pg/pg/v10"
+    "github.com/go-pg/pg/v10/orm"
+)
+
+func bad1() {
+    db := pg.Connect(&pg.Options{
+        Addr:     ":5432",
+        User:     "user",
+        Password: "pass",
+        Database: "db_name",
+    })
+    query = "SELECT name FROM users WHERE age=" + req.FormValue("age")
+    // ruleid: pg-sqli
+    err := db.Model(book).
+        Where("id > ?", 100).
+        WhereOr(query).
+        Limit(1).
+        Select()
+}
+
+func bad2() {
+    db := pg.Connect(opt)
+    query = fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email)
+    story := new(Story)
+    // ruleid: pg-sqli
+    err = db.Model(story).
+        Relation("Author").
+        From("Hello").
+        Where("SELECT name FROM users WHERE age=" + req.FormValue("age")).
+        Select()
+    if err != nil {
+        panic(err)
+    }
+}
+
+func bad3() {
+   opt, err := pg.ParseURL("postgres://user:pass@localhost:5432/db_name")
+    if err != nil {
+        panic(err)
+    }
+
+    db := pg.Connect(opt)
+
+    query = "SELECT name FROM users WHERE age="
+    query += req.FormValue("age")
+    // ruleid: pg-sqli
+    err := db.Model(book).
+    Where(query).
+    WhereGroup(func(q *pg.Query) (*pg.Query, error) {
+        q = q.WhereOr("id = 1").
+            WhereOr("id = 2")
+        return q, nil
+    }).
+    Limit(1).
+    Select()
+}
+
+func bad4(db *pg.DB) {
+    query = fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email)
+    // ruleid: pg-sqli
+    err := db.Model((*Book)(nil)).
+    Column("author_id").
+    ColumnExpr(query).
+    Group("author_id").
+    Order("book_count DESC").
+    Select(&res)
+}
+
+func bad5(db *pg.DB) {
+    // ruleid: pg-sqli
+    err = db.Model((*Book)(nil)).
+    Column("title", "text").
+    Where("SELECT name FROM users WHERE age=" + req.FormValue("age")).
+    Select()
+}
+
+func bad6(db *pg.DB) {
+    // ruleid: pg-sqli
+    err = db.Model((*Book)(nil)).
+    Column("title", "text").
+    Where(fmt.Sprintf("SELECT * FROM users WHERE email='%s';",    email)).
+    Select()
+}
+
+func ok1(db *pg.DB) {
+    query = fmt.Sprintf("SELECT * FROM users WHERE email=hello;")
+    // ok: pg-sqli
+    err = db.Model((*Book)(nil)).
+    Column("title", "text").
+    Where(query).
+    Select()
+}
+
+func ok2(db *pg.DB) {
+    query = "SELECT name FROM users WHERE age=" + "3"
+    // ok: pg-sqli
+    err = db.Model((*Book)(nil)).
+    Column("title", "text").
+    ColumnExpr(query).
+    Select()
+}
+
+func ok3(db *pg.DB) {
+    query = "SELECT name FROM users WHERE age="
+    query += "3"
+    // ok: pg-sqli
+    err = db.Model((*Book)(nil)).
+    Column("title", "text").
+    Where(query).
+    Select()
+}
+
+func ok4(db *pg.DB) {
+    // ok: pg-sqli
+    err := db.Model((*Book)(nil)).
+    Column("title", "text").
+    Where("id = ?", 1).
+    Select(&title, &text)
+}
+
+func ok5(db *pg.DB) {
+    // ok: pg-sqli
+    err := db.Model((*Book)(nil)).
+    Column("title", "text").
+    Where("SELECT name FROM users WHERE age=" + "3").
+    Select(&title, &text)
+}
+
+func ok6(db *pg.DB) {
+    // ok: pg-sqli
+    err := db.Model().
+    ColumnExpr(fmt.Sprintf("SELECT * FROM users WHERE email=hello;"))
+}

--- a/go/lang/security/audit/sqli/pg-orm-sqli.go
+++ b/go/lang/security/audit/sqli/pg-orm-sqli.go
@@ -15,7 +15,7 @@ func bad1() {
         Database: "db_name",
     })
     query = "SELECT name FROM users WHERE age=" + req.FormValue("age")
-    // ruleid: pg-sqli
+    // ruleid: pg-orm-sqli
     err := db.Model(book).
         Where("id > ?", 100).
         WhereOr(query).
@@ -27,7 +27,7 @@ func bad2() {
     db := pg.Connect(opt)
     query = fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email)
     story := new(Story)
-    // ruleid: pg-sqli
+    // ruleid: pg-orm-sqli
     err = db.Model(story).
         Relation("Author").
         From("Hello").
@@ -48,7 +48,7 @@ func bad3() {
 
     query = "SELECT name FROM users WHERE age="
     query += req.FormValue("age")
-    // ruleid: pg-sqli
+    // ruleid: pg-orm-sqli
     err := db.Model(book).
     Where(query).
     WhereGroup(func(q *pg.Query) (*pg.Query, error) {
@@ -62,7 +62,7 @@ func bad3() {
 
 func bad4(db *pg.DB) {
     query = fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email)
-    // ruleid: pg-sqli
+    // ruleid: pg-orm-sqli
     err := db.Model((*Book)(nil)).
     Column("author_id").
     ColumnExpr(query).
@@ -72,7 +72,7 @@ func bad4(db *pg.DB) {
 }
 
 func bad5(db *pg.DB) {
-    // ruleid: pg-sqli
+    // ruleid: pg-orm-sqli
     err = db.Model((*Book)(nil)).
     Column("title", "text").
     Where("SELECT name FROM users WHERE age=" + req.FormValue("age")).
@@ -80,7 +80,7 @@ func bad5(db *pg.DB) {
 }
 
 func bad6(db *pg.DB) {
-    // ruleid: pg-sqli
+    // ruleid: pg-orm-sqli
     err = db.Model((*Book)(nil)).
     Column("title", "text").
     Where(fmt.Sprintf("SELECT * FROM users WHERE email='%s';",    email)).
@@ -89,7 +89,7 @@ func bad6(db *pg.DB) {
 
 func ok1(db *pg.DB) {
     query = fmt.Sprintf("SELECT * FROM users WHERE email=hello;")
-    // ok: pg-sqli
+    // ok: pg-orm-sqli
     err = db.Model((*Book)(nil)).
     Column("title", "text").
     Where(query).
@@ -98,7 +98,7 @@ func ok1(db *pg.DB) {
 
 func ok2(db *pg.DB) {
     query = "SELECT name FROM users WHERE age=" + "3"
-    // ok: pg-sqli
+    // ok: pg-orm-sqli
     err = db.Model((*Book)(nil)).
     Column("title", "text").
     ColumnExpr(query).
@@ -108,7 +108,7 @@ func ok2(db *pg.DB) {
 func ok3(db *pg.DB) {
     query = "SELECT name FROM users WHERE age="
     query += "3"
-    // ok: pg-sqli
+    // ok: pg-orm-sqli
     err = db.Model((*Book)(nil)).
     Column("title", "text").
     Where(query).
@@ -116,7 +116,7 @@ func ok3(db *pg.DB) {
 }
 
 func ok4(db *pg.DB) {
-    // ok: pg-sqli
+    // ok: pg-orm-sqli
     err := db.Model((*Book)(nil)).
     Column("title", "text").
     Where("id = ?", 1).
@@ -124,7 +124,7 @@ func ok4(db *pg.DB) {
 }
 
 func ok5(db *pg.DB) {
-    // ok: pg-sqli
+    // ok: pg-orm-sqli
     err := db.Model((*Book)(nil)).
     Column("title", "text").
     Where("SELECT name FROM users WHERE age=" + "3").
@@ -132,7 +132,7 @@ func ok5(db *pg.DB) {
 }
 
 func ok6(db *pg.DB) {
-    // ok: pg-sqli
+    // ok: pg-orm-sqli
     err := db.Model().
     ColumnExpr(fmt.Sprintf("SELECT * FROM users WHERE email=hello;"))
 }

--- a/go/lang/security/audit/sqli/pg-orm-sqli.yaml
+++ b/go/lang/security/audit/sqli/pg-orm-sqli.yaml
@@ -1,0 +1,52 @@
+rules:
+- id: pg-orm-sqli
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            $DB.$METHOD(...,$QUERY,...)
+      - pattern-either:
+        - pattern-inside: |
+            $QUERY = $X + $Y
+            ...
+        - pattern-inside: |
+            $QUERY += $X
+            ...
+        - pattern-inside: |
+            $QUERY = fmt.Sprintf("...", $PARAM1, ...)
+            ...
+      - pattern-not-inside: |
+          $QUERY += "..."
+          ...
+      - pattern-not-inside: |
+          $QUERY = "..." + "..."
+          ...
+    - pattern: |
+        $DB.$INTFUNC1(...).$METHOD(..., $X + $Y, ...).$INTFUNC2(...)
+    - pattern: |
+        $DB.$METHOD(..., fmt.Sprintf("...", $PARAM1, ...), ...)
+    - pattern-inside: |
+        $DB = pg.Connect(...)
+        ...
+    - pattern-inside: |
+        func $FUNCNAME(..., $DB *pg.DB, ...) {
+          ...
+        }
+  - pattern-not: |
+      $DB.$INTFUNC1(...).$METHOD(..., "..." + "...", ...).$INTFUNC2(...)
+  - metavariable-regex:
+      metavariable: $METHOD
+      regex: ^(Where|WhereOr|Join|GroupExpr|OrderExpr|ColumnExpr)$
+  languages:
+  - go
+  message: |
+    Detected string concatenation with a non-literal variable in a go-pg ORM
+    SQL statement. This could lead to SQL injection if the variable is user-controlled
+    and not properly sanitized. In order to prevent SQL injection,
+    do not use strings concatenated with user-controlled input.
+    Instead, use parameterized statements.
+  metadata:
+    references:
+    - https://pg.uptrace.dev/queries/
+  severity: WARNING

--- a/go/lang/security/audit/sqli/pgx-sqli.go
+++ b/go/lang/security/audit/sqli/pgx-sqli.go
@@ -1,0 +1,121 @@
+package main
+
+import "database/sql"
+import "fmt"
+
+func bad1() {
+    pgxConfig := pgx.ConnConfig{
+        Host:     "localhost",
+        Database: "quetest",
+        User:     "quetest",
+    }
+    pgxConnPoolConfig := pgx.ConnPoolConfig{pgxConfig, 3, nil}
+    conn, err := pgx.NewConnPool(pgxConnPoolConfig)
+    if err != nil {
+        log.Fatal(err)
+    }
+    query = "SELECT name FROM users WHERE age=" + req.FormValue("age")
+    // ruleid: pgx-sqli
+    rows, err := conn.Query(query)
+}
+
+func bad2() {
+    conn, err := pgx.Connect(context.Background(), os.Getenv("DATABASE_URL"))
+    if err != nil {
+        panic(err)
+    }
+    query = "SELECT name FROM users WHERE age=" + req.FormValue("age")
+    // ruleid: pgx-sqli
+    conn.QueryEx(query)
+}
+
+func bad3() {
+    config, err := pgx.ParseConfig(os.Getenv("DATABASE_URL"))
+    if err != nil {
+       panic(err)
+    }
+    config.Logger = log15adapter.NewLogger(log.New("module", "pgx"))
+
+    conn, err := pgx.ConnectConfig(context.Background(), config)
+
+    query = "SELECT name FROM users WHERE age="
+    query += req.FormValue("age")
+    // ruleid: pgx-sqli
+    conn.QueryRow(query)
+}
+
+func bad4(conn *pgx.Conn) {
+    query = fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email)
+    // ruleid: pgx-sqli
+    conn.Exec(query)
+}
+
+func bad4(conn *pgx.Conn) {
+    // ruleid: pgx-sqli
+    conn.Exec("SELECT name FROM users WHERE age=" + req.FormValue("age"))
+}
+
+func bad5(conn *pgx.Conn) {
+    // ruleid: pgx-sqli
+    conn.ExecEx(fmt.Sprintf("SELECT * FROM users WHERE email='%s';", email))
+}
+
+func ok1(conn *pgx.Conn) {
+    query = fmt.Sprintf("SELECT * FROM users WHERE email=hello;")
+    // ok: pgx-sqli
+    conn.QueryRowEx(query)
+}
+
+func ok2(conn *pgx.Conn) {
+    query = "SELECT name FROM users WHERE age=" + "3"
+    // ok: pgx-sqli
+    conn.Query(query)
+}
+
+func ok3(conn *pgx.Conn) {
+    query = "SELECT name FROM users WHERE age="
+    query += "3"
+    // ok: pgx-sqli
+    conn.QueryRow(query)
+}
+
+func ok4(conn *pgx.Conn) {
+    // ok: pgx-sqli
+    conn.Exec("INSERT INTO users(name, email) VALUES($1, $2)",
+  "Jon Calhoun", "jon@calhoun.io")
+}
+
+func ok5(conn *pgx.Conn) {
+    // ok: pgx-sqli
+    conn.Exec("SELECT name FROM users WHERE age=" + "3")
+}
+
+func ok6(conn *pgx.Conn) {
+    // ok: pgx-sqli
+    conn.Exec(fmt.Sprintf("SELECT * FROM users WHERE email=hello;"))
+}
+
+func ok7() {
+    conf := pgx.ConnPoolConfig{
+        ConnConfig: pgx.ConnConfig{
+            Host:     "/run/postgresql",
+            User:     "postgres",
+            Database: "test",
+        },
+        MaxConnections: 5,
+    }
+    db, err := pgx.NewConnPool(conf)
+    if err != nil {
+        panic(err)
+    }
+    if _, err := db.Prepare("my-query", "select $1::int"); err != nil {
+        panic(err)
+    }
+    // ok: pgx-sqli
+    row := db.QueryRow("my-query", 10)
+    var i int
+    if err := row.Scan(&i); err != nil {
+        panic(err)
+    }
+    fmt.Println(i)
+}

--- a/go/lang/security/audit/sqli/pgx-sqli.yaml
+++ b/go/lang/security/audit/sqli/pgx-sqli.yaml
@@ -1,5 +1,21 @@
 rules:
-- id: gosql-sqli
+- id: pgx-sqli
+  languages:
+  - go
+  message: >
+    Detected string concatenation with a non-literal variable in a pgx
+
+    Go SQL statement. This could lead to SQL injection if the variable is user-controlled
+
+    and not properly sanitized. In order to prevent SQL injection,
+
+    used parameterized queries instead. You can use parameterized queries like so:
+
+    (`SELECT $1 FROM table`, `data1)
+  metadata:
+    references:
+    - https://github.com/jackc/pgx
+    - https://pkg.go.dev/github.com/jackc/pgx/v4#hdr-Connection_Pool
   patterns:
   - pattern-either:
     - patterns:
@@ -26,25 +42,20 @@ rules:
     - pattern: $DB.$METHOD(..., fmt.Sprintf("...", $PARAM1, ...), ...)
   - pattern-either:
     - pattern-inside: |
-        $DB, ... = sql.Open(...)
+        $DB, ... = pgx.Connect(...)
         ...
     - pattern-inside: |
-        func $FUNCNAME(..., $DB *sql.DB, ...) {
+        $DB, ... = pgx.NewConnPool(...)
+        ...
+    - pattern-inside: |
+        $DB, ... = pgx.ConnectConfig(...)
+        ...
+    - pattern-inside: |
+        func $FUNCNAME(..., $DB *pgx.Conn, ...) {
           ...
         }
   - pattern-not: $DB.$METHOD(..., "..." + "...", ...)
   - metavariable-regex:
       metavariable: $METHOD
-      regex: ^(Exec|ExecContent|Query|QueryContext|QueryRow|QueryRowContext)$
-  languages:
-  - go
-  message: |
-    Detected string concatenation with a non-literal variable in a "database/sql"
-    Go SQL statement. This could lead to SQL injection if the variable is user-controlled
-    and not properly sanitized. In order to prevent SQL injection,
-    used parameterized queries or prepared statements instead.
-    You can use prepared statements with the 'Prepare' and 'PrepareContext' calls.
-  metadata:
-    references:
-    - https://golang.org/pkg/database/sql/
+      regex: ^(Exec|ExecEx|Query|QueryEx|QueryRow|QueryRowEx)$
   severity: WARNING


### PR DESCRIPTION
Go SQLi rules. Includes support for:
* [x] database/sql driver
* [x] go-pg driver (popular ORM for postgresql)
* [x] pgx driver (popular for postgresql, replaced lib/pq)