### PR TITLE
Add host* key rules

### DIFF
--- a/yaml/kubernetes/security/hostipc-pod.test.yaml
+++ b/yaml/kubernetes/security/hostipc-pod.test.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: view-pid
+spec:
+  # ruleid: hostipc-pod
+  hostIPC: true
+  containers:
+  - name: nginx
+    image: nginx

--- a/yaml/kubernetes/security/hostipc-pod.yaml
+++ b/yaml/kubernetes/security/hostipc-pod.yaml
@@ -1,0 +1,18 @@
+rules:
+- id: hostipc-pod
+  patterns:
+  - pattern-inside: |
+      spec:
+        ...
+  - pattern: |
+      hostIPC: true
+  message: |
+    Pod is sharing the host IPC namespace. This allows container processes
+    to communicate with processes on the host which reduces isolation and
+    bypasses container protection models. Remove the 'hostIPC' key to disable
+    this functionality.
+  metadata:
+    references:
+    - https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+  languages: [yaml]
+  severity: WARNING

--- a/yaml/kubernetes/security/hostnetwork-pod.test.yaml
+++ b/yaml/kubernetes/security/hostnetwork-pod.test.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: view-pid
+spec:
+  # ruleid: hostnetwork-pod
+  hostNetwork: true
+  containers:
+  - name: nginx
+    image: nginx

--- a/yaml/kubernetes/security/hostnetwork-pod.yaml
+++ b/yaml/kubernetes/security/hostnetwork-pod.yaml
@@ -1,0 +1,18 @@
+rules:
+- id: hostnetwork-pod
+  patterns:
+  - pattern-inside: |
+      spec:
+        ...
+  - pattern: |
+      hostNetwork: true
+  message: |
+    Pod may use the node network namespace. This gives the pod access to the
+    loopback device, services listening on localhost, and could be used to
+    snoop on network activity of other pods on the same node. Remove the
+    'hostNetwork' key to disable this functionality.
+  metadata:
+    references:
+    - https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+  languages: [yaml]
+  severity: WARNING

--- a/yaml/kubernetes/security/hostpid-pod.test.yaml
+++ b/yaml/kubernetes/security/hostpid-pod.test.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: view-pid
+spec:
+  # ruleid: hostpid-pod
+  hostPID: true
+  containers:
+  - name: nginx
+    image: nginx

--- a/yaml/kubernetes/security/hostpid-pod.yaml
+++ b/yaml/kubernetes/security/hostpid-pod.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: hostpid-pod
+  patterns:
+  - pattern-inside: |
+      spec:
+        ...
+  - pattern: |
+      hostPID: true
+  message: |
+    Pod is sharing the host process ID namespace. When paired with ptrace
+    this can be used to escalate privileges outside of the container. Remove
+    the 'hostPID' key to disable this functionality.
+  metadata:
+    references:
+    - https://kubernetes.io/docs/concepts/policy/pod-security-policy/#host-namespaces
+  languages: [yaml]
+  severity: WARNING


### PR DESCRIPTION
This should cover fixing https://github.com/returntocorp/semgrep-rules/issues/1097. This doesn't cover everything there, but the task is very generally defined - if we're looking for something more specific we can create a new issue :+1: 

I considered adding a rule for `hostPorts`, but it seems too general, and susceptible to FPs IMO. You can easily overexpose ports with that key, but we don't have any way of knowing that without more application context. 