### PR TITLE
add rule to detect full Spring Actuator activation

### DIFF
--- a/java/spring/security/audit/spring-actuator-fully-enabled.properties
+++ b/java/spring/security/audit/spring-actuator-fully-enabled.properties
@@ -1,3 +1,4 @@
+# ok: spring-actuator-fully-enabled
 foo=bar
 # ruleid: spring-actuator-fully-enabled
 management.endpoints.web.exposure.include=*

--- a/java/spring/security/audit/spring-actuator-fully-enabled.properties
+++ b/java/spring/security/audit/spring-actuator-fully-enabled.properties
@@ -1,0 +1,3 @@
+foo=bar
+# ruleid: spring-actuator-fully-enabled
+management.endpoints.web.exposure.include=*

--- a/java/spring/security/audit/spring-actuator-fully-enabled.yaml
+++ b/java/spring/security/audit/spring-actuator-fully-enabled.yaml
@@ -1,17 +1,16 @@
 rules:
 - id: spring-actuator-fully-enabled
-  pattern: management.endpoints.web.exposure.include=* 
+  pattern: management.endpoints.web.exposure.include=*
   message: |
     Spring Boot Actuator is fully enabled. This exposes sensitive endpoints such as /actuator/env, /actuator/logfile, /actuator/heapdump and others.
     Unless you have Spring Security enabled or another means to protect these endpoints, this functionality is available without authentication, causing a severe security risk.
-  metadata:
-    owasp: 'A6: Security Misconfiguration'
   severity: WARNING
   languages: [generic]
   paths:
     include:
     - '*properties'
   metadata:
+    owasp: 'A6: Security Misconfiguration'
     references:
     - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-exposing-endpoints
     - https://medium.com/walmartglobaltech/perils-of-spring-boot-actuators-misconfiguration-185c43a0f785

--- a/java/spring/security/audit/spring-actuator-fully-enabled.yaml
+++ b/java/spring/security/audit/spring-actuator-fully-enabled.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: spring-actuator-fully-enabled
+  pattern: management.endpoints.web.exposure.include=* 
+  message: |
+    Spring Boot Actuator is fully enabled. This exposes sensitive endpoints such as /actuator/env, /actuator/logfile, /actuator/heapdump and others.
+    Unless you have Spring Security enabled or another means to protect these endpoints, this functionality is available without authentication, causing a severe security risk.
+  metadata:
+    owasp: 'A6: Security Misconfiguration'
+  severity: WARNING
+  languages: [generic]
+  paths:
+    include:
+    - '*properties'
+  metadata:
+    references:
+    - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-exposing-endpoints
+    - https://medium.com/walmartglobaltech/perils-of-spring-boot-actuators-misconfiguration-185c43a0f785


### PR DESCRIPTION
I created this rule to detect full activation of Spring Actuator in Spring properties files, which imposes quite a security risk when not mitigated appropriately.