### PR TITLE
Change language 'none' -> 'regex'

### DIFF
--- a/java/lang/security/audit/xss/jsf/autoescape-disabled.yaml
+++ b/java/lang/security/audit/xss/jsf/autoescape-disabled.yaml
@@ -16,5 +16,5 @@ rules:
     include:
     - '*.html'
     - '*.xhtml'
-  languages: [none]
+  languages: [regex]
   severity: WARNING

--- a/java/lang/security/audit/xss/jsp/no-scriptlets.yaml
+++ b/java/lang/security/audit/xss/jsp/no-scriptlets.yaml
@@ -16,5 +16,5 @@ rules:
   paths:
     include:
     - '*.jsp'
-  languages: [none]
+  languages: [regex]
   severity: WARNING

--- a/java/lang/security/audit/xss/jsp/use-escapexml.yaml
+++ b/java/lang/security/audit/xss/jsp/use-escapexml.yaml
@@ -18,5 +18,5 @@ rules:
   paths:
     include:
     - '*.jsp'
-  languages: [none]
+  languages: [regex]
   severity: WARNING

--- a/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
+++ b/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
@@ -19,5 +19,5 @@ rules:
   paths:
     include:
     - '*.jsp'
-  languages: [none]
+  languages: [regex]
   severity: WARNING

--- a/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
@@ -12,7 +12,7 @@ rules:
     references:
     - http://www.managerjs.com/blog/2015/05/will-ejs-escape-save-me-from-xss-sorta/
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.ejs'

--- a/javascript/express/security/audit/xss/ejs/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-href.yaml
@@ -15,7 +15,7 @@ rules:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
     - https://github.com/pugjs/pug/issues/2952
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.ejs'

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
@@ -13,7 +13,7 @@ rules:
     references:
     - https://github.com/janl/mustache.js/#variables
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.mustache'

--- a/javascript/express/security/audit/xss/mustache/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-href.yaml
@@ -15,7 +15,7 @@ rules:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
     - https://github.com/pugjs/pug/issues/2952
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.mustache'

--- a/javascript/express/security/audit/xss/pug/and-attributes.yaml
+++ b/javascript/express/security/audit/xss/pug/and-attributes.yaml
@@ -12,7 +12,7 @@ rules:
     references:
     - https://pugjs.org/language/attributes.html#attributes
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.pug'

--- a/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
@@ -13,7 +13,7 @@ rules:
     - https://pugjs.org/language/code.html#unescaped-buffered-code
     - https://pugjs.org/language/attributes.html#unescaped-attributes
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.pug'

--- a/javascript/express/security/audit/xss/pug/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-href.yaml
@@ -15,7 +15,7 @@ rules:
     - https://github.com/pugjs/pug/issues/2952
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.pug'

--- a/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
@@ -16,7 +16,7 @@ rules:
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
     - https://github.com/ESAPI/owasp-esapi-js
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.pug'

--- a/javascript/vue/security/audit/xss/templates/avoid-v-html.yaml
+++ b/javascript/vue/security/audit/xss/templates/avoid-v-html.yaml
@@ -5,7 +5,7 @@ rules:
   metadata:
     references:
     - https://vuejs.org/v2/guide/syntax.html#Raw-HTML
-  languages: [none]
+  languages: [regex]
   paths:
     include:
     - '*.vue'

--- a/python/django/security/audit/xss/template-autoescape-off.yaml
+++ b/python/django/security/audit/xss/template-autoescape-off.yaml
@@ -11,7 +11,7 @@ rules:
     references:
     - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#autoescape
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.html'

--- a/python/django/security/audit/xss/template-href-var.yaml
+++ b/python/django/security/audit/xss/template-href-var.yaml
@@ -15,7 +15,7 @@ rules:
     - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#url
     - https://content-security-policy.com/
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.html'

--- a/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
+++ b/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
@@ -12,7 +12,7 @@ rules:
     references:
     - https://docs.djangoproject.com/en/3.0/ref/templates/builtins/#safeseq
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.html'

--- a/python/flask/security/xss/audit/template-autoescape-off.yaml
+++ b/python/flask/security/xss/audit/template-autoescape-off.yaml
@@ -12,7 +12,7 @@ rules:
     - https://flask.palletsprojects.com/en/1.1.x/templating/#controlling-autoescaping
     - https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.html'

--- a/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
+++ b/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
@@ -11,7 +11,7 @@ rules:
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
   languages:
-  - none
+  - regex
   paths:
     include:
     - '*.html'


### PR DESCRIPTION
I think `regex` is more descriptive than `none`. Hopefully we can deprecate and remove `none` in favor of `regex` someday.