### PR TITLE
Add rule for no broken URLs

### DIFF
--- a/generic/no-broken-urls.md
+++ b/generic/no-broken-urls.md
@@ -1,0 +1,9 @@
+# URLs
+
+This is a working URL: <https://httpbin.org/status/200>
+
+This is a broken URL: <https://httpbin.org/status/404>
+
+This is a working URL: [working](https://httpbin.org/status/200)
+
+This is a broken URL: [broken](https://httpbin.org/status/404)

--- a/generic/no-broken-urls.yml
+++ b/generic/no-broken-urls.yml
@@ -1,0 +1,16 @@
+rules:
+  - id: no-broken-urls
+    message: Accessing $URL did not return a successful status code.
+    languages: [generic]
+    severity: WARNING
+    patterns:
+      - pattern-inside: "[...]($URL)"
+      - pattern-regex: 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
+      # messes with evaluation internals: https://github.com/returntocorp/semgrep/blob/9a73a142dccfa281999418510843886c3d260c71/semgrep/semgrep/evaluation.py#L218
+      - pattern-where-python: |
+          import requests
+          try:
+              success = requests.head(vars["$URL"], timeout=5).ok
+          except:
+              success = False
+          not success


### PR DESCRIPTION
@minusworld @mschwager I tried to do this as a proof of concept but cannot get a metavariable to match the full URL because spacegrep sees lots of separators within. It also seems like `pattern-where-python` doesn't give access to the full match, only the metavars. Do you see a workaround, or will this need a Semgrep CLI feature request?