### PR TITLE
Allow further attributes after the method

### DIFF
--- a/java/spring/security/unrestricted-request-mapping.yaml
+++ b/java/spring/security/unrestricted-request-mapping.yaml
@@ -5,7 +5,7 @@ rules:
       @RequestMapping(...)
       $RETURNTYPE $METHOD(...) { ... }
   - pattern-not-inside: |
-      @RequestMapping(..., method = $X)
+      @RequestMapping(..., method = $X, ...)
       $RETURNTYPE $METHOD(...) { ... }
   message: >-
     Detected a method annotated with 'RequestMapping' that does not specify


### PR DESCRIPTION
It is not uncommon that other attributes follow the method attribute or that the method attribute is not the last in line.