### PR TITLE
javascript: Use window.prompt() to get "dynamic" data

### DIFF
--- a/javascript/browser/security/eval-detected.js
+++ b/javascript/browser/security/eval-detected.js
@@ -24,7 +24,7 @@ eval(constVar + secondConstVar);
  * Positive Matches
  */
 
-let dynamic = "function dynamicStrings() { return 'dynamic strings are not'; }"
+let dynamic = window.prompt() // arbitrary user input
 
 // ruleid:eval-detected
 eval(dynamic + 'possibly malicious code');

--- a/javascript/browser/security/new-function-detected.js
+++ b/javascript/browser/security/new-function-detected.js
@@ -30,7 +30,7 @@ let notEvaluatedFunc = new Function(document.getElementById('userInput'));
  * Positive Matches
  */
 
-let dynamic = "function dynamicStrings() { return 'dynamic strings are not'; }"
+let dynamic = window.prompt() // arbitrary user input
 
 // ruleid:new-function-detected
 func = new Function(dynamic + 'possibly malicious code');


### PR DESCRIPTION
In returntocorp/semgrep#2978 we extend the ability of Semgrep to recognize constant definitions and these false positives (note that `dynamic` is actually a constant string) stop being reported. We fix that by using arbitrary user input.