### PR TITLE
Simplify JS/TS rules in preparation for semgrep#2978

### DIFF
--- a/javascript/express/security/express-jwt-hardcoded-secret.js
+++ b/javascript/express/security/express-jwt-hardcoded-secret.js
@@ -6,16 +6,16 @@ app.get('/protected', jwt({ secret: 'shhhhhhared-secret' }), function(req, res) 
     res.sendStatus(200);
 });
 
-// ruleid: express-jwt-hardcoded-secret
 let hardcodedSecret = 'shhhhhhared-secret'
 
+// ruleid: express-jwt-hardcoded-secret
 app.get('/protected2', jwt({ secret: hardcodedSecret }), function(req, res) {
     if (!req.user.admin) return res.sendStatus(401);
     res.sendStatus(200);
 });
 
-// ruleid: express-jwt-hardcoded-secret
 let secret = "hardcode"
+// ruleid: express-jwt-hardcoded-secret
 const opts = Object.assign({issuer: 'http://issuer'}, {secret})
 
 app.get('/protected3', jwt(opts), function(req, res) {
@@ -30,10 +30,10 @@ app.get('/ok-protected', jwt({ secret: process.env.SECRET }), function(req, res)
 });
 
 
-// ok: express-jwt-hardcoded-secret
 let configSecret = config.get('secret')
 const opts = Object.assign({issuer: 'http://issuer'}, {secret: configSecret})
 
+// ok: express-jwt-hardcoded-secret
 app.get('/ok-protected', jwt(opts), function(req, res) {
     if (!req.user.admin) return res.sendStatus(401);
     res.sendStatus(200);

--- a/javascript/express/security/express-jwt-hardcoded-secret.yaml
+++ b/javascript/express/security/express-jwt-hardcoded-secret.yaml
@@ -24,16 +24,6 @@ rules:
     - pattern: |
         $JWT(<... {secret: "..."} ...>,...);
     - pattern: |
-        $SECRET = "...";
-        ...
-        $JWT(<... {secret: $SECRET} ...>,...);
-    - pattern: |
         $OPTS = <... {secret: "..."} ...>;
-        ...
-        $JWT($OPTS,...);
-    - pattern: |-
-        $SECRET = "...";
-        ...
-        $OPTS = <... {secret: $SECRET} ...>;
         ...
         $JWT($OPTS,...);

--- a/typescript/react/security/react-insecure-request.jsx
+++ b/typescript/react/security/react-insecure-request.jsx
@@ -3,8 +3,8 @@ import axios from 'axios';
 // ruleid: react-insecure-request
 fetch('http://www.example.com', 'GET', {})
 
-// ruleid: react-insecure-request
 let addr = "http://www.example.com"
+// ruleid: react-insecure-request
 fetch(addr, 'POST', {})
 
 // ruleid: react-insecure-request

--- a/typescript/react/security/react-insecure-request.tsx
+++ b/typescript/react/security/react-insecure-request.tsx
@@ -3,8 +3,8 @@ import axios from 'axios';
 // ruleid: react-insecure-request
 fetch('http://www.example.com', 'GET', {})
 
-// ruleid: react-insecure-request
 let addr = "http://www.example.com"
+// ruleid: react-insecure-request
 fetch(addr, 'POST', {})
 
 // ruleid: react-insecure-request

--- a/typescript/react/security/react-insecure-request.yaml
+++ b/typescript/react/security/react-insecure-request.yaml
@@ -36,13 +36,7 @@ rules:
             $OPTS = {url: "=~/[Hh][Tt][Tt][Pp]:\/\/.*/"}
             ...
             $AXIOS($OPTS, ...)
-    - patterns:
-      - pattern-either:
-        - pattern: fetch("=~/[Hh][Tt][Tt][Pp]:\/\/.*/", ...)
-        - pattern: |
-            $VAR = "=~/[Hh][Tt][Tt][Pp]:\/\/.*/"
-            ...
-            fetch($VAR, ...)
+    - pattern: fetch("=~/[Hh][Tt][Tt][Pp]:\/\/.*/", ...)
   message: |
     Unencrypted request over HTTP detected.
   metadata:


### PR DESCRIPTION
With PR semgrep#2978 Semgrep will infer JS/TS constants even if they are
missing the `const' qualifier.