### PR TITLE
fix: return-in-init should ignore None returns

### DIFF
--- a/python/lang/correctness/return-in-init.py
+++ b/python/lang/correctness/return-in-init.py
@@ -6,7 +6,7 @@ class A:
 
 class B:
     def __init__(a, b, c):
-        # ruleid:return-in-init
+        # ok:return-in-init
         return
 
 
@@ -70,3 +70,8 @@ class G:
     def func2():
         # ok:yield-in-init
         yield
+
+class H:
+    def __init__(self, x):
+        # ok:return-in-init
+        return None

--- a/python/lang/correctness/return-in-init.yaml
+++ b/python/lang/correctness/return-in-init.yaml
@@ -7,9 +7,10 @@ rules:
   - pattern-inside: |
       def __init__(...):
           ...
-  - pattern-either:
+  - patterns:
     - pattern: return ...
-    - pattern: return
+    - pattern-not: return
+    - pattern-not: return None
   message: '`return` should never appear inside a class __init__ function. This will cause a runtime error.'
   languages: [python]
   severity: ERROR


### PR DESCRIPTION
Currently this rule flags folllowing code as error:
```python
def __init__(self):
    return
```

As noted in documentation, the runtime error ONLY occurs when a non-None value is returned. So this is a false positive.

Reference:
- https://docs.python.org/3/reference/datamodel.html#object.__init__