### PR TITLE
Update detected-aws-secret-access-key.yaml

### DIFF
--- a/generic/secrets/security/detected-aws-secret-access-key.yaml
+++ b/generic/secrets/security/detected-aws-secret-access-key.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: detected-aws-secret-access-key
   pattern-regex: |-
-    (("|'|`)?((?i)aws)_?((?i)secret)_?((?i)access)?_?((?i)key)?_?((?i)id)?("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?[A-Za-z0-9/+=]{40}("|'|`)?)
+    (("|'|`)?((?i)aws)_?\w*((?i)secret)_?\w*("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?[A-Za-z0-9/+=]{40}("|'|`)?)
   languages: [regex]
   message: AWS Secret Access Key detected
   severity: ERROR


### PR DESCRIPTION
This should now match words between the keywords 'aws' and 'secret'
e.g. Previously this would not have been matched: `AWS_TEST_SECRET = "..."`

Also as the words 'access', 'key', and 'id' were all optional, they are effectively redundant and only add arbitrary strictness to the rule.