### PR TITLE
Improve Bandit rules

### DIFF
--- a/python/lang/security/audit/paramiko/paramiko-exec-command.py
+++ b/python/lang/security/audit/paramiko/paramiko-exec-command.py
@@ -5,19 +5,19 @@ from paramiko import client
 
 
 client = paramiko.client.SSHClient()
-# this is safe
+client.connect("somehost")
+
 # ok:paramiko-exec-command
-client.connect('somehost')
+client.exec_command("ls -r /")
 
-# this is not safe
 # ruleid:paramiko-exec-command
-client.exec_command('something; really; unsafe')
-
-
-
-
+client.exec_command(user_input)
 
 client2 = client.SSHClient()
-client2.connect("somewhere-out-there")
-# ruleid:paramiko-exec-command
+client2.connect("somehost")
+
+# ok:paramiko-exec-command
 client2.exec_command("ls -r /")
+
+# ruleid:paramiko-exec-command
+client2.exec_command(user_input)

--- a/python/lang/security/audit/paramiko/paramiko-exec-command.yaml
+++ b/python/lang/security/audit/paramiko/paramiko-exec-command.yaml
@@ -2,9 +2,10 @@ rules:
 - id: paramiko-exec-command
   patterns:
   - pattern-inside: |
-      import paramiko
+      $CLIENT = paramiko.client.SSHClient(...)
       ...
   - pattern: $CLIENT.exec_command(...)
+  - pattern-not: $CLIENT.exec_command("...", ...)
   message: |
     Unverified SSL context detected. This will permit insecure connections without verifying
     SSL certificates. Use 'ssl.create_default_context()' instead.

--- a/python/lang/security/audit/subprocess-shell-true.py
+++ b/python/lang/security/audit/subprocess-shell-true.py
@@ -1,17 +1,20 @@
-# cf. https://github.com/returntocorp/semgrep/blob/develop/docs/writing_rules/examples.md#auditing-dangerous-function-use
-
 import subprocess
 import sys
 
-subprocess.call("echo 'hello'") # Doesn't match
+# ok:subprocess-shell-true
+subprocess.call("echo 'hello'")
 
-subprocess.call("grep -R {} .".format(sys.argv[1])) # Doesn't match
+# ok:subprocess-shell-true
+subprocess.call("grep -R {} .".format(sys.argv[1]))
+
+# ok:subprocess-shell-true
+subprocess.call("echo 'hello'", shell=True)
 
 # ruleid:subprocess-shell-true
-subprocess.call("grep -R {} .".format(sys.argv[1]), shell=True) # Matches here
+subprocess.call("grep -R {} .".format(sys.argv[1]), shell=True)
 
 # ruleid:subprocess-shell-true
-subprocess.call("grep -R {} .".format(sys.argv[1]), shell=True, cwd="/home/user") # Matches here
+subprocess.call("grep -R {} .".format(sys.argv[1]), shell=True, cwd="/home/user")
 
 # ruleid:subprocess-shell-true
-subprocess.run("grep -R {} .".format(sys.argv[1]), shell=True) # Matches here too!
+subprocess.run("grep -R {} .".format(sys.argv[1]), shell=True)

--- a/python/lang/security/audit/subprocess-shell-true.yaml
+++ b/python/lang/security/audit/subprocess-shell-true.yaml
@@ -1,6 +1,8 @@
 rules:
 - id: subprocess-shell-true
-  pattern: subprocess.$FUNC(..., shell=True, ...)
+  patterns:
+  - pattern: subprocess.$FUNC(..., shell=True, ...)
+  - pattern-not: subprocess.$FUNC("...", shell=True, ...)
   message: |
     Found 'subprocess' function '$FUNC' with 'shell=True'. This is dangerous because this call will spawn
     the command using a shell process. Doing so propagates current shell settings and variables, which


### PR DESCRIPTION
Fixes https://github.com/returntocorp/enterprise/issues/623.

I took a look through the rules in our Bandit ruleset. There wasn't much low hanging fruit available for improvement, but I did find a couple injection-style rules that could be improved a bit.

The only other consideration I noticed was improving our [`use-defused-xml`](https://github.com/returntocorp/semgrep-rules/blob/develop/python/lang/security/use-defused-xml.yaml) rule. We had a large discrepancy in results between this rule and Bandit's [XML rules](https://bandit.readthedocs.io/en/latest/blacklists/blacklist_imports.html#b405-import-xml-etree). One option would be only detecting the XML imports Bandit does instead of a blanket `import xml` detection. 

Although the discrepancy is noted, it's not clear how we can improve this rule to closer achieve parity. Unfortunately the MAP triager isn't working for large numbers of results, so it's impossible to tell where the discrepancies are. Without solid evidence of how we can improve this rule, and without user feedback on FPs and FNs, I would suggest we leave it as-is until we have more concrete data.