### PR TITLE
Add rule for nested 'pattern-either'

### DIFF
--- a/python/flask/security/injection/os-system-injection.yaml
+++ b/python/flask/security/injection/os-system-injection.yaml
@@ -31,28 +31,27 @@ rules:
   - pattern: os.system(..., <... flask.request.$W[...] ...>, ...)
   - pattern: os.system(..., <... flask.request.$W(...) ...>, ...)
   - pattern: os.system(..., <... flask.request.$W ...>, ...)
-  - pattern-either:
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W.get(...) ...>
-          ...
-          os.system(<... $INTERM ...>)
-      - pattern: os.system(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W[...] ...>
-          ...
-          os.system(<... $INTERM ...>)
-      - pattern: os.system(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W(...) ...>
-          ...
-          os.system(<... $INTERM ...>)
-      - pattern: os.system(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W ...>
-          ...
-          os.system(<... $INTERM ...>)
-      - pattern: os.system(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        os.system(<... $INTERM ...>)
+    - pattern: os.system(...)

--- a/python/flask/security/injection/path-traversal-open.yaml
+++ b/python/flask/security/injection/path-traversal-open.yaml
@@ -37,57 +37,55 @@ rules:
   - pattern: open(..., <... flask.request.$W[...] ...>, ...)
   - pattern: open(..., <... flask.request.$W(...) ...>, ...)
   - pattern: open(..., <... flask.request.$W ...>, ...)
-  - pattern-either:
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W.get(...) ...>
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        open(<... $INTERM ...>, ...)
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
           ...
-          open(<... $INTERM ...>, ...)
-      - pattern: open(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W[...] ...>
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
           ...
-          open(<... $INTERM ...>, ...)
-      - pattern: open(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W(...) ...>
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
           ...
-          open(<... $INTERM ...>, ...)
-      - pattern: open(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W ...>
+    - pattern: open(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        with open(<... $INTERM ...>, ...) as $F:
           ...
-          open(<... $INTERM ...>, ...)
-      - pattern: open(...)
-  - pattern-either:
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W.get(...) ...>
-          ...
-          with open(<... $INTERM ...>, ...) as $F:
-            ...
-      - pattern: open(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W[...] ...>
-          ...
-          with open(<... $INTERM ...>, ...) as $F:
-            ...
-      - pattern: open(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W(...) ...>
-          ...
-          with open(<... $INTERM ...>, ...) as $F:
-            ...
-      - pattern: open(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W ...>
-          ...
-          with open(<... $INTERM ...>, ...) as $F:
-            ...
-      - pattern: open(...)
+    - pattern: open(...)

--- a/python/flask/security/injection/user-eval.yaml
+++ b/python/flask/security/injection/user-eval.yaml
@@ -29,28 +29,27 @@ rules:
   - pattern: eval(..., <... flask.request.$W[...] ...>, ...)
   - pattern: eval(..., <... flask.request.$W(...) ...>, ...)
   - pattern: eval(..., <... flask.request.$W ...>, ...)
-  - pattern-either:
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W.get(...) ...>
-          ...
-          eval(..., <... $INTERM ...>, ...)
-      - pattern: eval(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W[...] ...>
-          ...
-          eval(..., <... $INTERM ...>, ...)
-      - pattern: eval(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W(...) ...>
-          ...
-          eval(..., <... $INTERM ...>, ...)
-      - pattern: eval(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W ...>
-          ...
-          eval(..., <... $INTERM ...>, ...)
-      - pattern: eval(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        eval(..., <... $INTERM ...>, ...)
+    - pattern: eval(...)

--- a/python/flask/security/injection/user-exec.yaml
+++ b/python/flask/security/injection/user-exec.yaml
@@ -29,28 +29,27 @@ rules:
   - pattern: exec(..., <... flask.request.$W[...] ...>, ...)
   - pattern: exec(..., <... flask.request.$W(...) ...>, ...)
   - pattern: exec(..., <... flask.request.$W ...>, ...)
-  - pattern-either:
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W.get(...) ...>
-          ...
-          exec(..., <... $INTERM ...>, ...)
-      - pattern: exec(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W[...] ...>
-          ...
-          exec(..., <... $INTERM ...>, ...)
-      - pattern: exec(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W(...) ...>
-          ...
-          exec(..., <... $INTERM ...>, ...)
-      - pattern: exec(...)
-    - patterns:
-      - pattern-inside: |
-          $INTERM = <... flask.request.$W ...>
-          ...
-          exec(..., <... $INTERM ...>, ...)
-      - pattern: exec(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W.get(...) ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W[...] ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W(...) ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)
+  - patterns:
+    - pattern-inside: |
+        $INTERM = <... flask.request.$W ...>
+        ...
+        exec(..., <... $INTERM ...>, ...)
+    - pattern: exec(...)

--- a/yaml/semgrep/unnecessary-parent.yaml
+++ b/yaml/semgrep/unnecessary-parent.yaml
@@ -25,4 +25,9 @@ rules:
           - $THING1
           - $THING2
           - ...
+    - pattern: |
+        pattern-either:
+        - ...
+        - pattern-either:
+          - ...
   severity: WARNING


### PR DESCRIPTION
From https://github.com/returntocorp/semgrep/pull/3169 - nested `pattern-either` is no longer a hard fail, but we can still warn users :+1: 