### PR TITLE
Switch to lombok for Java tests

### DIFF
--- a/tests/performance/.test_public_repos.yaml
+++ b/tests/performance/.test_public_repos.yaml
@@ -11,8 +11,8 @@ java:
 - url: https://github.com/apache/avro
   commit: c903aa6d6fc42d3c347f95d469a8364ea44165e8
 javascript:
-- url: https://github.com/axios/axios
-  commit: ffea03453f77a8176c51554d5f6c3c6829294649
+- url: https://github.com/projectlombok/lombok
+  commit: 6758714ed564d72236564889157c4812eacb96fb
 c:
 - url: https://github.com/zlib-ng/zlib-ng
   commit: c71ca170224f31a219513aa470f82aa50a3ded48

--- a/tests/performance/.test_public_repos.yaml
+++ b/tests/performance/.test_public_repos.yaml
@@ -8,11 +8,11 @@ python:
 - url: https://github.com/pallets/flask
   commit: 65a0a4b585781b5dd3db4009de3195e2ac7f049f
 java:
-- url: https://github.com/apache/avro
-  commit: c903aa6d6fc42d3c347f95d469a8364ea44165e8
-javascript:
 - url: https://github.com/projectlombok/lombok
   commit: 6758714ed564d72236564889157c4812eacb96fb
+javascript:
+- url: https://github.com/axios/axios
+  commit: ffea03453f77a8176c51554d5f6c3c6829294649
 c:
 - url: https://github.com/zlib-ng/zlib-ng
   commit: c71ca170224f31a219513aa470f82aa50a3ded48


### PR DESCRIPTION
avro had a bunch of subdirectories for each implementation of avro in different languages. This made avro huge and the Java tests disproportionately long.

This switches to [lombok](https://github.com/projectlombok/lombok) which clocks in at about 90,000 sloc and should be a better "medium" repo for tests.