### PR TITLE
add session support to the regexes as well

### DIFF
--- a/python/requests/best-practice/use-timeout.yaml
+++ b/python/requests/best-practice/use-timeout.yaml
@@ -3,6 +3,8 @@ rules:
   patterns:
   - pattern-not: requests.$W(..., timeout=$N, ...)
   - pattern-not: requests.$W(..., **$KWARGS)
+  - pattern-not: session.$W(..., **$KWARGS)
+  - pattern-not: session.$W(..., **$KWARGS)  
   - pattern-either:
     - pattern: requests.request(...)
     - pattern: requests.get(...)
@@ -11,6 +13,12 @@ rules:
     - pattern: requests.delete(...)
     - pattern: requests.head(...)
     - pattern: requests.patch(...)
+    - pattern: session.get(...)
+    - pattern: session.post(...)
+    - pattern: session.put(...)
+    - pattern: session.delete(...)
+    - pattern: session.head(...)
+    - pattern: session.patch(...)    
   fix-regex:
     regex: (.*)\)
     replacement: \1, timeout=30)


### PR DESCRIPTION
It's really common, I think, to write code like this:

```
session = requests.Session()
r = session.get(some_url)
```

Hopefully this will catch that as well without catching things it shouldn't. I also do this:

```
s = requests.Session()
s.get(some_url)
```

But I felt like that would probably catch things we didn't want, so I left that out for now.