### PR TITLE
Add rule for the GitHub tokens

### DIFF
--- a/generic/secrets/security/detected-github-token.txt
+++ b/generic/secrets/security/detected-github-token.txt
@@ -1,0 +1,5 @@
+# ruleid: detected-github-token
+GITHUB_TOKEN=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
+
+# ruleid: detected-github-token
+github_token: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

--- a/generic/secrets/security/detected-github-token.yaml
+++ b/generic/secrets/security/detected-github-token.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: detected-github-token
+  pattern-regex: |-
+    gh[pousr]_[A-Za-z0-9_]{36,251}
+  languages: [regex]
+  message: GitHub Token detected
+  severity: ERROR
+  metadata:
+    source-rule-url: https://github.blog/changelog/2021-03-04-authentication-token-format-updates/
+    category: security
+    technology:
+    - secrets


### PR DESCRIPTION
This PR adds support for the new Github token format which is described in the [github blog](https://github.blog/changelog/2021-03-04-authentication-token-format-updates/) article. Tested locally with a token generated (and revoked) in the GH UI.