### PR TITLE
Include GCM rule for hardcoded IV/nonce

### DIFF
--- a/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
+++ b/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
@@ -64,5 +64,5 @@ public class GcmHardcodedIV
 
         theIV = BAD_IV.getBytes();
     }
-    
+
 }

--- a/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
+++ b/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
@@ -9,6 +9,8 @@ public class GcmHardcodedIV
 {
     public static final int GCM_TAG_LENGTH = 16;
     public static final String BAD_IV = "ab0123456789";
+    //It has not been found how to detect hardcoded byte arrays with semgrep
+    //todoruleid: gcm-nonce-reuse
     public static final byte[] BAD_IV2 = new byte[]{0,1,2,3,4,5,6,7,8,9,10,11};
 
     private static byte[] theIV;
@@ -37,6 +39,7 @@ public class GcmHardcodedIV
         SecretKeySpec keySpec = new SecretKeySpec(theKey.getEncoded(), "AES");
         byte[] theBadIV = BAD_IV.getBytes();
 
+        //ruleid: gcm-nonce-reuse
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theBadIV);
         cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmParameterSpec);
 
@@ -49,6 +52,8 @@ public class GcmHardcodedIV
         Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
         SecretKeySpec keySpec = new SecretKeySpec(theKey.getEncoded(), "AES");
 
+        //Hard to detect that theIV is indeed built from a hardcoded string
+        //todoruleid: gcm-nonce-reuse
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theIV);
         cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmParameterSpec);
 

--- a/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
+++ b/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
@@ -40,6 +40,7 @@ public class GcmHardcodedIV
         byte[] theBadIV = BAD_IV.getBytes();
 
         //ruleid: gcm-nonce-reuse
+        //ruleid: gcm-detection
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theBadIV);
         cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmParameterSpec);
 
@@ -54,6 +55,7 @@ public class GcmHardcodedIV
 
         //Hard to detect that theIV is indeed built from a hardcoded string
         //todoruleid: gcm-nonce-reuse
+        //ruleid: gcm-detection
         GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theIV);
         cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmParameterSpec);
 

--- a/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
+++ b/java/lang/security/audit/crypto/gcm-hardcoded-iv.java
@@ -1,0 +1,68 @@
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+public class GcmHardcodedIV
+{
+    public static final int GCM_TAG_LENGTH = 16;
+    public static final String BAD_IV = "ab0123456789";
+    public static final byte[] BAD_IV2 = new byte[]{0,1,2,3,4,5,6,7,8,9,10,11};
+
+    private static byte[] theIV;
+    private static SecretKey theKey;
+
+    public static void main( String[] args )
+    {
+        String clearText = args[0];
+        System.out.println(clearText);
+
+        try {
+            setKeys();
+
+            String cipherText = encrypt(clearText);
+            System.out.println(cipherText);
+
+            String decrypted = decrypt(cipherText);
+            System.out.println(decrypted);
+        } catch(Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    public static String encrypt(String clearText) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(theKey.getEncoded(), "AES");
+        byte[] theBadIV = BAD_IV.getBytes();
+
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theBadIV);
+        cipher.init(Cipher.ENCRYPT_MODE, keySpec, gcmParameterSpec);
+
+        byte[] cipherText = cipher.doFinal(clearText.getBytes());
+
+        return Base64.getEncoder().encodeToString(cipherText);
+    }
+
+    public static String decrypt(String cipherText) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        SecretKeySpec keySpec = new SecretKeySpec(theKey.getEncoded(), "AES");
+
+        GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, theIV);
+        cipher.init(Cipher.DECRYPT_MODE, keySpec, gcmParameterSpec);
+
+        byte[] decoded = Base64.getDecoder().decode(cipherText);
+        byte[] decryptedText = cipher.doFinal(decoded);
+
+        return new String(decryptedText);
+    }
+
+    public static void setKeys() throws Exception {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+        keyGenerator.init(256);
+
+        theIV = BAD_IV.getBytes();
+    }
+    
+}

--- a/java/lang/security/audit/crypto/gcm-hardcoded-iv.yaml
+++ b/java/lang/security/audit/crypto/gcm-hardcoded-iv.yaml
@@ -1,22 +1,22 @@
 rules:
-  - id: gcm-nonce-reuse
-    languages:
-      - java
-    message: "GCM IV/nonce is reused: encryption can be totally useless, cf https://www.youtube.com/watch?v=r1awgAl90wM"
+- id: gcm-nonce-reuse
+  languages:
+  - java
+  message: 'GCM IV/nonce is reused: encryption can be totally useless, cf https://www.youtube.com/watch?v=r1awgAl90wM'
 #   NB: constants are automatically propagated so easy to define hard coded strings with "..."
 #   but what about static byte arrays ? there seems to be no native support in semgrep
-    patterns:
-      - pattern-either:
-        - pattern: new GCMParameterSpec(..., "...".getBytes(...), ...);
-        - pattern: byte[] $NONCE = "...".getBytes(...); ... new GCMParameterSpec(..., $NONCE, ...);
-    severity: ERROR
+  patterns:
+  - pattern-either:
+    - pattern: new GCMParameterSpec(..., "...".getBytes(...), ...);
+    - pattern: byte[] $NONCE = "...".getBytes(...); ... new GCMParameterSpec(..., $NONCE, ...);
+  severity: ERROR
 
-  - id: gcm-detection
-    languages:
-      - java
-    message: "GCM detected, please check that IV/nonce is not reused"
-    patterns:
-      - pattern-either:
-        - pattern: $METHOD.getInstance("AES/GCM/NoPadding",...);
-        - pattern: new GCMParameterSpec(...);
-    severity: INFO
+- id: gcm-detection
+  languages:
+  - java
+  message: GCM detected, please check that IV/nonce is not reused
+  patterns:
+  - pattern-either:
+    - pattern: $METHOD.getInstance("AES/GCM/NoPadding",...);
+    - pattern: new GCMParameterSpec(...);
+  severity: INFO

--- a/java/lang/security/audit/crypto/gcm-hardcoded-iv.yaml
+++ b/java/lang/security/audit/crypto/gcm-hardcoded-iv.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: gcm-nonce-reuse
+    languages:
+      - java
+    message: "GCM IV/nonce is reused: encryption can be totally useless, cf https://www.youtube.com/watch?v=r1awgAl90wM"
+#   NB: constants are automatically propagated so easy to define hard coded strings with "..."
+#   but what about static byte arrays ? there seems to be no native support in semgrep
+    patterns:
+      - pattern-either:
+        - pattern: new GCMParameterSpec(..., "...".getBytes(...), ...);
+        - pattern: byte[] $NONCE = "...".getBytes(...); ... new GCMParameterSpec(..., $NONCE, ...);
+    severity: ERROR
+
+  - id: gcm-detection
+    languages:
+      - java
+    message: "GCM detected, please check that IV/nonce is not reused"
+    patterns:
+      - pattern-either:
+        - pattern: $METHOD.getInstance("AES/GCM/NoPadding",...);
+        - pattern: new GCMParameterSpec(...);
+    severity: INFO

--- a/terraform/lang/security/ec2-imdsv1-optional.yaml
+++ b/terraform/lang/security/ec2-imdsv1-optional.yaml
@@ -1,17 +1,17 @@
 rules:
-  - id: ec2-imdsv1-optional
-    languages:
-      - generic
-    message: |
-      AWS EC2 Instance allowing use of the IMDSv1
-    metadata:
-      references:
-        - https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service
-        - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#metadata-options
-    paths:
-      include:
-        - '*.tf'
-    patterns:
-      - pattern: http_tokens = "optional"
-      - pattern-inside: '{ ... metadata_options { ... } ... }'
-    severity: ERROR
+- id: ec2-imdsv1-optional
+  languages:
+  - generic
+  message: |
+    AWS EC2 Instance allowing use of the IMDSv1
+  metadata:
+    references:
+    - https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service
+    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#metadata-options
+  paths:
+    include:
+    - '*.tf'
+  patterns:
+  - pattern: http_tokens = "optional"
+  - pattern-inside: '{ ... metadata_options { ... } ... }'
+  severity: ERROR


### PR DESCRIPTION
Reusing the same IV/nonce with GCM can make encryption totally useless with the knowledge of one (cleartext,ciphertext) pair (cf https://www.youtube.com/watch?v=r1awgAl90wM)

This is a first basic rule: it only detects hardcoded IVs built from strings.
I have not found how to detect harcoded byte arrays

There is also an INFO rule for manual review each time GCM is detected.

NB: Those rules could be defined for other languages than Java.