### PR TITLE
fix: updates javascript.express.security.audit.xss.mustache.explicit-unescape to better support non-mustache templates

### DIFF
--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
@@ -60,7 +60,7 @@
     {{/time}}
 </script>
 
-<!-- ok: template-explicit-unescape-->
-<custom-element color="{{ form.controls.firstName.invalid && form.controls.firstName.touched ? 'red': 'green' }}"></custom-element>
+<!-- ok: template-explicit-unescape -->
+<custom-element color="{{ form.controls.name.invalid && form.controls.name.touched ? 'red': 'green' }}"></custom-element>
 
 </html>

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.mustache
@@ -60,4 +60,7 @@
     {{/time}}
 </script>
 
+<!-- ok: template-explicit-unescape-->
+<custom-element color="{{ form.controls.firstName.invalid && form.controls.firstName.touched ? 'red': 'green' }}"></custom-element>
+
 </html>

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
@@ -25,4 +25,4 @@ rules:
   severity: WARNING
   pattern-either:
   - pattern-regex: '{{{((?!include).)*?}}}'
-  - pattern-regex: '{{[^}]*&[^}]*}}'
+  - pattern-regex: '{{[^}&]*&[^}&]*}}'


### PR DESCRIPTION
Solution:

Updates Regex to avoid certain angular template patterns, and adds test element to validate 

Addresses #1335 returntocorp/semgrep/issues/3344 