### PR TITLE
Cleanup OWASP metadata strings

### DIFF
--- a/contrib/nodejsscan/xss_mustache_escape.yaml
+++ b/contrib/nodejsscan/xss_mustache_escape.yaml
@@ -6,7 +6,7 @@ rules:
   - javascript
   metadata:
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
-    owasp: 'A7: Cross-Site Scripting XSS'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - node.js

--- a/generic/html-templates/security/unquoted-attribute-var.yaml
+++ b/generic/html-templates/security/unquoted-attribute-var.yaml
@@ -6,7 +6,7 @@ rules:
     add quotes around the template expression, like this: "{{ expr }}".
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
     category: security

--- a/generic/html-templates/security/var-in-href.yaml
+++ b/generic/html-templates/security/var-in-href.yaml
@@ -12,7 +12,7 @@ rules:
     You may also consider setting the Content Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
     - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#url

--- a/generic/html-templates/security/var-in-script-src.yaml
+++ b/generic/html-templates/security/var-in-script-src.yaml
@@ -10,7 +10,7 @@ rules:
     allowlist and be sure to URL-encode the result.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://adamj.eu/tech/2020/02/18/safely-including-data-for-javascript-in-a-django-template/?utm_campaign=Django%2BNewsletter&utm_medium=rss&utm_source=Django_Newsletter_12A
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough

--- a/generic/html-templates/security/var-in-script-tag.yaml
+++ b/generic/html-templates/security/var-in-script-tag.yaml
@@ -13,7 +13,7 @@ rules:
     retrieving the data in your script by using the element ID (e.g., `document.getElementById`).
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://adamj.eu/tech/2020/02/18/safely-including-data-for-javascript-in-a-django-template/?utm_campaign=Django%2BNewsletter&utm_medium=rss&utm_source=Django_Newsletter_12A
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough

--- a/go/lang/security/audit/net/wip-xss-using-responsewriter-and-printf.yaml
+++ b/go/lang/security/audit/net/wip-xss-using-responsewriter-and-printf.yaml
@@ -51,7 +51,7 @@ rules:
     sanitized or escaped.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: "A7: Cross-Site Scripting ('XSS')"
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
   severity: WARNING
   languages:

--- a/go/lang/security/audit/xss/import-text-template.yaml
+++ b/go/lang/security/audit/xss/import-text-template.yaml
@@ -4,7 +4,7 @@ rules:
     'text/template' does not escape HTML content. If you need
     to escape HTML content, use 'html/template' instead.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://www.veracode.com/blog/secure-development/use-golang-these-mistakes-could-compromise-your-apps-security

--- a/go/lang/security/audit/xss/no-direct-write-to-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-direct-write-to-responsewriter.yaml
@@ -6,7 +6,7 @@ rules:
     vulnerabilities. Instead, use the 'html/template' package
     and render data using 'template.Execute()'.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/

--- a/go/lang/security/audit/xss/no-fprintf-to-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-fprintf-to-responsewriter.yaml
@@ -6,7 +6,7 @@ rules:
     vulnerabilities. Instead, use the 'html/template' package
     to render data to users.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/

--- a/go/lang/security/audit/xss/no-interpolation-in-tag.yaml
+++ b/go/lang/security/audit/xss/no-interpolation-in-tag.yaml
@@ -8,7 +8,7 @@ rules:
     tags instead.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://github.com/golang/go/issues/19669
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/

--- a/go/lang/security/audit/xss/no-interpolation-js-template-string.yaml
+++ b/go/lang/security/audit/xss/no-interpolation-js-template-string.yaml
@@ -10,7 +10,7 @@ rules:
     is properly escaped.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://github.com/golang/go/issues/9200#issuecomment-66100328
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/

--- a/go/lang/security/audit/xss/no-io-writestring-to-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-io-writestring-to-responsewriter.yaml
@@ -6,7 +6,7 @@ rules:
     vulnerabilities. Instead, use the 'html/template' package
     to render data to users.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/

--- a/go/lang/security/audit/xss/no-printf-in-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-printf-in-responsewriter.yaml
@@ -6,7 +6,7 @@ rules:
     vulnerabilities. Instead, use the 'html/template' package
     to render data to users.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://blogtitle.github.io/robn-go-security-pearls-cross-site-scripting-xss/

--- a/go/lang/security/audit/xss/template-html-does-not-escape.yaml
+++ b/go/lang/security/audit/xss/template-html-does-not-escape.yaml
@@ -9,7 +9,7 @@ rules:
     use 'template.Execute()'.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://golang.org/pkg/html/template/#HTML
     - https://github.com/0c34/govwa/blob/139693e56406b5684d2a6ae22c0af90717e149b8/vulnerability/xss/xss.go#L33

--- a/java/lang/security/audit/crypto/rsa-no-padding.yaml
+++ b/java/lang/security/audit/crypto/rsa-no-padding.yaml
@@ -2,7 +2,7 @@ rules:
 - id: rsa-no-padding
   metadata:
     cwe: 'CWE-326: Inadequate Encryption Strength'
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     source-rule-url: https://find-sec-bugs.github.io/bugs.htm#RSA_NO_PADDING
     references:
     - https://rdist.root.org/2009/10/06/why-rsa-encryption-padding-is-critical/

--- a/java/lang/security/audit/xss/jsf/autoescape-disabled.yaml
+++ b/java/lang/security/audit/xss/jsf/autoescape-disabled.yaml
@@ -6,7 +6,7 @@ rules:
     vulnerability. Ensure no external data can reach here, or
     remove 'escape=false' from this element.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: 'CWE-150: Improper Neutralization of Escape, Meta, or Control Sequences'
     references:
     - https://stackoverflow.com/a/7442668

--- a/java/lang/security/audit/xss/jsp/no-scriptlets.yaml
+++ b/java/lang/security/audit/xss/jsp/no-scriptlets.yaml
@@ -6,7 +6,7 @@ rules:
     Instead, consider migrating to JSF or using the Expression Language
     '${...}' with the escapeXml function in your JSP files.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
     references:
     - https://stackoverflow.com/a/3180202

--- a/java/lang/security/audit/xss/jsp/use-escapexml.yaml
+++ b/java/lang/security/audit/xss/jsp/use-escapexml.yaml
@@ -8,7 +8,7 @@ rules:
     the JSTL taglib. See https://www.tutorialspoint.com/jsp/jstl_function_escapexml.htm
     for more information.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
     references:
     - https://www.tutorialspoint.com/jsp/jstl_function_escapexml.htm

--- a/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
+++ b/java/lang/security/audit/xss/jsp/use-jstl-escaping.yaml
@@ -9,7 +9,7 @@ rules:
     See https://www.tutorialspoint.com/jsp/jstl_core_out_tag.htm
     for more information.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
     references:
     - https://www.tutorialspoint.com/jsp/jstl_core_out_tag.htm

--- a/java/lang/security/audit/xss/no-direct-response-writer.yaml
+++ b/java/lang/security/audit/xss/no-direct-response-writer.yaml
@@ -28,7 +28,7 @@ rules:
     Consider using a view technology such as JavaServer Faces (JSFs) which
     automatically escapes HTML views.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
     references:
     - https://www3.ntu.edu.sg/home/ehchua/programming/java/JavaServerFaces.html

--- a/java/lang/security/servletresponse-writer-xss.yaml
+++ b/java/lang/security/servletresponse-writer-xss.yaml
@@ -6,7 +6,7 @@ rules:
     data is properly encoded using org.owasp.encoder.Encode.forHtml: 'Encode.forHtml($VAR)'.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: "A7: Cross-Site Scripting ('XSS')"
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     source-rule-url: https://find-sec-bugs.github.io/bugs.htm#XSS_SERVLET
     category: security
   severity: ERROR

--- a/javascript/browser/security/dom-based-xss.yaml
+++ b/javascript/browser/security/dom-based-xss.yaml
@@ -11,7 +11,7 @@ rules:
     Consider allowlisting appropriate values or using an approach which does not involve the URL.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://owasp.org/www-community/attacks/DOM_Based_XSS
     category: security

--- a/javascript/browser/security/insecure-document-method.yaml
+++ b/javascript/browser/security/insecure-document-method.yaml
@@ -16,7 +16,7 @@ rules:
     User controlled data in methods like `innerHTML`, `outerHTML` or `document.write` is an anti-pattern that can lead to XSS vulnerabilities
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - browser

--- a/javascript/browser/security/insecure-innerhtml.yaml
+++ b/javascript/browser/security/insecure-innerhtml.yaml
@@ -9,7 +9,7 @@ rules:
     User controlled data in a `$EL.innerHTML` is an anti-pattern that can lead to XSS vulnerabilities
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - browser

--- a/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
+++ b/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
@@ -24,7 +24,7 @@ rules:
 
   severity: WARNING
   metadata:
-    owasp: 'A6: Sensitive Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-345: Insufficient Verification of Data Authenticity'
     category: security
     technology:

--- a/javascript/browser/security/raw-html-concat.yaml
+++ b/javascript/browser/security/raw-html-concat.yaml
@@ -8,7 +8,7 @@ rules:
   severity: WARNING
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://owasp.org/www-community/attacks/xss/
     category: security

--- a/javascript/browser/security/wildcard-postmessage-configuration.yaml
+++ b/javascript/browser/security/wildcard-postmessage-configuration.yaml
@@ -7,7 +7,7 @@ rules:
   - typescript
   severity: WARNING
   metadata:
-    owasp: 'A6: Sensitive Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-345: Insufficient Verification of Data Authenticity'
     category: security
     technology:

--- a/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
@@ -8,7 +8,7 @@ rules:
     need escaping, ensure no external data can reach this location.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - http://www.managerjs.com/blog/2015/05/will-ejs-escape-save-me-from-xss-sorta/
     category: security

--- a/javascript/express/security/audit/xss/ejs/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-href.yaml
@@ -10,7 +10,7 @@ rules:
     the Content Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
     - https://github.com/pugjs/pug/issues/2952

--- a/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
@@ -10,7 +10,7 @@ rules:
     allowlist and be sure to URL-encode the result.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
     - https://github.com/ESAPI/owasp-esapi-js

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
@@ -11,7 +11,7 @@ rules:
     in OWASP ESAPI.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
     - https://github.com/ESAPI/owasp-esapi-js

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
@@ -9,7 +9,7 @@ rules:
     can reach this location.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://github.com/janl/mustache.js/#variables
     category: security

--- a/javascript/express/security/audit/xss/mustache/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-href.yaml
@@ -10,7 +10,7 @@ rules:
     the Content Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
     - https://github.com/pugjs/pug/issues/2952

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
@@ -11,7 +11,7 @@ rules:
     in OWASP ESAPI.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
     - https://github.com/ESAPI/owasp-esapi-js

--- a/javascript/express/security/audit/xss/pug/and-attributes.yaml
+++ b/javascript/express/security/audit/xss/pug/and-attributes.yaml
@@ -8,7 +8,7 @@ rules:
     can reach this location.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://pugjs.org/language/attributes.html#attributes
     category: security

--- a/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
@@ -8,7 +8,7 @@ rules:
     can reach this location.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://pugjs.org/language/code.html#unescaped-buffered-code
     - https://pugjs.org/language/attributes.html#unescaped-attributes

--- a/javascript/express/security/audit/xss/pug/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-href.yaml
@@ -10,7 +10,7 @@ rules:
     the Content Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://github.com/pugjs/pug/issues/2952
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI

--- a/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
@@ -11,7 +11,7 @@ rules:
     in OWASP ESAPI.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough
     - https://github.com/ESAPI/owasp-esapi-js

--- a/javascript/fbjs/security/audit/insecure-createnodesfrommarkup.yaml
+++ b/javascript/fbjs/security/audit/insecure-createnodesfrommarkup.yaml
@@ -10,7 +10,7 @@ rules:
     User controlled data in a `createNodesFromMarkup` is an anti-pattern that can lead to XSS vulnerabilities
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - fbjs

--- a/javascript/jquery/security/audit/jquery-insecure-method.yaml
+++ b/javascript/jquery/security/audit/jquery-insecure-method.yaml
@@ -7,7 +7,7 @@ rules:
   severity: WARNING
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://owasp.org/www-community/attacks/xss/
     - https://bugs.jquery.com/ticket/9521

--- a/javascript/jquery/security/audit/jquery-insecure-selector.yaml
+++ b/javascript/jquery/security/audit/jquery-insecure-selector.yaml
@@ -7,7 +7,7 @@ rules:
   severity: WARNING
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://owasp.org/www-community/attacks/xss/
     - https://bugs.jquery.com/ticket/9521

--- a/javascript/jquery/security/audit/prohibit-jquery-html.yaml
+++ b/javascript/jquery/security/audit/prohibit-jquery-html.yaml
@@ -9,7 +9,7 @@ rules:
     JQuery's html function can lead to XSS. If the string is plain test, use the text function instead.
     Otherwise, use a function that escapes html such as edx's HtmlUtils.setHtml.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss.html#javascript-concat-html

--- a/javascript/lang/security/audit/unknown-value-with-script-tag.yaml
+++ b/javascript/lang/security/audit/unknown-value-with-script-tag.yaml
@@ -11,7 +11,7 @@ rules:
     could be susceptible to cross-site scripting (XSS). Ensure '$UNK' is not
     externally controlled, or sanitize this data.
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://www.developsec.com/2017/11/09/xss-in-a-script-tag/

--- a/javascript/lang/security/detect-disable-mustache-escape.yaml
+++ b/javascript/lang/security/detect-disable-mustache-escape.yaml
@@ -2,7 +2,7 @@ rules:
 - id: detect-disable-mustache-escape
   metadata:
     cwe: 'CWE-116: Improper Encoding or Escaping of Output'
-    owasp: 'A7: Cross-Site Scripting XSS'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-disable-mustache-escape.js
     category: security
   message: |

--- a/python/django/security/audit/xss/class-extends-safestring.yaml
+++ b/python/django/security/audit/xss/class-extends-safestring.yaml
@@ -8,7 +8,7 @@ rules:
     use 'mark_safe' instead and ensure no user data can reach it.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.1/howto/custom-template-tags/#filters-and-auto-escaping
     - https://github.com/django/django/blob/f138e75910b1e541686c4dce3d8f467f6fc234cb/django/utils/safestring.py#L11

--- a/python/django/security/audit/xss/context-autoescape-off.yaml
+++ b/python/django/security/audit/xss/context-autoescape-off.yaml
@@ -7,7 +7,7 @@ rules:
     to 'True'.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.1/ref/settings/#templates
     - https://docs.djangoproject.com/en/3.1/topics/templates/#django.template.backends.django.DjangoTemplates

--- a/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
+++ b/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
@@ -7,7 +7,7 @@ rules:
     template engine to safely render HTML.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.1/intro/tutorial03/#a-shortcut-render
     - https://docs.djangoproject.com/en/3.1/topics/http/shortcuts/#render

--- a/python/django/security/audit/xss/filter-with-is-safe.yaml
+++ b/python/django/security/audit/xss/filter-with-is-safe.yaml
@@ -10,7 +10,7 @@ rules:
     content with 'mark_safe()'.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.1/topics/security/#cross-site-scripting-xss-protection
     - https://docs.djangoproject.com/en/3.1/howto/custom-template-tags/#filters-and-auto-escaping

--- a/python/django/security/audit/xss/global-autoescape-off.yaml
+++ b/python/django/security/audit/xss/global-autoescape-off.yaml
@@ -7,7 +7,7 @@ rules:
     to 'True'.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.1/ref/settings/#templates
     - https://docs.djangoproject.com/en/3.1/topics/templates/#django.template.backends.django.DjangoTemplates

--- a/python/django/security/audit/xss/html-magic-method.yaml
+++ b/python/django/security/audit/xss/html-magic-method.yaml
@@ -9,7 +9,7 @@ rules:
     to render raw HTML than a class with a magic method.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.0/_modules/django/utils/html/#conditional_escape
     - https://gist.github.com/minusworld/7885d8a81dba3ea2d1e4b8fd3c218ef5

--- a/python/django/security/audit/xss/html-safe.yaml
+++ b/python/django/security/audit/xss/html-safe.yaml
@@ -10,7 +10,7 @@ rules:
     to render raw HTML than a class with a magic method.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.0/_modules/django/utils/html/#html_safe
     - https://gist.github.com/minusworld/7885d8a81dba3ea2d1e4b8fd3c218ef5

--- a/python/django/security/audit/xss/template-autoescape-off.yaml
+++ b/python/django/security/audit/xss/template-autoescape-off.yaml
@@ -7,7 +7,7 @@ rules:
     If you must do this, consider instead, using `mark_safe` in Python code.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#autoescape
     category: security

--- a/python/django/security/audit/xss/template-blocktranslate-no-escape.yaml
+++ b/python/django/security/audit/xss/template-blocktranslate-no-escape.yaml
@@ -27,7 +27,7 @@ rules:
       {%...endfilter...%}
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss_in_django_templates.html#html-escaping-translations-in-django-templates
     - https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#internationalization-in-template-code

--- a/python/django/security/audit/xss/template-href-var.yaml
+++ b/python/django/security/audit/xss/template-href-var.yaml
@@ -9,7 +9,7 @@ rules:
     the Content Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
     - https://docs.djangoproject.com/en/3.1/ref/templates/builtins/#url

--- a/python/django/security/audit/xss/template-translate-as-no-escape.yaml
+++ b/python/django/security/audit/xss/template-translate-as-no-escape.yaml
@@ -110,7 +110,7 @@ rules:
       {{ ... $TRANS ... }}
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss_in_django_templates.html#html-escaping-translations-in-django-templates
     - https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#internationalization-in-template-code

--- a/python/django/security/audit/xss/template-translate-no-escape.yaml
+++ b/python/django/security/audit/xss/template-translate-no-escape.yaml
@@ -31,7 +31,7 @@ rules:
       {%...endfilter...%}
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://edx.readthedocs.io/projects/edx-developer-guide/en/latest/preventing_xss/preventing_xss_in_django_templates.html#html-escaping-translations-in-django-templates
     - https://docs.djangoproject.com/en/3.1/topics/i18n/translation/#internationalization-in-template-code

--- a/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
+++ b/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
@@ -8,7 +8,7 @@ rules:
     use `mark_safe` in your Python code.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://docs.djangoproject.com/en/3.0/ref/templates/builtins/#safeseq
     category: security

--- a/python/django/security/audit/xss/var-in-script-tag.yaml
+++ b/python/django/security/audit/xss/var-in-script-tag.yaml
@@ -18,7 +18,7 @@ rules:
   - pattern: '{{ ... }}'
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://adamj.eu/tech/2020/02/18/safely-including-data-for-javascript-in-a-django-template/?utm_campaign=Django%2BNewsletter&utm_medium=rss&utm_source=Django_Newsletter_12A
     - https://www.veracode.com/blog/secure-development/nodejs-template-engines-why-default-encoders-are-not-enough

--- a/python/flask/security/audit/directly-returned-format-string.yaml
+++ b/python/flask/security/audit/directly-returned-format-string.yaml
@@ -7,7 +7,7 @@ rules:
     'render_template()'.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - flask

--- a/python/flask/security/xss/audit/direct-use-of-jinja2.yaml
+++ b/python/flask/security/xss/audit/direct-use-of-jinja2.yaml
@@ -8,7 +8,7 @@ rules:
     in order to prevent XSS.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://jinja.palletsprojects.com/en/2.11.x/api/#basics
     category: security

--- a/python/flask/security/xss/audit/explicit-unescape-with-markup.yaml
+++ b/python/flask/security/xss/audit/explicit-unescape-with-markup.yaml
@@ -7,7 +7,7 @@ rules:
     or consider rewriting to not use 'Markup()'.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://tedboy.github.io/flask/generated/generated/flask.Markup.html
     category: security

--- a/python/flask/security/xss/audit/template-autoescape-off.yaml
+++ b/python/flask/security/xss/audit/template-autoescape-off.yaml
@@ -7,7 +7,7 @@ rules:
     is a cross-site scripting (XSS) vulnerability, or turn autoescape on.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/templating/#controlling-autoescaping
     - https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup

--- a/python/flask/security/xss/audit/template-href-var.yaml
+++ b/python/flask/security/xss/audit/template-href-var.yaml
@@ -9,7 +9,7 @@ rules:
     Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
     - https://content-security-policy.com/

--- a/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
+++ b/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
@@ -7,7 +7,7 @@ rules:
     is a cross-site scripting (XSS) vulnerability.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
     category: security

--- a/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
+++ b/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
@@ -6,7 +6,7 @@ rules:
     add quotes around the template expression, like this: "{{ expr }}".
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss
     category: security

--- a/python/jwt/security/unverified-jwt-decode.yaml
+++ b/python/jwt/security/unverified-jwt-decode.yaml
@@ -7,7 +7,7 @@ rules:
     checks for the token which means the token could be tampered with by
     malicious actors. Ensure that the JWT token is verified.
   metadata:
-    owasp: 'A5: Broken Authentication'
+    owasp: 'A2: Broken Authentication'
     cwe: 'CWE-287: Improper Authentication'
     references:
     - https://github.com/we45/Vulnerable-Flask-App/blob/752ee16087c0bfb79073f68802d907569a1f0df7/app/app.py#L96

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open-ftp.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open-ftp.yaml
@@ -6,7 +6,7 @@ rules:
     unencrypted. Consider using SFTP instead. urllib does not support SFTP,
     so consider a library which supports SFTP.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.OpenerDirector.open

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-openerdirector-open.yaml
@@ -4,7 +4,7 @@ rules:
     Detected an unsecured transmission channel. 'OpenerDirector.open(...)' is
     being used with 'http://'. Use 'https://' instead to secure the channel.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.OpenerDirector.open

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-request-object-ftp.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-request-object-ftp.yaml
@@ -6,7 +6,7 @@ rules:
     SFTP instead. urllib does not support SFTP natively, so consider using
     a library which supports SFTP.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.Request

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-request-object.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-request-object.yaml
@@ -5,7 +5,7 @@ rules:
     protocol, 'http://'. This connection will not be encrypted. Use
     'https://' instead.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.Request

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen-ftp.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen-ftp.yaml
@@ -5,7 +5,7 @@ rules:
     encrypted. Consider using SFTP instead. urllib does not support SFTP,
     so consider switching to a library which supports SFTP.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopen.yaml
@@ -4,7 +4,7 @@ rules:
     Detected 'urllib.urlopen()' using 'http://'. This request will not be
     encrypted. Use 'https://' instead.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open-ftp.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open-ftp.yaml
@@ -5,7 +5,7 @@ rules:
     being used with 'ftp://'. Use SFTP instead. urllib does not support
     SFTP, so consider using a library which supports SFTP.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.URLopener.open

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-open.yaml
@@ -4,7 +4,7 @@ rules:
     Detected an unsecured transmission channel. 'URLopener.open(...)' is
     being used with 'http://'. Use 'https://' instead to secure the channel.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.URLopener.open

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve-ftp.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve-ftp.yaml
@@ -5,7 +5,7 @@ rules:
     being used with 'ftp://'. Use SFTP instead. urllib does not support
     SFTP, so consider using a library which supports SFTP.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.URLopener.retrieve

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlopener-retrieve.yaml
@@ -4,7 +4,7 @@ rules:
     Detected an unsecured transmission channel. 'URLopener.retrieve(...)' is
     being used with 'http://'. Use 'https://' instead to secure the channel.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.URLopener.retrieve

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve-ftp.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve-ftp.yaml
@@ -5,7 +5,7 @@ rules:
     encrypted. Use SFTP instead. urllib does not support SFTP, so consider
     switching to a library which supports SFTP.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.urlretrieve

--- a/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve.yaml
+++ b/python/lang/security/audit/insecure-transport/urllib/insecure-urlretrieve.yaml
@@ -4,7 +4,7 @@ rules:
     Detected 'urllib.urlretrieve()' using 'http://'. This request will not be
     encrypted. Use 'https://' instead.
   metadata:
-    owasp: 'A3: Sensitve Data Exposure'
+    owasp: 'A3: Sensitive Data Exposure'
     cwe: 'CWE-319: Cleartext Transmission of Sensitive Information'
     references:
     - https://docs.python.org/3/library/urllib.request.html#urllib.request.urlretrieve

--- a/ruby/rails/security/audit/xss/avoid-content-tag.yaml
+++ b/ruby/rails/security/audit/xss/avoid-content-tag.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: avoid-content-tag
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/template_injection/index.markdown

--- a/ruby/rails/security/audit/xss/avoid-html-safe.yaml
+++ b/ruby/rails/security/audit/xss/avoid-html-safe.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: avoid-html-safe
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/cross_site_scripting/index.markdown

--- a/ruby/rails/security/audit/xss/avoid-raw.yaml
+++ b/ruby/rails/security/audit/xss/avoid-raw.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: avoid-raw
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html#method-i-raw

--- a/ruby/rails/security/audit/xss/avoid-render-inline.yaml
+++ b/ruby/rails/security/audit/xss/avoid-render-inline.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: avoid-render-inline
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#inline-renders---even-worse-than-xss

--- a/ruby/rails/security/audit/xss/avoid-render-text.yaml
+++ b/ruby/rails/security/audit/xss/avoid-render-text.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: avoid-render-text
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#inline-renders---even-worse-than-xss

--- a/ruby/rails/security/audit/xss/manual-template-creation.yaml
+++ b/ruby/rails/security/audit/xss/manual-template-creation.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: manual-template-creation
   metadata:
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
     - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/template_injection/index.markdown

--- a/ruby/rails/security/audit/xss/templates/dangerous-link-to.yaml
+++ b/ruby/rails/security/audit/xss/templates/dangerous-link-to.yaml
@@ -11,7 +11,7 @@ rules:
     setting the Content Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#cross-site-scripting-xss
     - https://brakemanscanner.org/docs/warning_types/link_to_href/

--- a/ruby/rails/security/audit/xss/templates/unquoted-attribute.yaml
+++ b/ruby/rails/security/audit/xss/templates/unquoted-attribute.yaml
@@ -6,7 +6,7 @@ rules:
     add quotes around the template expression, like this: "<%= expr %>".
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://brakemanpro.com/2017/09/08/cross-site-scripting-in-rails#unquoted-attributes
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss

--- a/ruby/rails/security/audit/xss/templates/var-in-href.yaml
+++ b/ruby/rails/security/audit/xss/templates/var-in-href.yaml
@@ -10,7 +10,7 @@ rules:
     the Content Security Policy (CSP) header.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://flask.palletsprojects.com/en/1.1.x/security/#cross-site-scripting-xss#:~:text=javascript:%20URI
     - https://github.com/pugjs/pug/issues/2952

--- a/typescript/react/security/audit/react-css-injection.yaml
+++ b/typescript/react/security/audit/react-css-injection.yaml
@@ -25,7 +25,7 @@ rules:
     User controlled data in a `style` attribute is an anti-pattern that can lead to XSS vulnerabilities
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - react

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -9,7 +9,7 @@ rules:
     Setting HTML from code is risky because it’s easy to inadvertently expose your users to a cross-site scripting (XSS) attack.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
     category: security

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -32,7 +32,7 @@ rules:
     a safe method which sanitizes URLs for the 'javascript:' URI.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls
     - https://pragmaticwebsecurity.com/articles/spasecurity/react-xss-part1.html

--- a/typescript/react/security/audit/react-html-element-spreading.yaml
+++ b/typescript/react/security/audit/react-html-element-spreading.yaml
@@ -11,7 +11,7 @@ rules:
     passing `dangerouslySetInnerHTML` to an element.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - react

--- a/typescript/react/security/audit/react-no-refs.yaml
+++ b/typescript/react/security/audit/react-no-refs.yaml
@@ -10,7 +10,7 @@ rules:
     `ref` usage found, refs give direct DOM access and may create a possibility for XSS
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - react

--- a/typescript/react/security/audit/react-props-injection.yaml
+++ b/typescript/react/security/audit/react-props-injection.yaml
@@ -25,7 +25,7 @@ rules:
     Inject arbitrary props into the new element. It may introduce an XSS vulnerability.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://medium.com/dailyjs/exploiting-script-injection-flaws-in-reactjs-883fb1fe36c1
     category: security

--- a/typescript/react/security/audit/react-styled-components-injection.yaml
+++ b/typescript/react/security/audit/react-styled-components-injection.yaml
@@ -39,7 +39,7 @@ rules:
     User controlled data in a styled component's css is an anti-pattern that can lead to XSS vulnerabilities
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://styled-components.com/docs/advanced#security
     category: security

--- a/typescript/react/security/audit/react-unsanitized-method.yaml
+++ b/typescript/react/security/audit/react-unsanitized-method.yaml
@@ -12,7 +12,7 @@ rules:
     User controlled data in a insertAdjacentHTML, document.write or document.writeln is an anti-pattern that can lead to XSS vulnerabilities
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - react

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -14,7 +14,7 @@ rules:
     User controlled data in a `$X` is an anti-pattern that can lead to XSS vulnerabilities
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     category: security
     technology:
     - react

--- a/typescript/react/security/react-markdown-insecure-html.yaml
+++ b/typescript/react/security/react-markdown-insecure-html.yaml
@@ -25,7 +25,7 @@ rules:
     Overwriting `transformLinkUri` or `transformImageUri` to something insecure or turning `allowDangerousHtml` on, will open code up to XSS vectors.
   metadata:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp: 'A7: Cross-site Scripting (XSS)'
+    owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
     - https://www.npmjs.com/package/react-markdown#security
     category: security


### PR DESCRIPTION
For https://github.com/returntocorp/enterprise/issues/668.

Makes this query more useful:

```
$ rg -g '*.yaml' -g '!*.test.yaml' -I -o 'owasp: .*' | sort | uniq -c
      1 owasp: ...'
      1 owasp: "=~/^A([0-9]|10): .+$/"'
    181 owasp: 'A1: Injection'
     53 owasp: 'A2: Broken Authentication'
    133 owasp: 'A3: Sensitive Data Exposure'
     23 owasp: 'A4: XML External Entities (XXE)'
      9 owasp: 'A5: Broken Access Control'
     46 owasp: 'A6: Security Misconfiguration'
     91 owasp: 'A7: Cross-Site Scripting (XSS)'
     31 owasp: 'A8: Insecure Deserialization'
     19 owasp: 'A9: Using Components with Known Vulnerabilities'
```