### PR TITLE
Dockerfile ignore line continuation

### DIFF
--- a/generic/dockerfile/best-practice/missing-dnf-clean-all.dockerfile
+++ b/generic/dockerfile/best-practice/missing-dnf-clean-all.dockerfile
@@ -7,5 +7,10 @@ RUN dnf update \
     && dnf install foo-1.0 \
     && dnf clean all
 
+# ok: missing-dnf-clean-all
+RUN dnf update && \
+    dnf install foo-1.0 && \
+    dnf clean all
+
 # ruleid: missing-dnf-clean-all
 RUN dnf install foo-1.0

--- a/generic/dockerfile/best-practice/missing-dnf-clean-all.yaml
+++ b/generic/dockerfile/best-practice/missing-dnf-clean-all.yaml
@@ -5,6 +5,7 @@ rules:
   patterns:
   - pattern: dnf $COMMAND
   - pattern-not-inside: RUN ... && dnf clean all
+  - pattern-not-inside: RUN ... && \ dnf clean all
   message: |
     This dnf command does not end with '&& dnf clean all'. Running 'dnf clean all' will remove cached data and reduce package size. (This must be performed in the same RUN step.)
   metadata:

--- a/generic/dockerfile/best-practice/missing-yum-clean-all.dockerfile
+++ b/generic/dockerfile/best-practice/missing-yum-clean-all.dockerfile
@@ -5,5 +5,10 @@ RUN yum update \
     && yum install foo-1.0 \
     && yum clean all
 
+# ok: missing-yum-clean-all
+RUN yum update && \
+    yum install foo-1.0 && \
+    yum clean all
+
 # ruleid: missing-yum-clean-all
 RUN yum install foo-1.0

--- a/generic/dockerfile/best-practice/missing-yum-clean-all.yaml
+++ b/generic/dockerfile/best-practice/missing-yum-clean-all.yaml
@@ -5,6 +5,7 @@ rules:
   patterns:
   - pattern: yum $COMMAND
   - pattern-not-inside: RUN ... && yum clean all
+  - pattern-not-inside: RUN ... && \ yum clean all
   message: |
     This yum command does not end with '&& yum clean all'. Running 'yum clean all' will remove cached data and reduce package size. (This must be performed in the same RUN step.)
   metadata:

--- a/generic/dockerfile/best-practice/missing-zypper-clean.dockerfile
+++ b/generic/dockerfile/best-practice/missing-zypper-clean.dockerfile
@@ -5,3 +5,6 @@ FROM opensuse/leap:15.2
 RUN zypper install -y httpd=2.4.46
 # ok: missing-zypper-clean
 RUN zypper install -y httpd=2.4.46 && zypper clean
+# ok: missing-zypper-clean
+RUN zypper install -y httpd=2.4.46 && \
+  zypper clean

--- a/generic/dockerfile/best-practice/missing-zypper-clean.yaml
+++ b/generic/dockerfile/best-practice/missing-zypper-clean.yaml
@@ -5,6 +5,7 @@ rules:
   patterns:
   - pattern: zypper $COMMAND
   - pattern-not-inside: RUN ... && zypper clean
+  - pattern-not-inside: RUN ... && \ zypper clean
   message: |
     This zypper command does not end with '&& zypper clean'. Running 'zypper clean' will remove cached data and reduce package size. (This must be performed in the same RUN step.)
   metadata:


### PR DESCRIPTION
Fix false positives for Dockerfiles with line continuation after the `&&`.
Added more unit tests.
Fixed for `yum`, `dnf`, and `zypper`