### PR TITLE
detect bracket object injection fix fp

### DIFF
--- a/javascript/lang/security/audit/detect-bracket-object-injection.js
+++ b/javascript/lang/security/audit/detect-bracket-object-injection.js
@@ -11,14 +11,16 @@ const validate = function() {
   }
   // ruleid:detect-bracket-object-injection
   const badField = formData[formData["foo"]];
-  // ok
+  // ok:detect-bracket-object-injection
   const goodField = formData[someOtherField];
-  // ok
+  // ok:detect-bracket-object-injection
   const someField = formData["bar"]
-  // ok
+  // ok:detect-bracket-object-injection
   const email = formData.split("@")[0];
   // ruleid:detect-bracket-object-injection
   const email = formData.split("@")[0 + a];
+  // ruleid:detect-bracket-object-injection
+  const email = formData.split("@")[a + 0];
   return {
     name: fieldName,
     value: '',

--- a/javascript/lang/security/audit/detect-bracket-object-injection.js
+++ b/javascript/lang/security/audit/detect-bracket-object-injection.js
@@ -15,6 +15,10 @@ const validate = function() {
   const goodField = formData[someOtherField];
   // ok
   const someField = formData["bar"]
+  // ok
+  const email = formData.split("@")[0];
+  // ruleid:detect-bracket-object-injection
+  const email = formData.split("@")[0 + a];
   return {
     name: fieldName,
     value: '',

--- a/javascript/lang/security/audit/detect-bracket-object-injection.yaml
+++ b/javascript/lang/security/audit/detect-bracket-object-injection.yaml
@@ -8,6 +8,10 @@ rules:
   - pattern-not-inside: |
       const $FIELD = ...;
       ...
+  - metavariable-regex:
+      metavariable: $FIELD
+      regex: >-
+        .*[^0-9].*
   message: |
     Object injection via bracket notation via $FIELD
   severity: WARNING

--- a/javascript/lang/security/audit/detect-bracket-object-injection.yaml
+++ b/javascript/lang/security/audit/detect-bracket-object-injection.yaml
@@ -4,14 +4,12 @@ rules:
   - pattern: |
       const $VAR = $OBJ[$FIELD];
   - pattern-not: |
+      const $VAR = $OBJ[($FIELD : float)]
+  - pattern-not: |
       const $VAR = $OBJ["..."];
   - pattern-not-inside: |
       const $FIELD = ...;
       ...
-  - metavariable-regex:
-      metavariable: $FIELD
-      regex: >-
-        .*[^0-9].*
   message: |
     Object injection via bracket notation via $FIELD
   severity: WARNING


### PR DESCRIPTION
Don't alert on array indexing (e.g. `array[123]`).