### PR TITLE
Add rule for missing dollar-sign chars in JS template strings. 

### DIFF
--- a/javascript/lang/correctness/missing-template-string-indicator.js
+++ b/javascript/lang/correctness/missing-template-string-indicator.js
@@ -1,0 +1,9 @@
+function name() {
+  // ok: missing-template-string-indicator
+  return `this is ${start.line}`
+}
+
+function name2() {
+  // ruleid: missing-template-string-indicator
+  return `this is {start.line}`
+}

--- a/javascript/lang/correctness/missing-template-string-indicator.yaml
+++ b/javascript/lang/correctness/missing-template-string-indicator.yaml
@@ -1,0 +1,15 @@
+rules:
+- id: missing-template-string-indicator
+  patterns:
+  - pattern: '`... {...} ...`'
+  - pattern-not-inside: '`... ${...} ...`'
+  languages: [generic]
+  message: >-
+    This looks like a JavaScript template string. Are you missing a '$' in front of '{...}'?
+  paths:
+    include:
+    - '*.js'
+    - '*.ts'
+    - '*.jsx'
+    - '*.tsx'
+  severity: ERROR


### PR DESCRIPTION
Uses 'generic' for now

Closes https://github.com/returntocorp/semgrep-rules/issues/174