### PR TITLE
add dangerous-annotations-usage rule

### DIFF
--- a/python/lang/security/audit/dangerous-annotations-usage.py
+++ b/python/lang/security/audit/dangerous-annotations-usage.py
@@ -1,0 +1,19 @@
+from typing import List, Set, Dict, Tuple, Optional, get_type_hints
+
+class C:
+    member: int = 0
+
+def smth(payload):
+  # ruleid: dangerous-annotations-usage
+  C.__annotations__["member"] = payload
+  get_type_hints(C)
+
+def ok1():
+  # ok: dangerous-annotations-usage
+  C.__annotations__["member"] = int
+  get_type_hints(C)
+
+def ok2():
+  # ok: dangerous-annotations-usage
+  C.__annotations__["member"] = List
+  get_type_hints(C)

--- a/python/lang/security/audit/dangerous-annotations-usage.yaml
+++ b/python/lang/security/audit/dangerous-annotations-usage.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: dangerous-annotations-usage
+  patterns:
+  - pattern: |
+      $C.__annotations__[$NAME] = $X
+  - pattern-not: |
+      $C.__annotations__[$NAME] = "..."
+  - pattern-not: |
+      $C.__annotations__[$NAME] = typing.$Y
+  - metavariable-regex:
+      metavariable: $X
+      regex: (?!(int|float|complex|list|tuple|range|str|bytes|bytearray|memoryview|set|frozenset|dict))
+  message: Annotations passed to `typing.get_type_hints` are evaluated in `globals` and `locals` namespaces. Make sure that
+    no arbitrary value can be written as the annotation and passed to `typing.get_type_hints` function.
+  severity: INFO
+  metadata:
+    cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    owasp: 'A1: Injection'
+    category: security
+  languages:
+  - python

--- a/python/lang/security/audit/dangerous-annotations-usage.yaml
+++ b/python/lang/security/audit/dangerous-annotations-usage.yaml
@@ -17,5 +17,7 @@ rules:
     cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
     owasp: 'A1: Injection'
     category: security
+    references:
+    - https://docs.python.org/3/library/typing.html#typing.get_type_hints
   languages:
   - python


### PR DESCRIPTION
```python
class C:
    member: int = 0

C.__annotations__["member"] = "print('Hello world')"
get_type_hints(C) # 'Hello world' will be printed to console
```
annotations are evaluated when passed to `get_type_hints` (https://docs.python.org/3/library/typing.html#typing.get_type_hints)
tracking every `get_type_hints` call may end up in lots of FPs so I created a rule for highlighting arbitrary write to `__annotations__`