### PR TITLE
python code injection

### DIFF
--- a/python/lang/security/audit/dangerous-code-run.py
+++ b/python/lang/security/audit/dangerous-code-run.py
@@ -1,0 +1,39 @@
+import code
+
+def run_payload1(payload: str) -> None:
+    console = code.InteractiveConsole()
+    # ruleid: dangerous-interactive-code-run
+    console.push(payload)
+
+def run_payload2(payload: str) -> None:
+    inperpreter = code.InteractiveInterpreter()
+    # ruleid: dangerous-interactive-code-run
+    inperpreter.runcode(code.compile_command(payload))
+
+def run_payload3(payload: str) -> None:
+    inperpreter = code.InteractiveInterpreter()
+    # ruleid: dangerous-interactive-code-run
+    pl = code.compile_command(payload)
+    inperpreter.runcode(pl)
+
+def run_payload4(payload: str) -> None:
+    inperpreter = code.InteractiveInterpreter()
+    # ruleid: dangerous-interactive-code-run
+    inperpreter.runsource(payload)
+
+def ok1() -> None:
+    console = code.InteractiveConsole()
+    console.push('print(123)')
+
+def ok2() -> None:
+    inperpreter = code.InteractiveInterpreter()
+    inperpreter.runcode(code.compile_command('print(123)'))
+
+def ok3() -> None:
+    inperpreter = code.InteractiveInterpreter()
+    pl = code.compile_command('print(123)')
+    inperpreter.runcode(pl)
+
+def ok4() -> None:
+    inperpreter = code.InteractiveInterpreter()
+    inperpreter.runsource('print(123)')

--- a/python/lang/security/audit/dangerous-code-run.yaml
+++ b/python/lang/security/audit/dangerous-code-run.yaml
@@ -1,0 +1,42 @@
+rules:
+- id: dangerous-interactive-code-run
+  patterns:
+  - pattern-either:
+    - pattern: |
+        $X.push($PAYLOAD,...)
+    - pattern: |
+        $X.runsource($PAYLOAD,...)
+    - pattern: |
+        $X.runcode(code.compile_command($PAYLOAD),...)
+    - pattern: |
+        $PL = code.compile_command($PAYLOAD,...)
+        ...
+        $X.runcode($PL,...)
+  - pattern-either:
+    - pattern-inside: |
+        $X = code.InteractiveConsole(...)
+        ...
+    - pattern-inside: |
+        $X = code.InteractiveInterpreter(...)
+        ...
+  - pattern-not: |
+      $X.push("...",...)
+  - pattern-not: |
+      $X.runsource("...",...)
+  - pattern-not: |
+      $X.runcode(code.compile_command("..."),...)
+  - pattern-not: |
+      $PL = code.compile_command("...",...)
+      ...
+      $X.runcode($PL,...)
+  message: |
+    Found dynamic content inside InteractiveConsole/InteractiveInterpreter method.
+    This is dangerous if external data can reach this function call because it allows a malicious actor to run arbitrary Python code.
+    Ensure no external data reaches here.
+  metadata:
+    cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    owasp: 'A1: Injection'
+    category: security
+  severity: WARNING
+  languages:
+  - python

--- a/python/lang/security/audit/dangerous-subinterpreters-run-string.py
+++ b/python/lang/security/audit/dangerous-subinterpreters-run-string.py
@@ -1,0 +1,9 @@
+import _xxsubinterpreters
+
+def run_payload(payload: str) -> None:
+    # ruleid: dangerous-subinterpreters-run-string
+    _xxsubinterpreters.run_string(_xxsubinterpreters.create(), payload)
+
+def okRun():
+    # ok: dangerous-subinterpreters-run-string
+    _xxsubinterpreters.run_string(_xxsubinterpreters.create(), "print(123)")

--- a/python/lang/security/audit/dangerous-subinterpreters-run-string.yaml
+++ b/python/lang/security/audit/dangerous-subinterpreters-run-string.yaml
@@ -1,0 +1,20 @@
+rules:
+- id: dangerous-subinterpreters-run-string
+  patterns:
+  - pattern: |
+      _xxsubinterpreters.run_string($ID, $PAYLOAD, ...)
+  - pattern-not: |
+      _xxsubinterpreters.run_string($ID, "...", ...)
+  message: |
+    Found dynamic content in `run_string`.
+    This is dangerous if external data can reach this function call because it allows a malicious actor to run arbitrary Python code.
+    Ensure no external data reaches here.
+  metadata:
+    cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    owasp: 'A1: Injection'
+    references:
+    - https://bugs.python.org/issue43472
+    category: security
+  severity: WARNING
+  languages:
+  - python

--- a/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.py
+++ b/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.py
@@ -1,0 +1,9 @@
+import _testcapi
+
+def run_payload(payload: str) -> None:
+    # ruleid: dangerous-testcapi-run-in-subinterp
+    _testcapi.run_in_subinterp(payload)
+
+def okTest(payload: str) -> None:
+    # ok: dangerous-testcapi-run-in-subinterp
+    _testcapi.run_in_subinterp("print('Hello world')")

--- a/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.py
+++ b/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.py
@@ -1,8 +1,13 @@
 import _testcapi
+from test import support
 
-def run_payload(payload: str) -> None:
+def run_payload1(payload: str) -> None:
     # ruleid: dangerous-testcapi-run-in-subinterp
     _testcapi.run_in_subinterp(payload)
+
+def run_payload2(payload: str) -> None:
+    # ruleid: dangerous-testcapi-run-in-subinterp
+    support.run_in_subinterp(payload)
 
 def okTest(payload: str) -> None:
     # ok: dangerous-testcapi-run-in-subinterp

--- a/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.yaml
+++ b/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.yaml
@@ -1,10 +1,15 @@
 rules:
 - id: dangerous-testcapi-run-in-subinterp
   patterns:
-  - pattern: |
-      _testcapi.run_in_subinterp($PAYLOAD, ...)
+  - pattern-either:
+    - pattern: |
+        _testcapi.run_in_subinterp($PAYLOAD, ...)
+    - pattern: |
+        test.support.run_in_subinterp($PAYLOAD, ...)
   - pattern-not: |
       _testcapi.run_in_subinterp("...", ...)
+  - pattern-not: |
+      test.support.run_in_subinterp("...", ...)
   message: |
     Found dynamic content in `run_in_subinterp`.
     This is dangerous if external data can reach this function call because it allows a malicious actor to run arbitrary Python code.

--- a/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.yaml
+++ b/python/lang/security/audit/dangerous-testcapi-run-in-subinterp.yaml
@@ -1,0 +1,18 @@
+rules:
+- id: dangerous-testcapi-run-in-subinterp
+  patterns:
+  - pattern: |
+      _testcapi.run_in_subinterp($PAYLOAD, ...)
+  - pattern-not: |
+      _testcapi.run_in_subinterp("...", ...)
+  message: |
+    Found dynamic content in `run_in_subinterp`.
+    This is dangerous if external data can reach this function call because it allows a malicious actor to run arbitrary Python code.
+    Ensure no external data reaches here.
+  metadata:
+    cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    owasp: 'A1: Injection'
+    category: security
+  severity: WARNING
+  languages:
+  - python


### PR DESCRIPTION
this is all Python internal magic, but still worth identifing
```python
import code
console = code.InteractiveConsole()
console.push('print(123)')
```

```python
import _xxsubinterpreters
_xxsubinterpreters.run_string(_xxsubinterpreters.create(), "print(123)")
```
https://bugs.python.org/issue43472

```python
import _testcapi
_testcapi.run_in_subinterp("print(123)")
```

most of this stuff is not even mentioned in the docs, but still works in `python3`