### PR TITLE
Speed up ExpressJS rules

### DIFF
--- a/javascript/express/security/audit/express-path-join-resolve-traversal.js
+++ b/javascript/express/security/audit/express-path-join-resolve-traversal.js
@@ -24,6 +24,22 @@ function testCtrl3(req,res) {
     res.send('Hello World!');
 }
 
+const func4 = function testCtrl4(req,res) {
+    // ruleid:express-path-join-resolve-traversal
+    let somePath = req.body.path;
+    const pth = path.join(opts.path, somePath);
+    extractFile(pth);
+    res.send('Hello World!');
+}
+
+const func5 = function (req,res) {
+    // ruleid:express-path-join-resolve-traversal
+    let somePath = req.body.path;
+    const pth = path.join(opts.path, somePath);
+    extractFile(pth);
+    res.send('Hello World!');
+}
+
 app.post('/test3', testCtrl3)
 
 app.post('/okTest', function (req,res) {

--- a/javascript/express/security/audit/express-path-join-resolve-traversal.yaml
+++ b/javascript/express/security/audit/express-path-join-resolve-traversal.yaml
@@ -16,12 +16,8 @@ rules:
       $PATH = require('path');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/audit/express-xml2json-xxe-event.yaml
+++ b/javascript/express/security/audit/express-xml2json-xxe-event.yaml
@@ -17,12 +17,8 @@ rules:
       require('xml2json');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/audit/res-render-injection.yaml
+++ b/javascript/express/security/audit/res-render-injection.yaml
@@ -12,12 +12,8 @@ rules:
     - express
   patterns:
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/express-expat-xxe.js
+++ b/javascript/express/security/express-expat-xxe.js
@@ -25,6 +25,20 @@ app.get('/test2', async (req, res) => {
     res.send('Hello World!')
 })
 
+const test3 = function func3(req, res) {
+    var parser = new expat.Parser('UTF-8')
+    // ruleid: express-expat-xxe
+    parser.parse(req.body)
+    res.send('Hello World!')
+}
+
+const test4 = function (req, res) {
+    var parser = new expat.Parser('UTF-8')
+    // ruleid: express-expat-xxe
+    parser.parse(req.body)
+    res.send('Hello World!')
+}
+
 app.get('/okTest1', async (req, res) => {
     var parser = new expat.Parser('UTF-8')
     // ok: express-expat-xxe

--- a/javascript/express/security/express-expat-xxe.yaml
+++ b/javascript/express/security/express-expat-xxe.yaml
@@ -24,12 +24,8 @@ rules:
       require('express');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
@@ -38,11 +34,9 @@ rules:
     - pattern-inside: $APP.options(..., function $FUNC($REQ, $RES) {...})
   - pattern-either:
     - pattern-inside: |
-        ...
         $PARSER = new $EXPAT.Parser(...);
         ...
     - pattern-inside: |
-        ...
         $PARSER = new Parser(...);
         ...
   - pattern-either:

--- a/javascript/express/security/express-phantom-injection.yaml
+++ b/javascript/express/security/express-phantom-injection.yaml
@@ -18,12 +18,8 @@ rules:
       require('express');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/express-puppeteer-injection.yaml
+++ b/javascript/express/security/express-puppeteer-injection.yaml
@@ -18,12 +18,8 @@ rules:
       require('express');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/express-sandbox-injection.yaml
+++ b/javascript/express/security/express-sandbox-injection.yaml
@@ -15,12 +15,8 @@ rules:
       $SANDBOX = require('sandbox');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/express-vm-injection.yaml
+++ b/javascript/express/security/express-vm-injection.yaml
@@ -15,12 +15,8 @@ rules:
       $VM = require('vm');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
@@ -80,12 +76,8 @@ rules:
       $VM = require('vm');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
@@ -149,12 +141,8 @@ rules:
       $VM = require('vm');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
@@ -266,12 +254,8 @@ rules:
       $VM = require('vm');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/express-vm2-injection.yaml
+++ b/javascript/express/security/express-vm2-injection.yaml
@@ -15,12 +15,8 @@ rules:
       require('vm2');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
@@ -140,12 +136,8 @@ rules:
       require('vm2');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/express-wkhtml-injection.yaml
+++ b/javascript/express/security/express-wkhtml-injection.yaml
@@ -18,12 +18,8 @@ rules:
       require('express');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
@@ -60,12 +56,8 @@ rules:
       require('express');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/express-xml2json-xxe.yaml
+++ b/javascript/express/security/express-xml2json-xxe.yaml
@@ -21,12 +21,8 @@ rules:
       require('xml2json');
       ...
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})

--- a/javascript/express/security/require-request.yaml
+++ b/javascript/express/security/require-request.yaml
@@ -13,12 +13,8 @@ rules:
     - express
   patterns:
   - pattern-either:
-    - pattern-inside: function ($REQ, $RES) {...}
-    - pattern-inside: function $FUNC($REQ, $RES) {...}
-    - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-    - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-    - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
+    - pattern-inside: function ... ($REQ, $RES) {...}
+    - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
     - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
     - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})


### PR DESCRIPTION
For https://github.com/returntocorp/semgrep-app/issues/2428.

The primary optimization here is that the following are equivalent, so unnecessary patterns can be removed:

```
- pattern-inside: function ($REQ, $RES) {...}
- pattern-inside: function $FUNC($REQ, $RES) {...}
- pattern-inside: function ($REQ, $RES, $NEXT) {...}
- pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
- pattern-inside: $X = function $FUNC($REQ, $RES) {...}
- pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
```

```
- pattern-inside: function ... ($REQ, $RES) {...}
- pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
```

Removing unnecessary patterns reduces the number of source code queries we need to make, which reduces runtime, and reduces the amount of state we need to keep in memory.

There were also a few trailing, unnecessary `...`'s I removed.