### PR TITLE
Some matches are now found correctly for javascript

### DIFF
--- a/javascript/lang/best-practice/assigned-undefined.js
+++ b/javascript/lang/best-practice/assigned-undefined.js
@@ -1,4 +1,6 @@
-// https://stackoverflow.com/questions/7452341/what-does-void-0-mean/7452352#7452352
+// 'undefined' is "assignable" syntactically but it's read-only (since
+// ECMAScript 5), so its value will remain 'undefined'.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined
 
 // ok:assigned-undefined
 alert(undefined); //alerts "undefined"

--- a/typescript/react/best-practice/react-props-in-state.jsx
+++ b/typescript/react/best-practice/react-props-in-state.jsx
@@ -1,6 +1,6 @@
 class Test1 extends React.Component {
   constructor() {
-    // todoruleid:react-props-in-state
+    // ruleid:react-props-in-state
     this.state = {
           foo: 'bar',
           color: this.props.color,
@@ -20,7 +20,7 @@ class Test1 extends React.Component {
 
 class Test2 extends React.Component {
   constructor() {
-    // todoruleid:react-props-in-state
+    // ruleid:react-props-in-state
     this.state = {
       textColor: slowlyCalculateTextColor(this.props.color)
     };


### PR DESCRIPTION
1. **react-props-in-state**: We're [switching to the typescript (TSX) parser to parse javascript](https://github.com/returntocorp/semgrep/pull/3444), and this construct happens to be supported better by the new parser.
2. **assigned-undefined**: No change here other than a comment, but we have a new bug in semgrep which causes the assigned-undefined test to fail (`undefined = 42;` is parsed incorrectly but no longer with a hard parsing error; previously, the parse error used to cause a successful fallback to the pfff parser which doesn't have the bug). This should be fixed in the tree-sitter grammars first and then propagated to semgrep, which I'm hoping to do this week but it will take some time no matter what. See progress at  https://github.com/tree-sitter/tree-sitter-javascript/pull/182. 

I'm not sure how to avoid breaking semgrep tests. Should we wait until https://github.com/returntocorp/semgrep/pull/3444 passes the assigned-undefined test that's currently failing?
