### PR TITLE
Fix dangerous-subshell result2 example

### DIFF
--- a/ruby/lang/security/dangerous-subshell.rb
+++ b/ruby/lang/security/dangerous-subshell.rb
@@ -3,7 +3,7 @@ def test_calls(user_input)
   result = `foo #{user_input} bar`
 
 # ruleid: dangerous-subshell
-  result2 = %{foo #{user_input} bar}
+  result2 = %x{foo #{user_input} bar}
 
 # ruleid: dangerous-subshell
   cmd = `foo #{user_input} bar #{smth_else}`


### PR DESCRIPTION
Only `%x{...}` is a subshell in ruby; `%{...}` is just a string.