### PR TITLE
Update no-string-eqeq.yaml

### DIFF
--- a/java/lang/correctness/no-string-eqeq.yaml
+++ b/java/lang/correctness/no-string-eqeq.yaml
@@ -1,8 +1,6 @@
 rules:
 - id: no-string-eqeq
   languages: [java]
-  equivalences:
-  - equivalence: $X == $Y ==> $Y == $X
   patterns:
   - pattern-not: null == (String $Y)
   - pattern: $X == (String $Y)


### PR DESCRIPTION
remove `equivalences` while keeping the rule behavior the same

for: https://github.com/returntocorp/semgrep-rules/issues/1365