### PR TITLE
Add formathtml-fstring-parameter

### DIFF
--- a/python/django/security/audit/xss/formathtml-fstring-parameter.py
+++ b/python/django/security/audit/xss/formathtml-fstring-parameter.py
@@ -1,0 +1,40 @@
+from django.utils.html import format_html
+
+planet = "world"
+markup = "<marquee>" + planet
+
+#############################################################
+
+# ok: formathtml-fstring-parameter
+print(format_html("hello {}", markup))
+# ok: formathtml-fstring-parameter
+print(format_html("hello {}", "<marquee>world"))
+# ok: formathtml-fstring-parameter
+print(format_html("hello {}", "<marquee>" "world"))
+# ok: formathtml-fstring-parameter
+print(format_html("hello {}", "<marquee>" + "world"))
+# ok: formathtml-fstring-parameter
+print(format_html("hello {}", f"<marquee>{planet}"))
+# ok: formathtml-fstring-parameter
+print(format_html("hello {}", "<marquee>%s" % planet))
+# ok: formathtml-fstring-parameter
+print(format_html("hello {}", "<marquee>{}".format(planet)))
+# ok: formathtml-fstring-parameter
+print(format_html("hello " "{}", "<marquee>world"))
+# ok: formathtml-fstring-parameter
+print(format_html("hello " + "{}", "<marquee>world"))
+
+#############################################################
+
+# ruleid: formathtml-fstring-parameter
+print(format_html("hello %s" % markup))
+# ruleid: formathtml-fstring-parameter
+print(format_html(f"hello {markup}"))
+# ruleid: formathtml-fstring-parameter
+print(format_html("hello {}".format(markup)))
+# ruleid: formathtml-fstring-parameter
+print(format_html("hello %s {}" % markup, markup))
+# ruleid: formathtml-fstring-parameter
+print(format_html(f"hello {markup} {{}}", markup))
+# ruleid: formathtml-fstring-parameter
+print(format_html("hello {} {{}}".format(markup), markup))

--- a/python/django/security/audit/xss/formathtml-fstring-parameter.yaml
+++ b/python/django/security/audit/xss/formathtml-fstring-parameter.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: formathtml-fstring-parameter
+  message: |
+    Passing a formatted string as first parameter to `format_html` disables the
+    proper encoding of variables. Any HTML in the first parameter is not
+    encoded. Using a formatted string as first parameter obsures which
+    parameters are encoded. Correct use of `format_html` is passing a static
+    format string as first parameter, and the variables to substitute as
+    subsequent parameters.
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-Site Scripting (XSS)'
+    references:
+    - https://docs.djangoproject.com/en/3.2/ref/utils/#django.utils.html.format_html
+    category: security
+    technology:
+    - django
+  languages:
+  - python
+  severity: WARNING
+  pattern-either:
+  - pattern: format_html(<... f"..." ...>, ...)
+  - pattern: format_html("..." % ..., ...)
+  - pattern: format_html("...".format(...), ...)


### PR DESCRIPTION
Correct use of `format_html` encodes its parameters. Here, "world" is HTML-encoded:
```
format_html("hello {}", world)
```

This test checks for incorrect use, where the interpolation is done before reaching `format_html`:
```
format_html(f"hello {world}")
```