### PR TITLE
Edit PyYAML load rule + add SnakeYAML rule

### DIFF
--- a/java/lang/security/use-snakeyaml-constructor.java
+++ b/java/lang/security/use-snakeyaml-constructor.java
@@ -1,0 +1,22 @@
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+public class SnakeYamlTestCase {
+    public void unsafeLoad(String toLoad) {
+        // ruleid:use-snakeyaml-constructor
+        Yaml yaml = new Yaml();
+        yaml.load(toLoad);
+    }
+
+    public void safeConstructorLoad(String toLoad) {
+        // ok:use-snakeyaml-constructor
+        Yaml yaml = new Yaml(new SafeConstructor());
+        yaml.load(toLoad);
+    }
+
+    public void customConstructorLoad(String toLoad, Class goodClass) {
+        // ok:use-snakeyaml-constructor
+        Yaml yaml = new Yaml(new Constructor(goodClass));
+        yaml.load(toLoad);
+    }
+}

--- a/java/lang/security/use-snakeyaml-constructor.yaml
+++ b/java/lang/security/use-snakeyaml-constructor.yaml
@@ -1,19 +1,19 @@
 rules:
-  - id: use-snakeyaml-constructor
-    languages:
-      - java
-    metadata:
-      owasp: 'A8: Insecure Deserialization'
-      cwe: 'CWE-502: Deserialization of Untrusted Data'
-      references:
-      - https://securitylab.github.com/research/swagger-yaml-parser-vulnerability/#snakeyaml-deserialization-vulnerability
-      category: security
-    message: >
-      Used SnakeYAML org.yaml.snakeyaml.Yaml() constructor with no arguments, which is vulnerable to deserialization attacks. 
-      Use the one-argument Yaml(...) constructor instead, with SafeConstructor or a custom Constructor as the argument.
-    patterns:
-        - pattern: |
-            $Y = new org.yaml.snakeyaml.Yaml();
-            ...
-            $Y.load(...);
-    severity: WARNING
+- id: use-snakeyaml-constructor
+  languages:
+  - java
+  metadata:
+    owasp: 'A8: Insecure Deserialization'
+    cwe: 'CWE-502: Deserialization of Untrusted Data'
+    references:
+    - https://securitylab.github.com/research/swagger-yaml-parser-vulnerability/#snakeyaml-deserialization-vulnerability
+    category: security
+  message: >
+    Used SnakeYAML org.yaml.snakeyaml.Yaml() constructor with no arguments, which is vulnerable to deserialization attacks.
+    Use the one-argument Yaml(...) constructor instead, with SafeConstructor or a custom Constructor as the argument.
+  patterns:
+  - pattern: |
+      $Y = new org.yaml.snakeyaml.Yaml();
+      ...
+      $Y.load(...);
+  severity: WARNING

--- a/java/lang/security/use-snakeyaml-constructor.yaml
+++ b/java/lang/security/use-snakeyaml-constructor.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: use-snakeyaml-constructor
+    languages:
+      - java
+    metadata:
+      owasp: 'A8: Insecure Deserialization'
+      cwe: 'CWE-502: Deserialization of Untrusted Data'
+      references:
+      - https://securitylab.github.com/research/swagger-yaml-parser-vulnerability/#snakeyaml-deserialization-vulnerability
+      category: security
+    message: >
+      Used SnakeYAML org.yaml.snakeyaml.Yaml() constructor with no arguments, which is vulnerable to deserialization attacks. 
+      Use the one-argument Yaml(...) constructor instead, with SafeConstructor or a custom Constructor as the argument.
+    metadata:
+      category: security
+    patterns:
+        - pattern: |
+            $Y = new org.yaml.snakeyaml.Yaml();
+            ...
+            $Y.load(...);
+    severity: WARNING

--- a/java/lang/security/use-snakeyaml-constructor.yaml
+++ b/java/lang/security/use-snakeyaml-constructor.yaml
@@ -11,8 +11,6 @@ rules:
     message: >
       Used SnakeYAML org.yaml.snakeyaml.Yaml() constructor with no arguments, which is vulnerable to deserialization attacks. 
       Use the one-argument Yaml(...) constructor instead, with SafeConstructor or a custom Constructor as the argument.
-    metadata:
-      category: security
     patterns:
         - pattern: |
             $Y = new org.yaml.snakeyaml.Yaml();

--- a/python/lang/security/deserialization/avoid-pyyaml-load.py
+++ b/python/lang/security/deserialization/avoid-pyyaml-load.py
@@ -4,9 +4,16 @@ import yaml
 #ruleid:avoid-pyyaml-load
 yaml.load("!!python/object/new:os.system [echo EXPLOIT!]")
 
+#ruleid:avoid-pyyaml-load
+yaml.load_all("!!python/object/new:os.system [echo EXPLOIT!]")
+
 def thing(**kwargs):
     #ruleid:avoid-pyyaml-load
     yaml.load("!!python/object/new:os.system [echo EXPLOIT!]", **kwargs)
+
+def other_thing(**kwargs):
+    #ruleid:avoid-pyyaml-load
+    yaml.load_all("!!python/object/new:os.system [echo EXPLOIT!]", **kwargs)
 
 def this_is_ok(stream):
     #ok:avoid-pyyaml-load
@@ -16,8 +23,18 @@ def this_is_also_ok(stream):
     #ok:avoid-pyyaml-load
     return yaml.load(stream, Loader=yaml.SafeLoader)
 
+def this_is_additionally_ok(stream):
+    #ok:avoid-pyyaml-load
+    return yaml.load_all(stream, Loader=yaml.CSafeLoader)
+
+def this_is_ok_too(stream):
+    #ok:avoid-pyyaml-load
+    return yaml.load_all(stream, Loader=yaml.SafeLoader)
+
 def check_ruamel_yaml():
     from ruamel.yaml import YAML
     yaml = YAML(typ="rt")
     # ok:avoid-pyyaml-load
     yaml.load("thing.yaml")
+    # ok:avoid-pyyaml-load
+    yaml.load_all("thing.yaml")

--- a/python/lang/security/deserialization/avoid-pyyaml-load.yaml
+++ b/python/lang/security/deserialization/avoid-pyyaml-load.yaml
@@ -28,4 +28,8 @@ rules:
       $YAML.load(...)
   - pattern-not: yaml.load(..., Loader=yaml.CSafeLoader, ...)
   - pattern-not: yaml.load(..., Loader=yaml.SafeLoader, ...)
-  - pattern: yaml.load(...)
+  - pattern-not: yaml.load_all(..., Loader=yaml.CSafeLoader, ...)
+  - pattern-not: yaml.load_all(..., Loader=yaml.SafeLoader, ...)
+  - pattern-either:
+    - pattern: yaml.load(...)
+    - pattern: yaml.load_all(...)

--- a/python/lang/security/deserialization/avoid-pyyaml-load.yaml
+++ b/python/lang/security/deserialization/avoid-pyyaml-load.yaml
@@ -25,7 +25,6 @@ rules:
   - pattern-not-inside: |
       $YAML = ruamel.yaml.YAML(...)
       ...
-      $YAML.load(...)
   - pattern-not: yaml.load(..., Loader=yaml.CSafeLoader, ...)
   - pattern-not: yaml.load(..., Loader=yaml.SafeLoader, ...)
   - pattern-not: yaml.load_all(..., Loader=yaml.CSafeLoader, ...)


### PR DESCRIPTION
PyYAML's load_all(...) is as vulnerable as load(...) in the same way, so I added it to the rule. Also, SnakeYAML is vulnerable to deserialization attacks (for example, see here: https://securitylab.github.com/research/swagger-yaml-parser-vulnerability/#snakeyaml-deserialization-vulnerability) so I added a rule for it.