### PR TITLE
Django/Python: Add path validation rules

### DIFF
--- a/python/django/maintainability/duplicate-path-assignment.py
+++ b/python/django/maintainability/duplicate-path-assignment.py
@@ -1,0 +1,142 @@
+from django.urls import path
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test"),
+    path('path/to/view', views.example_view, name="test"),
+]
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test"),
+    path('path/to/other_view', view.other_view, name="hello"),
+    path('path/to/view', views.example_view, name="test"),
+]
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view),
+    path('path/to/view', views.example_view),
+]
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}),
+    path('path/to/view', views.example_view, {'abc': 'def'}),
+]
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}),
+    path('path/to/view', views.example_view, {'def': 'abc'}),
+]
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="test123"),
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="test123"),
+]
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="test123"),
+    path('path/to/view', views.example_view, {'def': 'abc'}),
+]
+
+# ruleid: duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="test123"),
+    path('path/to/view', views.example_view),
+]
+
+# ruleid: conflicting-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test"),
+    path('path/to/view', views.other_view, name="test"),
+]
+
+# ruleid: conflicting-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test"),
+    path('path/to/other_view', view.other_view, name="hello"),
+    path('path/to/view', views.other_view, name="test"),
+]
+
+# ruleid: conflicting-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view),
+    path('path/to/view', views.other_view),
+]
+
+# ruleid: conflicting-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}),
+    path('path/to/view', views.other_view, {'abc': 'def'}),
+]
+
+# ruleid: conflicting-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}),
+    path('path/to/view', views.other_view, {'def': 'abc'}),
+]
+
+# I would prefer duplicate-path-assignment to not match the following test cases
+# to avoid giving two messages for the same issue, but could not find a way yet.
+# todook: duplicate-path-assignment
+# ruleid: duplicate-path-assignment-different-names, duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test"),
+    path('path/to/view', views.example_view, name="other_name"),
+]
+
+# todook: duplicate-path-assignment
+# ruleid: duplicate-path-assignment-different-names, duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="test"),
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="other_name"),
+]
+
+# todook: duplicate-path-assignment
+# ruleid: duplicate-path-assignment-different-names, duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="test"),
+    path('path/to/other/view', views.other_view, {'abc': 'def'}, name="some_test"),
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="other_name"),
+]
+
+# todook: duplicate-path-assignment
+# ruleid: duplicate-path-assignment-different-names, duplicate-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, {'abc': 'def'}, name="test123"),
+    path('path/to/view', views.example_view, {'def': 'abc'}, name="test456"),
+]
+
+# ruleid: duplicate-name-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test123"),
+    path('path/to/other/view', views.other_view, name="test123"),
+]
+
+# ruleid: conflicting-path-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test123"),
+    path('path/to/view', views.other_view, name="test123"),
+]
+
+# ruleid: duplicate-name-assignment
+urlpatterns = [
+    path('path/to/view', views.example_view, name="test123"),
+    path('path/to/other/view', views.other_view, name="test123"),
+]
+
+# ok: duplicate-path-assignment-different-names, conflicting-path-assignment, duplicate-path-assignment
+urlpatterns = [
+    path('path/to/other_view', views.example_view, name="test"),
+    path('path/to/view', views.example_view, name="test"),
+]
+
+# ok: duplicate-path-assignment-different-names, conflicting-path-assignment, duplicate-path-assignment
+urlpatterns = [
+    path('path/to/other_view', views.example_view, name="test"),
+    path('path/to/view', views.other_view, name="test_abc"),
+]

--- a/python/django/maintainability/duplicate-path-assignment.yaml
+++ b/python/django/maintainability/duplicate-path-assignment.yaml
@@ -1,0 +1,69 @@
+rules:
+- id: duplicate-path-assignment
+  languages:
+  - python
+  message: path for `$URL` is uselessly assigned twice
+  metadata:
+    category: maintainability
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - django
+  patterns:
+  - pattern: |
+      [..., django.urls.path('$URL', $VIEW, ...), ..., django.urls.path('$URL', $VIEW, ...), ...]
+  severity: WARNING
+- id: conflicting-path-assignment
+  languages:
+  - python
+  message: >
+    The path for `$URL` is assigned once to view `$VIEW` and once to `$DIFFERENT_VIEW`, which can lead to unexpected behavior.
+    Verify what the intended target view is and delete the other route.
+  metadata:
+    category: maintainability
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - django
+  patterns:
+  - pattern: |
+      [..., django.urls.path('$URL', $VIEW, ...), ..., django.urls.path('$URL', $DIFFERENT_VIEW, ...), ...]
+  - pattern-not: |
+      [..., django.urls.path('$URL', $VIEW, ...), ..., django.urls.path('$URL', $VIEW, ...), ...]
+  severity: ERROR
+- id: duplicate-path-assignment-different-names
+  languages:
+  - python
+  message: path for `$URL` is assigned twice with different names
+  metadata:
+    category: maintainability
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - django
+  patterns:
+  - pattern: |
+      [..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ..., django.urls.path('$URL', $VIEW, name='$OTHER_NAME', ...), ...]
+  - pattern-not: |
+      [..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ...]
+  severity: WARNING
+- id: duplicate-name-assignment
+  languages:
+  - python
+  message: >
+    The name `$NAME` is used for both `$URL` and `$OTHER_URL`, which can lead to unexpected behavior when using URL reversing.
+    Pick a unique name for each path.
+  metadata:
+    category: maintainability
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - django
+    references:
+    - https://docs.djangoproject.com/en/3.2/topics/http/urls/#naming-url-patterns
+  patterns:
+  - pattern: |
+      [..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ..., django.urls.path('$OTHER_URL', $OTHER_VIEW, name='$NAME', ...), ...]
+  - pattern-not: |
+      [..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ...]
+  - pattern-not: |
+      [..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ..., django.urls.path('$URL', $OTHER_VIEW, name='$NAME', ...), ...]
+  - pattern-not: |
+      [..., django.urls.path('$URL', $VIEW, name='$NAME', ...), ..., django.urls.path('$OTHER_URL', $VIEW, name='$NAME', ...), ...]
+  severity: ERROR


### PR DESCRIPTION
Django uses [paths](https://docs.djangoproject.com/en/3.2/ref/urls/#path) for routing requests to different views. If paths are defined multiple times, this can be either inefficient or, in the worst case, lead to [unexpected behavior](https://docs.djangoproject.com/en/3.2/topics/http/urls/#naming-url-patterns). These rules are a first attempt at writing validators for these path issues. Feedback is welcome. In particular, I am unsure if I selected the severity (warning vs. error) and type of issue (maintainability vs. correctness) correctly. 

Let me know if you would like to see changes. If you like these rules, I can write analogous rules for the [`re_path`](https://docs.djangoproject.com/en/3.2/ref/urls/#re-path) function, but I wanted to check if this was considered useful / in scope for the rulesets before taking on the extra work for that. If you would like to se `re_path` rules: Should I extend the existing rules, or write separate rules for `re_path`?

First time contributing to this repository, so please point out any mistakes I may have made.