### PR TITLE
[JS] angular: security: Fix rules to use the latest Semgrep features

### DIFF
--- a/javascript/angular/security/detect-angular-element-methods.js
+++ b/javascript/angular/security/detect-angular-element-methods.js
@@ -9,6 +9,10 @@ app.controller('myCtrl', function($scope) {
     // ruleid: detect-angular-element-methods
     var now = angular.element($scope.input).wrap();
 
+    var el = angular.element($scope.input);
+    // ruleid: detect-angular-element-methods
+    var now = el.html();
+
     return now;
 
 });

--- a/javascript/angular/security/detect-angular-element-methods.yaml
+++ b/javascript/angular/security/detect-angular-element-methods.yaml
@@ -1,5 +1,6 @@
 rules:
 - id: detect-angular-element-methods
+  mode: taint
   message: |
     Use of angular.element can lead to XSS if after,append,html,prepend,replaceWith,wrap are used with user-input.
   languages:
@@ -12,19 +13,19 @@ rules:
     category: security
     technology:
     - angular
-  fix: |
-
   severity: WARNING
-  pattern-either:
-  - pattern: |
-      angular.element($SOURCE).html(...);
-  - pattern: |
-      angular.element($SOURCE).append(...);
-  - pattern: |
-      angular.element($SOURCE).prepend(...);
-  - pattern: |
-      angular.element($SOURCE).replaceWith(...);
-  - pattern: |
-      angular.element($SOURCE).wrap(...);
-  - pattern: |
-      angular.element($SOURCE).after(...);
+  pattern-sources:
+    - pattern: angular.element(...)
+  pattern-sinks:
+    - pattern: |
+        $SINK.html(...);
+    - pattern: |
+        $SINK.append(...);
+    - pattern: |
+        $SINK.prepend(...);
+    - pattern: |
+        $SINK.replaceWith(...);
+    - pattern: |
+        $SINK.wrap(...);
+    - pattern: |
+        $SINK.after(...);

--- a/javascript/angular/security/detect-angular-open-redirect.js
+++ b/javascript/angular/security/detect-angular-open-redirect.js
@@ -1,18 +1,17 @@
 var app = angular.module('MyApp', []);
 app.controller('myCtrl', function($scope, $sce) {
+    $scope.userInput = 'foo';
 
-$scope.userInput = 'foo';
     $scope.sayHello = function() {
      // ruleid:detect-angular-open-redirect
      $window.location.href = input + '/app/logout';
-     // ruleid:detect-angular-open-redirect
      input = $scope.input;
      // ruleid:detect-angular-open-redirect
      $window.location.href = input + '/app/logout';
 
-
      //Data is not coming from user input
      $location.location.location = test
+     // ok:detect-angular-open-redirect
      $window.location.href = "//untatintedredirect"
    };
 

--- a/javascript/angular/security/detect-angular-open-redirect.yaml
+++ b/javascript/angular/security/detect-angular-open-redirect.yaml
@@ -17,12 +17,9 @@ rules:
     category: security
     technology:
     - angular
-  fix: |
-
   severity: ERROR
-  pattern-either:
+  patterns:
   - pattern: |
-      $SOURCE = $INPUT;
-      $window.location.href = $SOURCE + $STATICVALUE;
-  - pattern: |
-      $window.location.href = $SOURCE + $STATICVALUE;
+      $window.location.href = ...
+  - pattern-not: |
+      $window.location.href = "..."

--- a/javascript/angular/security/detect-angular-resource-loading.js
+++ b/javascript/angular/security/detect-angular-resource-loading.js
@@ -5,7 +5,19 @@ var app = angular.module('MyApp', []).config(function ($sceDelegateProvider) {
     // ruleid: detect-angular-resource-loading
     $sceDelegateProvider.resourceUrlWhitelist(['http://semgrep.dev', '**']);
 
-    // Only one site is whitelisted, assumed to be safe
+    // ruleid: detect-angular-resource-loading
+    $sceDelegateProvider.resourceUrlWhitelist(['http://semgrep.dev', '**', 'http://semgrep.dev']);
+
+    // ruleid: detect-angular-resource-loading
+    $sceDelegateProvider.resourceUrlWhitelist(['http://**.semgrep.dev']);
+
+    // ok: detect-angular-resource-loading
+    $sceDelegateProvider.resourceUrlWhitelist(['http://semgrep.dev/ooo']);
+
+    // ok: detect-angular-resource-loading
+    $sceDelegateProvider.resourceUrlWhitelist(['http://semgrep.dev/**']);
+
+    // ok: detect-angular-resource-loading
     $sceDelegateProvider.resourceUrlWhitelist(['http://semgrep.dev']);
 
 });

--- a/javascript/angular/security/detect-angular-resource-loading.yaml
+++ b/javascript/angular/security/detect-angular-resource-loading.yaml
@@ -1,9 +1,16 @@
 rules:
 - id: detect-angular-resource-loading
-  pattern: |
-    $sceDelegateProvider.resourceUrlWhitelist([...,'**' ]);
+  pattern-either:
+  - pattern: |
+      $sceDelegateProvider.resourceUrlWhitelist([...,'**',...]);
+  - patterns:
+    - pattern: |
+        $sceDelegateProvider.resourceUrlWhitelist([...,$DOM,...]);
+    - metavariable-regex:
+        metavariable: $DOM
+        regex: "^'.*\\*\\*.+'$"
   message: |
-    $sceDelegateProvider allowlisting can be introduce security issues if wildcards are used.
+    $sceDelegateProvider allowlisting can introduce security issues if wildcards are used.
   languages:
   - javascript
   - typescript
@@ -14,6 +21,4 @@ rules:
     category: security
     technology:
     - angular
-  fix: |
-
   severity: WARNING

--- a/javascript/angular/security/detect-angular-trust-as-method.js
+++ b/javascript/angular/security/detect-angular-trust-as-method.js
@@ -1,10 +1,9 @@
 var app = angular.module('MyApp', []);
 app.controller('myCtrl', function($scope, $sce) {
+    $scope.userInput = 'foo';
 
-$scope.userInput = 'foo';
     $scope.sayHello = function() {
 
-     // ruleid:detect-angular-trust-as-method
      value = $scope.html
      // ruleid:detect-angular-trust-as-method
      $sce.trustAs($sce.HTML, value);

--- a/javascript/angular/security/detect-angular-trust-as-method.yaml
+++ b/javascript/angular/security/detect-angular-trust-as-method.yaml
@@ -1,16 +1,16 @@
 rules:
 - id: detect-angular-trust-as-method
-  patterns:
-  - pattern-either:
-    - pattern: |
-        $SOURCE = $scope.$INPUT;
-        $sce.trustAs($sce.$TRUSTMETHOD,$SOURCE);
-    - pattern: |
-        $sce.trustAs($sce.$TRUSTMETHOD,$INPUT);
-  - pattern-inside: |
-      app.controller(..., function($scope,$sce){
-      ...
-      });
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-inside: |
+        app.controller(..., function($scope,$sce) {
+        ...
+        });
+    - pattern: $scope.$X
+  pattern-sinks:
+  - pattern: $sce.trustAs(...)
+  - pattern: $sce.trustAsHtml(...)
   message: |
     The use of $sce.trustAs can be dangerous if unsantiized user input flows through this API.
   languages:
@@ -23,6 +23,4 @@ rules:
     category: security
     technology:
     - angular
-  fix: |
-
   severity: WARNING


### PR DESCRIPTION
In Semgrep v0.38.0 we released flow-based constant propagation.

In Semgrep v0.58.0 we released a new iteration of taint-mode that should
(we hope) allow us to get rid of fake-taint rules.

Let's use them!