### PR TITLE
Android: Add rules for network-security-config files

### DIFF
--- a/java/android/best-practice/manifest-security-features.xml
+++ b/java/android/best-practice/manifest-security-features.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.manifest-test" >
+    <application
+        <!-- ruleid: manifest-usesCleartextTraffic-true, manifest-usesCleartextTraffic-ignored-by-nsc -->
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:fullBackupContent="false"
+        tools:ignore="GoogleAppIndexingWarning">
+
+        <activity
+            android:name="com.example.networksecurity.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.manifest-test" >
+    <application
+        <!-- ok: manifest-usesCleartextTraffic-ignored-by-nsc -->
+        <!-- ruleid: manifest-usesCleartextTraffic-true -->
+        android:usesCleartextTraffic="true"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:fullBackupContent="false"
+        tools:ignore="GoogleAppIndexingWarning">
+
+        <activity
+            android:name="com.example.networksecurity.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.manifest-test" >
+    <application
+        <!-- ok: manifest-usesCleartextTraffic-true, manifest-usesCleartextTraffic-ignored-by-nsc -->
+        android:usesCleartextTraffic="false"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:fullBackupContent="false"
+        tools:ignore="GoogleAppIndexingWarning">
+
+        <activity
+            android:name="com.example.networksecurity.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/java/android/best-practice/manifest-security-features.yaml
+++ b/java/android/best-practice/manifest-security-features.yaml
@@ -1,0 +1,54 @@
+rules:
+- id: manifest-usesCleartextTraffic-true
+  languages:
+  - generic
+  message: >
+    The Android manifest is configured to allow non-encrypted connections.
+    Evaluate if this is necessary for your app, and disable it if appropriate.
+    This flag is ignored on Android 7 (API 24) and above if a Network Security
+    Config is present.
+  metadata:
+    category: best-practice
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - android
+    references:
+    - https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic
+    - https://developer.android.com/training/articles/security-config
+  patterns:
+  - pattern: |
+      android:usesCleartextTraffic="true"
+  - pattern-not-inside: |
+      <!-- ... -->
+  severity: INFO
+  paths:
+    include:
+    - '*.xml'
+- id: manifest-usesCleartextTraffic-ignored-by-nsc
+  languages:
+  - generic
+  message: >
+    Manifest uses both `android:usesCleartextTraffic` and Network Security Config.
+    The `usesCleartextTraffic` directive is ignored on Android 7 (API 24) and above
+    if a Network Security Config is present.
+  metadata:
+    category: best-practice
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - android
+    references:
+    - https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic
+    - https://developer.android.com/training/articles/security-config
+  patterns:
+  - pattern-either:
+        # Need to define both orders, as the generic parser does not know that the order does not matter
+    - pattern: |
+        android:usesCleartextTraffic ... android:networkSecurityConfig
+    - pattern: |
+        android:networkSecurityConfig ... android:usesCleartextTraffic
+  - pattern-not-inside: |
+      <!-- ... -->
+  severity: INFO
+  paths:
+    include:
+    - '*.xml'

--- a/java/android/best-practice/network-security-config.xml
+++ b/java/android/best-practice/network-security-config.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- ruleid: nsc-allows-plaintext-traffic -->
+    <base-config cleartextTrafficPermitted="true">
+    </base-config>
+
+    <domain-config>
+        <domain includeSubdomains="true">localhost</domain>
+        <trust-anchors>
+            <!-- Trust a debug certificate in addition to the system certificates -->
+            <certificates src="system" />
+            <certificates src="@raw/debug_certificate" />
+        </trust-anchors>
+    </domain-config>
+
+</network-security-config>
+
+<network-security-config>
+    <!-- ok: nsc-allows-plaintext-traffic -->
+    <!-- <base-config cleartextTrafficPermitted="true"> -->
+    <!-- ok: nsc-allows-plaintext-traffic -->
+    <base-config cleartextTrafficPermitted="false">
+    </base-config>
+
+    <domain-config>
+        <domain includeSubdomains="true">localhost</domain>
+        <trust-anchors>
+            <!-- Trust a debug certificate in addition to the system certificates -->
+            <certificates src="system" />
+            <certificates src="@raw/debug_certificate" />
+        </trust-anchors>
+    </domain-config>
+
+</network-security-config>
+
+<network-security-config>
+    <!-- ok: nsc-allows-plaintext-traffic -->
+    <base-config cleartextTrafficPermitted="false">
+    </base-config>
+
+    <domain-config>
+        <domain includeSubdomains="true">localhost</domain>
+        <trust-anchors>
+            <!-- Trust a debug certificate in addition to the system certificates -->
+            <certificates src="system" />
+            <certificates src="@raw/debug_certificate" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>
+
+<network-security-config xmlns:tools="http://schemas.android.com/tools" tools:ignore="InsecureBaseConfiguration,AcceptsUserCertificates">
+    <!-- ok: nsc-allows-plaintext-traffic -->
+    <base-config cleartextTrafficPermitted="true">
+            <!-- Trust system and user certificates -->
+            <certificates src="system" />
+            <!-- ok: nsc-allows-user-ca-certs -->
+            <certificates src="user" />
+    </base-config>
+
+    <domain-config>
+        <domain includeSubdomains="true">localhost</domain>
+        <trust-anchors>
+            <!-- Trust a debug certificate in addition to the system certificates -->
+            <certificates src="system" />
+            <!-- ok: nsc-allows-user-ca-certs-for-domain -->
+            <certificates src="user" />
+            <certificates src="@raw/debug_certificate" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>
+
+<network-security-config xmlns:tools="http://schemas.android.com/tools" tools:ignore="InsecureBaseConfiguration">
+    <!-- ok: nsc-allows-plaintext-traffic -->
+    <base-config cleartextTrafficPermitted="true">
+            <!-- Trust system and user certificates -->
+            <certificates src="system" />
+            <!-- ruleid: nsc-allows-user-ca-certs -->
+            <certificates src="user" />
+    </base-config>
+
+    <domain-config>
+        <domain includeSubdomains="true">localhost</domain>
+        <trust-anchors>
+            <!-- Trust a debug certificate in addition to the system certificates -->
+            <certificates src="system" />
+            <!-- ruleid: nsc-allows-user-ca-certs-for-domain -->
+            <certificates src="user" />
+            <certificates src="@raw/debug_certificate" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>
+
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains="true">example.com</domain>
+        <!-- ok: nsc-pinning-without-expiration -->
+        <pin-set expiration="2018-01-01">
+            <!-- ruleid: nsc-pinning-without-backup -->
+            <pin digest="SHA-256">7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>
+
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains="true">example.com</domain>
+        <!-- ok: nsc-pinning-without-expiration -->
+        <pin-set expiration="2018-01-01">
+            <!-- ok: nsc-pinning-without-backup -->
+            <pin digest="SHA-256">7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=</pin>
+            <!-- backup pin -->
+            <pin digest="SHA-256">fwza0LRMXouZHRC8Ei+4PyuldPDcf3UKgO/04cDM1oE=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>
+
+
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains="true">example.com</domain>
+        <!-- ruleid: nsc-pinning-without-expiration -->
+        <pin-set>
+            <!-- ok: nsc-pinning-without-backup -->
+            <pin digest="SHA-256">7HIpactkIAq2Y49orFOOQKurWxmmSFZhBCoQYcRhJ3Y=</pin>
+            <!-- backup pin -->
+            <pin digest="SHA-256">fwza0LRMXouZHRC8Ei+4PyuldPDcf3UKgO/04cDM1oE=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>

--- a/java/android/best-practice/network-security-config.yml
+++ b/java/android/best-practice/network-security-config.yml
@@ -1,0 +1,166 @@
+rules:
+- id: nsc-allows-plaintext-traffic
+  languages:
+  - generic
+  message: >
+    The Network Security Config is set to allow non-encrypted connections.
+    Evaluate if this is necessary for your app, and disable it if appropriate.
+    (To hide this warning, set `xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="InsecureBaseConfiguration"` as parameters to your
+    `<network-security-config>`)
+  metadata:
+    category: best-practice
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - android
+    references:
+    - https://developer.android.com/training/articles/security-config
+    - https://www.nowsecure.com/blog/2018/08/15/a-security-analysts-guide-to-network-security-configuration-in-android-p/
+  patterns:
+  - pattern: |
+      <base-config ... cleartextTrafficPermitted="true" ... >
+  - pattern-not-inside: |
+      <!-- ... -->
+     # If the config explicitly tells us not to check for insecure configurations, respect that
+      # (on a best-effort basis due to limitations of how much you can glob in generic parser mode)
+  - pattern-not-inside: |
+      <network-security-config ... InsecureBaseConfiguration ... >... ... ... ... ... ... ... ... ... ... </network-security-config>
+  severity: INFO
+  paths:
+    include:
+    - '*.xml'
+- id: nsc-pinning-without-backup
+  languages:
+  - generic
+  message: >
+    Your app uses TLS public key pinning without specifying a backup key.
+    If you are forced to change TLS keys or CAs on short notice, not
+    having a backup pin can lead to connectivity issues until you can push
+    out an update. It is considered best practice to add at least one additional
+    pin as a backup.
+  metadata:
+    category: best-practice
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - android
+    references:
+    - https://developer.android.com/training/articles/security-config#CertificatePinning
+    - https://www.nowsecure.com/blog/2018/08/15/a-security-analysts-guide-to-network-security-configuration-in-android-p/
+  patterns:
+      # FIXME: This check will currently not detect cases where there are two pins
+      # listed, but one of them is inside a <!-- comment --> - these will be recognized
+      # as having two or more pins. I don't think detecting these cases while not falsely
+      # detecting cases where there are three pins, but the middle one is commented out,
+      # is possible using the generic parser - this would require a specialized XML parser
+      # that has knowledge about comments etc.
+  - pattern: |
+      <pin ...>...</pin>
+  - pattern-not-inside: |
+      <pin ...>...</pin>...<pin ...>...</pin>
+  - pattern-inside: |
+      <pin-set ...> ... ... </pin-set>
+  - pattern-inside: |
+      <domain-config ... > ... ... ... ... ... </domain-config>
+  - pattern-not-inside: |
+      <!-- ... -->
+  severity: INFO
+  paths:
+    include:
+    - '*.xml'
+- id: nsc-pinning-without-expiration
+  languages:
+  - generic
+  message: >
+    Your app uses TLS public key pinning without specifying an expiration date.
+    If your users do not update the app to receive new pins in time, expired or replaced
+    certificates can lead to connectivity issues until they install an update.
+    It is considered best practice to set an expiration time, after which the system will
+    default to trusting system CAs and disregard the pin.
+  metadata:
+    category: best-practice
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - android
+    references:
+    - https://developer.android.com/training/articles/security-config#CertificatePinning
+    - https://www.nowsecure.com/blog/2018/08/15/a-security-analysts-guide-to-network-security-configuration-in-android-p/
+  patterns:
+  - pattern: |
+      <pin-set ...>... ... ...</pin-set>
+  - pattern-not-inside: |
+      <pin-set ... expiration="..."> ... ... ... </pin-set>
+  - pattern-inside: |
+      <domain-config ... > ... ... ... ... ... </domain-config>
+  - pattern-not-inside: |
+      <!-- ... -->
+  severity: INFO
+  paths:
+    include:
+    - '*.xml'
+- id: nsc-allows-user-ca-certs
+  languages:
+  - generic
+  message: >
+    The Network Security Config is set to accept user-installed CAs.
+    Evaluate if this is necessary for your app, and disable it if appropriate.
+    (To hide this warning, set `xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="AcceptsUserCertificates"` as parameters to your
+    `<network-security-config>`)
+  metadata:
+    category: best-practice
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - android
+    references:
+    - https://developer.android.com/training/articles/security-config
+    - https://www.nowsecure.com/blog/2018/08/15/a-security-analysts-guide-to-network-security-configuration-in-android-p/
+  patterns:
+  - pattern: |
+      <certificates ... user ... />
+  - pattern-inside: |
+      <base-config ... > ... ... ... ... </base-config>
+  - pattern-not-inside: |
+      <!-- ... -->
+     # If the config explicitly tells us not to check for user CAs, respect that
+      # (on a best-effort basis due to limitations of how much you can glob in generic parser mode)
+  - pattern-not-inside: |
+      <network-security-config ... AcceptsUserCertificates ... >... ... ... ... ... ... ... ... ... ... </network-security-config>
+  severity: WARNING
+  paths:
+    include:
+    - '*.xml'
+- id: nsc-allows-user-ca-certs-for-domain
+  languages:
+  - generic
+  message: >
+    The Network Security Config is set to accept user-installed CAs for the
+    domain `$DOMAIN`.
+    Evaluate if this is necessary for your app, and disable it if appropriate.
+    (To hide this warning, set `xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="AcceptsUserCertificates"` as parameters to your
+    `<network-security-config>`)
+  metadata:
+    category: best-practice
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    technology:
+    - android
+    references:
+    - https://developer.android.com/training/articles/security-config
+    - https://www.nowsecure.com/blog/2018/08/15/a-security-analysts-guide-to-network-security-configuration-in-android-p/
+  patterns:
+  - pattern: |
+      <certificates src="user" ... />
+  - pattern-inside: |
+      <trust-anchors> ... ... ... </trust-anchors>
+  - pattern-inside: |
+      <domain-config ... > ... <domain ...> $DOMAIN </domain>... ... ... </domain-config>
+  - pattern-not-inside: |
+      <!-- ... -->
+     # If the config explicitly tells us not to check for user CAs, respect that
+      # (on a best-effort basis due to limitations of how much you can glob in generic parser mode)
+  - pattern-not-inside: |
+      <network-security-config ... AcceptsUserCertificates ... >... ... ... ... ... ... ... ... ... ... </network-security-config>
+  severity: WARNING
+  paths:
+    include:
+    - '*.xml'


### PR DESCRIPTION
Android apps can specify security policies for network traffic in two places: the Manifest-file (outdated) and a network-security-policy.xml file. This PR adds rules for detecting a number of common issues related to these files, see the rule messages for more details. 

I figure these rules walk the line between security and best-practice as a categorization - I chose best-practice as there are sometimes good reasons to deviate from these best practices, and tried to write the rules in a way where they respect the [`tools:ignore` attribute](https://developer.android.com/studio/write/tool-attributes#toolsignore) (although that may not always be successful due to limitations of the `generic` parser, and my limited knowledge of which of these attributes exist) to try to reduce the amount of annoyance to developers.

As always, feedback is very welcome. I chose not to submit these rules to [MobSF](https://github.com/MobSF) as they already have [their own checks for these issues](https://github.com/MobSF/Mobile-Security-Framework-MobSF/blob/master/mobsf/StaticAnalyzer/views/android/network_security.py), which are implemented outside of their corpus of semgrep rules.