### PR TITLE
Add rules related to handling CRLF line endings in OCaml

### DIFF
--- a/ocaml/lang/portability/crlf-support.ml
+++ b/ocaml/lang/portability/crlf-support.ml
@@ -1,0 +1,34 @@
+let get_line ic =
+  try
+    (* ruleid:broken-input-line *)
+    Some (input_line ic)
+  with
+    End_of_file -> None
+
+let with_in_file path f =
+  (* ruleid:prefer-read-in-binary-mode *)
+  let ic = open_in path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> f ic)
+
+let with_in_file path f =
+  (* ruleid:prefer-write-in-binary-mode *)
+  let oc = open_out path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> f oc)
+
+(* Force text mode without triggering alert *)
+let with_in_text path f =
+  let ic = open_in_gen [Open_text] 0o000 path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> f ic)
+
+(* Force text mode without triggering alert *)
+let with_out_text path f =
+  let oc = open_out_gen [Open_text] 0o666 path in
+  Fun.protect
+    ~finally:(fun () -> close_out_noerr oc)
+    (fun () -> f oc)

--- a/ocaml/lang/portability/crlf-support.yaml
+++ b/ocaml/lang/portability/crlf-support.yaml
@@ -1,0 +1,43 @@
+rules:
+- id: broken-input-line
+  pattern: |
+    input_line
+  message: |
+    'input_line' leaves a '\r' (CR) character when reading lines from
+    a Windows text file, whose lines end in "\r\n" (CRLF). This is a
+    problem for any Windows file that is being read either on a Unix-like
+    platform or on Windows in binary mode. If the code already takes
+    care of removing any trailing '\r' after reading the line, add a
+    '(* nosemgrep *)' comment to disable this warning.
+  languages: [ocaml]
+  severity: WARNING
+  metadata:
+    category: portability
+
+- id: prefer-read-in-binary-mode
+  pattern: open_in
+  fix: open_in_bin
+  message: |
+    'open_in' behaves differently on Windows and on Unix-like
+    systems with respect to line endings. To get the same behavior
+    everywhere, use 'open_in_bin' or 'open_in_gen [Open_binary]'.
+    If you really want CRLF-to-LF translations to take place when
+    running on Windows, use 'open_in_gen [Open_text]'.
+  languages: [ocaml]
+  severity: WARNING
+  metadata:
+    category: portability
+
+- id: prefer-write-in-binary-mode
+  pattern: open_out
+  fix: open_out_bin
+  message: |
+    'open_out' behaves differently on Windows and on Unix-like
+    systems with respect to line endings. To get the same behavior
+    everywhere, use 'open_out_bin' or 'open_out_gen [Open_binary]'.
+    If you really want LF-to-CRLF translations to take place when
+    running on Windows, use 'open_out_gen [Open_text]'.
+  languages: [ocaml]
+  severity: WARNING
+  metadata:
+    category: portability


### PR DESCRIPTION
These are my first semgrep rules for actual use! Please let me know of anything that could be improved.

I tested this, including the autofix, in the live editor: https://semgrep.dev/s/mjambon:ocaml-crlf-support

The sample OCaml code compiles and might actually work, although I offer no guarantee.
