### PR TITLE
Expand rule to cover a broader set of origin validation scenarios

### DIFF
--- a/javascript/browser/security/insufficient-postmessage-origin-validation.js
+++ b/javascript/browser/security/insufficient-postmessage-origin-validation.js
@@ -1,25 +1,69 @@
-//ruleid:insufficient-postmessage-origin-validation
-window.addEventListener("message", receiveMessage, false);
-
-
-//addEventListener Safe Usage (Origin Checked)
-const globalRegex = RegExp('/^http://www.examplesender.com$/', 'g');
-window.addEventListener("message", function(message){
-    if(globalRegex.test(message.origin)){
-         console.log(message.data);
-   }
+// ruleid: insufficient-postmessage-origin-validation
+window.addEventListener("message", function (evt) {
+  console.log('Inline without origin check!');
 });
 
-//addEventListener Safe Usage (Origin Checked)
-window.addEventListener("message", function(message){
-if (event.origin !== "http://example.com") {
-    return;
-}
+// ruleid: insufficient-postmessage-origin-validation
+function oldHandler(evt) {
+  console.log('Normal function handler without origin check!');
+};
+
+window.addEventListener("message", oldHandler, false);
+
+// ruleid: insufficient-postmessage-origin-validation
+window.addEventListener('message', (evt) => {
+  console.log('Inline arrow function without origin check!');
 });
 
-//addEventListener Safe Usage (Origin Checked)
-window.addEventListener("message", function(message){
-if (event.origin == "http://example.com") {
-    alert("Works");
-}
+// ruleid: insufficient-postmessage-origin-validation
+window.addEventListener('message', evt => {
+  console.log('Inline arrow function without parenthesis & origin check!');
+});
+
+// ruleid: insufficient-postmessage-origin-validation
+const handler = (evt) => {
+  console.log('Arrow function handler without origin check!');
+};
+
+window.addEventListener("message", handler, false);
+
+// ok: insufficient-postmessage-origin-validation
+window.addEventListener("message", function (evt) {
+  if (evt.origin == "http://example.com") {
+    console.log('Normal inline function declaration with origin validation');
+  }
+});
+
+// ok: insufficient-postmessage-origin-validation
+function normalHandler(evt) {
+  if (evt.origin == "http://example.com") {
+    console.log('Normal function handler with origin validation');
+  }
+};
+
+window.addEventListener('message', normalHandler, false);
+
+// ok: insufficient-postmessage-origin-validation
+window.addEventListener('message', (evt) => {
+  if (evt.origin !== "http://example.com") {
+    console.log('Inline arrow function declaration with origin validation');
+  }
+});
+
+// ok: insufficient-postmessage-origin-validation
+const arrowHandler = (evt) => {
+  if (evt.origin == "http://example.com") {
+    console.log('Arrow function handler with origin validation');
+  }
+};
+
+window.addEventListener('message', arrowHandler, false);
+
+const globalRegex = RegExp('/^http://www\.example\.com$/', 'g');
+
+// ok: insufficient-postmessage-origin-validation
+window.addEventListener("message", (evt) => {
+  if (globalRegex.test(evt.origin)) {
+    console.log(message.data);
+  }
 });

--- a/javascript/browser/security/insufficient-postmessage-origin-validation.js
+++ b/javascript/browser/security/insufficient-postmessage-origin-validation.js
@@ -3,11 +3,11 @@ window.addEventListener("message", function (evt) {
   console.log('Inline without origin check!');
 });
 
-// ruleid: insufficient-postmessage-origin-validation
 function oldHandler(evt) {
   console.log('Normal function handler without origin check!');
 };
 
+// ruleid: insufficient-postmessage-origin-validation
 window.addEventListener("message", oldHandler, false);
 
 // ruleid: insufficient-postmessage-origin-validation
@@ -20,11 +20,11 @@ window.addEventListener('message', evt => {
   console.log('Inline arrow function without parenthesis & origin check!');
 });
 
-// ruleid: insufficient-postmessage-origin-validation
 const handler = (evt) => {
   console.log('Arrow function handler without origin check!');
 };
 
+// ruleid: insufficient-postmessage-origin-validation
 window.addEventListener("message", handler, false);
 
 // ok: insufficient-postmessage-origin-validation

--- a/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
+++ b/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
@@ -1,20 +1,31 @@
 rules:
 - id: insufficient-postmessage-origin-validation
-  patterns:
-  - pattern: |
-      window.addEventListener(...)
-  - pattern-not: |
-      window.addEventListener(..., function($OBJECT){ if ($OBJ.origin == $X) {
-                  ...
-              } })
-  - pattern-not: |
-      window.addEventListener(..., function($OBJECT){ if ($REGEX.test($OBJECT.origin)){
+  pattern-either:
+  - patterns:
+    - pattern: |
+        window.addEventListener('message', $FUNC, ...)
+    - metavariable-pattern:
+        metavariable: $FUNC
+        patterns:
+        - pattern: |
+            function($OBJ) { ... }
+        - pattern-not: |
+            function($OBJ) { ... if (<... $OBJ.origin ...>) { ... } ... }
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          function $FNAME($OBJ) { $CONTEXT }
           ...
-      } })
-  - pattern-not: |
-      window.addEventListener(..., function($OBJECT){ if ($OBJ.origin !== $X) {
-                  ...
-              } })
+          window.addEventListener('message', $FNAME,...)
+      - pattern: |
+          $FNAME = (...) => { $CONTEXT }
+          ...
+          window.addEventListener('message', $FNAME,...)
+    - metavariable-pattern:
+        metavariable: $CONTEXT
+        patterns:
+        - pattern-not: |
+            ... if (<... $OBJ.origin ...>) { ... } ...
   message: |
     No validation of origin is done by the addEventListener API. It may be possible to exploit this flaw to perform Cross Origin attacks such as Cross-Site Scripting(XSS).
   languages:

--- a/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
+++ b/javascript/browser/security/insufficient-postmessage-origin-validation.yaml
@@ -13,14 +13,14 @@ rules:
             function($OBJ) { ... if (<... $OBJ.origin ...>) { ... } ... }
   - patterns:
     - pattern-either:
-      - pattern: |
+      - pattern-inside: |
           function $FNAME($OBJ) { $CONTEXT }
           ...
-          window.addEventListener('message', $FNAME,...)
-      - pattern: |
+      - pattern-inside: |
           $FNAME = (...) => { $CONTEXT }
           ...
-          window.addEventListener('message', $FNAME,...)
+    - pattern: |
+        window.addEventListener('message', $FNAME,...)
     - metavariable-pattern:
         metavariable: $CONTEXT
         patterns:
@@ -31,8 +31,6 @@ rules:
   languages:
   - javascript
   - typescript
-  fix: |
-
   severity: WARNING
   metadata:
     owasp: 'A3: Sensitive Data Exposure'


### PR DESCRIPTION
The current rule takes into account:

1. Inline function declarations within `addEventListener`
2. Specific operators for origin validation within the handler

The new rule expands it to cover:

1. Inline and external function declarations
2. Checks whether origin is being called or not within an if clause in
   the handler

To see this rule in action: https://semgrep.dev/s/rkOR

If we think checking for specific equality operators is something
desirable we can change the rule to something like: https://semgrep.dev/s/brjE