### PR TITLE
add lazy-load-module rule

### DIFF
--- a/javascript/lang/best-practice/lazy-load-module.js
+++ b/javascript/lang/best-practice/lazy-load-module.js
@@ -1,0 +1,8 @@
+// ok: lazy-load-module
+const fs = require('fs')
+
+function smth() {
+  // ruleid: lazy-load-module
+  const mod = require('module-name')
+  return mod();
+}

--- a/javascript/lang/best-practice/lazy-load-module.yaml
+++ b/javascript/lang/best-practice/lazy-load-module.yaml
@@ -7,10 +7,13 @@ rules:
           ...
       }
   message: |
-    Lazy loading can complicate code bundling if care is not taken.
+    Lazy loading can complicate code bundling if care is not taken, also `require`s are run synchronously by Node.js.
+    If they are called from within a function, it may block other requests from being handled at a more critical time.
+    The best practice is to `require` modules at the beginning of each file, before and outside of any functions.
   languages: [js, ts]
   severity: WARNING
   metadata:
     category: best-practice
     references:
     - https://nodesecroadmap.fyi/chapter-2/dynamism.html
+    - https://github.com/goldbergyoni/nodebestpractices#-38-require-modules-first-not-inside-functions

--- a/javascript/lang/best-practice/lazy-load-module.yaml
+++ b/javascript/lang/best-practice/lazy-load-module.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: lazy-load-module
+  patterns:
+  - pattern: require(...)
+  - pattern-inside: |
+      function $NAME(...) {
+          ...
+      }
+  message: |
+    Lazy loading can complicate code bundling if care is not taken.
+  languages: [js, ts]
+  severity: WARNING
+  metadata:
+    category: best-practice
+    references:
+    - https://nodesecroadmap.fyi/chapter-2/dynamism.html


### PR DESCRIPTION
Simple rule for bad pattern: dynamic `require` usage