### PR TITLE
add code-string-concat rule

### DIFF
--- a/javascript/lang/security/audit/code-string-concat.js
+++ b/javascript/lang/security/audit/code-string-concat.js
@@ -1,0 +1,35 @@
+function test1() {
+  const data = JSON.stringify(key);
+  // ruleid:code-string-concat
+  return exec(`(function(){${data}})`)
+}
+
+function test2() {
+  const data = JSON.stringify(key);
+
+  // ruleid:code-string-concat
+  const command = `(secret) => {${data}}`
+  return exec(command)
+}
+
+function test3(userInput) {
+  // ruleid:code-string-concat
+  var command = "new Function('"+userInput+"')";
+  return exec(command)
+}
+
+function test4(userInput) {
+  // ruleid:code-string-concat
+  var command = "eval('"+userInput+"')";
+  return exec(command)
+}
+
+function ok1() {
+  var command = "eval('123')";
+  return exec(command)
+}
+
+function ok1() {
+  var command = "eval('123')";
+  return exec(command)
+}

--- a/javascript/lang/security/audit/code-string-concat.yaml
+++ b/javascript/lang/security/audit/code-string-concat.yaml
@@ -31,4 +31,4 @@ rules:
   - patterns:
     - pattern-inside: |
         `...${...}...`
-    - pattern-regex: .*(function|Function|eval|\([^\(\)]*\)\s*=>).*
+    - pattern-regex: function|Function|eval|\([^\(\)]*\)\s*=>

--- a/javascript/lang/security/audit/code-string-concat.yaml
+++ b/javascript/lang/security/audit/code-string-concat.yaml
@@ -1,0 +1,34 @@
+rules:
+- id: code-string-concat
+  message: >-
+    User controlled data in eval() or similar functions may result in Code Injection
+  languages:
+  - javascript
+  - typescript
+  severity: WARNING
+  metadata:
+    owasp: 'A1: Injection'
+    cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    category: security
+    technology:
+    - node.js
+  pattern-either:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern: $STRING + $EXPR
+        - pattern-not: $STRING + "..."
+      - patterns:
+        - pattern: $EXPR + $STRING
+        - pattern-not: '"..." + $STRING'
+      - patterns:
+        - pattern: '[..., $STRING, ...].join(...)'
+      - patterns:
+        - pattern: $VAR += $STRING
+    - metavariable-regex:
+        metavariable: $STRING
+        regex: .*(function|Function|eval|\([^\(\)]*\)\s*=>).*
+  - patterns:
+    - pattern-inside: |
+        `...${...}...`
+    - pattern-regex: .*(function|Function|eval|\([^\(\)]*\)\s*=>).*


### PR DESCRIPTION
Command injection prevention rule, looking for string concatenation of stuff like `"function(){" + userInput + "}"`