### PR TITLE
add rule for public s3 bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .pytest_cache/
 .DS_Store
 .vscode/
+.venv

--- a/json/aws/security/public-s3-bucket-test.json
+++ b/json/aws/security/public-s3-bucket-test.json
@@ -1,0 +1,27 @@
+
+  {
+    "Resources": {
+      "MyBucketF68F3FF0": {
+        "Type": "AWS::S3::Bucket",
+        "Properties": {
+          "BucketEncryption": {
+            "ServerSideEncryptionConfiguration": [
+              {
+                "ServerSideEncryptionByDefault": {
+                  "SSEAlgorithm": "aws:kms"
+                }
+              }
+            ]
+          },
+          "PublicAccessBlockConfiguration": {
+            "BlockPublicAcls": true,
+            "BlockPublicPolicy": true,
+            "IgnorePublicAcls": false,
+            "RestrictPublicBuckets": true
+          }
+        },
+        "UpdateReplacePolicy": "Delete",
+        "DeletionPolicy": "Delete"
+      }
+    }
+  }

--- a/json/aws/security/public-s3-bucket.json
+++ b/json/aws/security/public-s3-bucket.json
@@ -22,6 +22,28 @@
         },
         "UpdateReplacePolicy": "Delete",
         "DeletionPolicy": "Delete"
+      },
+      "MyBucketF68F3FF1": {
+        "Type": "AWS::S3::Bucket",
+        "Properties": {
+          "BucketEncryption": {
+            "ServerSideEncryptionConfiguration": [
+              {
+                "ServerSideEncryptionByDefault": {
+                  "SSEAlgorithm": "aws:kms"
+                }
+              }
+            ]
+          },
+          "PublicAccessBlockConfiguration": {
+            "BlockPublicAcls": true,
+            "BlockPublicPolicy": true,
+            "IgnorePublicAcls": true,
+            "RestrictPublicBuckets": true
+          }
+        },
+        "UpdateReplacePolicy": "Delete",
+        "DeletionPolicy": "Delete"
       }
     }
   }

--- a/json/aws/security/public-s3-bucket.json
+++ b/json/aws/security/public-s3-bucket.json
@@ -1,5 +1,6 @@
 
   {
+
     "Resources": {
       "MyBucketF68F3FF0": {
         "Type": "AWS::S3::Bucket",
@@ -13,6 +14,7 @@
               }
             ]
           },
+          // ruleid: public-s3-bucket
           "PublicAccessBlockConfiguration": {
             "BlockPublicAcls": true,
             "BlockPublicPolicy": true,
@@ -35,6 +37,7 @@
               }
             ]
           },
+          // ok : public-s3-bucket
           "PublicAccessBlockConfiguration": {
             "BlockPublicAcls": true,
             "BlockPublicPolicy": true,

--- a/json/aws/security/public-s3-bucket.yaml
+++ b/json/aws/security/public-s3-bucket.yaml
@@ -1,52 +1,51 @@
 rules:
-  - id: public-s3-policy-statement
-    languages:
-      - json
-    message: |
-      Detected public s3 bucket. This policy allows anyone to have some kind of access
-      to the bucket. The exact level of access and types of actions allowed will depend on the configuration of
-      bucket policy and ACLs. Please review the bucket configuration to make sure they are set with intended values. 
-    metadata:
-      category: security
-      cwe: "CWE-264: Permissions, Privileges, and Access Controls"
-      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-      owasp: "A6: Security Misconfiguration"
-      references:
-        - https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
-      technology:
-        - aws
-    patterns:
-      - pattern-inside: |
-          $BUCKETNAME: {
-            "Type": "AWS::S3::Bucket",
-            "Properties": {
-            ...,
-            },
-            ...,
-          }
-      - pattern-either:
-          - pattern: |
-             "PublicAccessBlockConfiguration": {
-                  ...,
-                  "RestrictPublicBuckets": false,
-                  ...,
-                },
-          - pattern: |
-             "PublicAccessBlockConfiguration": {
-                  ...,
-                  "IgnorePublicAcls": false,
-                  ...,
-                },
-          - pattern: |
-             "PublicAccessBlockConfiguration": {
-                  ...,
-                  "BlockPublicAcls": false,
-                  ...,
-                }, 
-          - pattern: |
-             "PublicAccessBlockConfiguration": {
-                  ...,
-                  "BlockPublicPolicy": false,
-                  ...,
-                },       
-    severity: WARNING
+- id: public-s3-policy-statement
+  languages:
+  - json
+  message: |
+    Detected public s3 bucket. This policy allows anyone to have some kind of access to the bucket. The exact level of access and types of actions allowed will depend on the configuration of
+    bucket policy and ACLs. Please review the bucket configuration to make sure they are set with intended values.
+  metadata:
+    category: security
+    cwe: 'CWE-264: Permissions, Privileges, and Access Controls'
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    owasp: 'A6: Security Misconfiguration'
+    references:
+    - https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
+    technology:
+    - aws
+  patterns:
+  - pattern-inside: |
+      $BUCKETNAME: {
+        "Type": "AWS::S3::Bucket",
+        "Properties": {
+        ...,
+        },
+        ...,
+      }
+  - pattern-either:
+    - pattern: |
+        "PublicAccessBlockConfiguration": {
+             ...,
+             "RestrictPublicBuckets": false,
+             ...,
+           },
+    - pattern: |
+        "PublicAccessBlockConfiguration": {
+             ...,
+             "IgnorePublicAcls": false,
+             ...,
+           },
+    - pattern: |
+        "PublicAccessBlockConfiguration": {
+             ...,
+             "BlockPublicAcls": false,
+             ...,
+           },
+    - pattern: |
+        "PublicAccessBlockConfiguration": {
+             ...,
+             "BlockPublicPolicy": false,
+             ...,
+           },
+  severity: WARNING

--- a/json/aws/security/public-s3-bucket.yaml
+++ b/json/aws/security/public-s3-bucket.yaml
@@ -1,5 +1,5 @@
 rules:
-- id: public-s3-policy-statement
+- id: public-s3-bucket
   languages:
   - json
   message: |

--- a/json/aws/security/public-s3-bucket.yaml
+++ b/json/aws/security/public-s3-bucket.yaml
@@ -1,0 +1,52 @@
+rules:
+  - id: public-s3-policy-statement
+    languages:
+      - json
+    message: |
+      Detected public s3 bucket. This policy allows anyone to have some kind of access
+      to the bucket. The exact level of access and types of actions allowed will depend on the configuration of
+      bucket policy and ACLs. Please review the bucket configuration to make sure they are set with intended values. 
+    metadata:
+      category: security
+      cwe: "CWE-264: Permissions, Privileges, and Access Controls"
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+      owasp: "A6: Security Misconfiguration"
+      references:
+        - https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html
+      technology:
+        - aws
+    patterns:
+      - pattern-inside: |
+          $BUCKETNAME: {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+            ...,
+            },
+            ...,
+          }
+      - pattern-either:
+          - pattern: |
+             "PublicAccessBlockConfiguration": {
+                  ...,
+                  "RestrictPublicBuckets": false,
+                  ...,
+                },
+          - pattern: |
+             "PublicAccessBlockConfiguration": {
+                  ...,
+                  "IgnorePublicAcls": false,
+                  ...,
+                },
+          - pattern: |
+             "PublicAccessBlockConfiguration": {
+                  ...,
+                  "BlockPublicAcls": false,
+                  ...,
+                }, 
+          - pattern: |
+             "PublicAccessBlockConfiguration": {
+                  ...,
+                  "BlockPublicPolicy": false,
+                  ...,
+                },       
+    severity: WARNING


### PR DESCRIPTION
- S3 bucket CloudFormation objects have a property called as `PublicAccessBlockConfiguration ` , which in turn, has 4 sub-properties. 
     - "BlockPublicAcls" 
     - "BlockPublicPolicy" 
     - "IgnorePublicAcls" 
     - "RestrictPublicBuckets"
   
    
   If any of these properties is set to `false`, there is a chance that an attacker may be able to perform some actions on some or all objects in the bucket.  This rule checks if any of these properties is set to `false` and if the detected pattern is part of an S3 bucket definition. 

More information here : https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html