### PR TITLE
Detect @Html.Raw on JSON

### DIFF
--- a/csharp/razor/security/html-raw-json.cshtml
+++ b/csharp/razor/security/html-raw-json.cshtml
@@ -1,0 +1,20 @@
+<script>
+    // ruleid: html-raw-json
+    var a = @Html.Raw(SomeFunc(Model).ToJson());
+</script>
+<script type="text/javascript">
+    SomeOtherCall();
+    // ruleid: html-raw-json
+    var obj = @Html.Raw(Json.Encode(Model));
+    alert("hello world");
+</script>
+<script>
+    // ruleid: html-raw-json
+    var obj = @Html.Raw(JsonConvert.SerializeObject(Model));
+</script>
+<script>
+    // ok: html-raw-json
+    var obj = @Html.Raw(Model.HtmlField);
+</script>
+// ok: html-raw-json
+<div data-json="@Json.Encode(Model)"></div>

--- a/csharp/razor/security/html-raw-json.yaml
+++ b/csharp/razor/security/html-raw-json.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: html-raw-json
+  patterns:
+    - pattern-either:
+      - pattern: "@Html.Raw(Json.Encode(...))"
+      - pattern: "@Html.Raw(JsonConvert.SerializeObject(...))"
+      - pattern: "@Html.Raw(...ToJson(...))"
+  message: Unencoded JSON in HTML context is vulnerable to cross-site scripting, because `</script>` is not properly encoded.
+  languages:
+  - generic
+  paths:
+    include:
+      - "*.cshtml"
+  severity: ERROR


### PR DESCRIPTION
A common pattern in ASP.NET is to convert a backend C# object to JavaScript,
using the following pattern in the Razor template:

```
<script>
var a = @Html.Raw(Json.Encode(Model));
</script>
```

This encodes `Model` to JSON and assigns it to `a`. The `Html.Raw` is used to
avoid HTML encoding. Unfortunately, this also makes it vulnerable to XSS. By
including `</script>` in the JSON, it is possible to break out of the script
context.

This rule detects this pattern, the combination of `@Html.Raw` with JSON
encoding. I chose not to match the surrounding `<script>`. This makes it more
specific where the error occurs, and this pattern would also be vulnerable
outside of JavaScript.