### PR TITLE
update missing-template-string-indicator rule

### DIFF
--- a/javascript/lang/correctness/missing-template-string-indicator.js
+++ b/javascript/lang/correctness/missing-template-string-indicator.js
@@ -3,6 +3,13 @@ function name() {
   return `this is ${start.line}`
 }
 
+function ok() {
+  // ok: missing-template-string-indicator
+  `test`;
+  if (true) { a = 3; }
+  `test`;
+}
+
 function name2() {
   // ruleid: missing-template-string-indicator
   return `this is {start.line}`

--- a/javascript/lang/correctness/missing-template-string-indicator.js
+++ b/javascript/lang/correctness/missing-template-string-indicator.js
@@ -14,3 +14,14 @@ function name2() {
   // ruleid: missing-template-string-indicator
   return `this is {start.line}`
 }
+
+function name3() {
+  // ok: missing-template-string-indicator
+  return "this is ${start.line}"
+}
+
+
+function name3() {
+  // ok: missing-template-string-indicator
+  return "this is {start.line}"
+}

--- a/javascript/lang/correctness/missing-template-string-indicator.yaml
+++ b/javascript/lang/correctness/missing-template-string-indicator.yaml
@@ -1,15 +1,13 @@
 rules:
 - id: missing-template-string-indicator
   patterns:
-  - pattern: '`... {...} ...`'
-  - pattern-not-inside: '`... ${...} ...`'
-  languages: [generic]
+  - pattern-inside: |
+      `...`
+  - pattern: $STR
+  - metavariable-regex:
+      metavariable: $STR
+      regex: .*[^$]+{[^{}]*}.*
+  languages: [js, ts]
   message: >-
     This looks like a JavaScript template string. Are you missing a '$' in front of '{...}'?
-  paths:
-    include:
-    - '*.js'
-    - '*.ts'
-    - '*.jsx'
-    - '*.tsx'
   severity: ERROR


### PR DESCRIPTION
had to change the rule from `generic` to `javascript + regex`
issue: https://github.com/returntocorp/semgrep-rules/issues/1461