### PR TITLE
Modify semgrep rule lints

### DIFF
--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -10,7 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     name: semgrep-rule-lints
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - uses: returntocorp/semgrep-action@v1
       with:
-        config: p/semgrep-rule-lints
+        config: >-
+          yaml/semgrep/duplicate-id.yaml
+          yaml/semgrep/duplicate-pattern.yaml
+          yaml/semgrep/unsatisfiable-rule.yaml
+          yaml/semgrep/metadata-cwe.yaml
+          yaml/semgrep/metadata-owasp.yaml
+          yaml/semgrep/metadata-references.yaml
+          yaml/semgrep/empty-message.yaml
+          yaml/semgrep/missing-message-field.yaml
+          yaml/semgrep/missing-language-field.yaml
+          yaml/semgrep/metadata-technology.yaml
+          yaml/semgrep/metadata-category.yaml
+          yaml/semgrep/multi-line-message.yaml
+          yaml/semgrep/slow-pattern-top-ellipsis.yaml

--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -16,7 +16,7 @@ jobs:
         config: >-
           yaml/semgrep/duplicate-id.yaml
           yaml/semgrep/duplicate-pattern.yaml
-          yaml/semgrep/unsatisfiable-rule.yaml
+          yaml/semgrep/unsatisfiable.yaml
           yaml/semgrep/metadata-cwe.yaml
           yaml/semgrep/metadata-owasp.yaml
           yaml/semgrep/metadata-references.yaml

--- a/yaml/semgrep/metadata-owasp.test.yaml
+++ b/yaml/semgrep/metadata-owasp.test.yaml
@@ -5,7 +5,7 @@ rules:
   languages: [json, yaml]
   pattern: '...'
   metadata:
-      # ok: metadata-owasp
+    # ok: metadata-owasp
     owasp: 'A1: Some Vulnerability'
 - id: example-2
   message: Example
@@ -13,7 +13,7 @@ rules:
   languages: [json, yaml]
   pattern: '...'
   metadata:
-      # ruleid: metadata-owasp
+    # ruleid: metadata-owasp
     owasp: 'A11: Some Vulnerability'
 - id: example-3
   message: Example
@@ -21,7 +21,7 @@ rules:
   languages: [json, yaml]
   pattern: '...'
   metadata:
-      # ruleid: metadata-owasp
+    # ruleid: metadata-owasp
     owasp: a4
 - id: example-4
   message: Example
@@ -29,5 +29,29 @@ rules:
   languages: [json, yaml]
   pattern: '...'
   metadata:
-      # ruleid: metadata-owasp
+    # ruleid: metadata-owasp
     owasp: A5 Some Vulnerability
+- id: example-5
+  message: Example
+  severity: ERROR
+  languages: [json, yaml]
+  pattern: '...'
+  metadata:
+    # ok: metadata-owasp
+    owasp:
+    # ok: metadata-owasp
+    - A05:2021 - Security Misconfiguration
+    # ok: metadata-owasp
+    - A06:2017 - Security Misconfiguration
+- id: example-6
+  message: Example
+  severity: ERROR
+  languages: [json, yaml]
+  pattern: '...'
+  metadata:
+    # ok: metadata-owasp
+    owasp:
+    # ruleid: metadata-owasp
+    - A5:2021 - Security Misconfiguration
+    # ruleid: metadata-owasp
+    - A06:201789 - Security Misconfiguration

--- a/yaml/semgrep/metadata-owasp.yaml
+++ b/yaml/semgrep/metadata-owasp.yaml
@@ -1,14 +1,22 @@
 rules:
 - id: metadata-owasp
   message: >-
-    The owasp tag in rule metadata should always be in the format "A0: Title".
+    The `owasp` tag in Semgrep rule metadata should start with the format "A00:YYYY",
+    where A00 is the OWASP top ten number and YYYY is the OWASP top ten year.
   severity: ERROR
   languages: [json, yaml]
   patterns:
   - pattern-inside: 'rules: ...'
   - pattern-inside: 'metadata: ...'
-  - pattern: 'owasp: ...'
-  - pattern-not: 'owasp: "=~/^A([0-9]|10): .+$/"'
+  - pattern-either:
+    - patterns:
+      - pattern: 'owasp: "..."'
+      - pattern-not: 'owasp: "=~/^A(0?[1-9]|10): .+$/"'
+    - patterns:
+      - pattern-inside: 'owasp: [...]'
+      - pattern: '"$ANYTHING"'
+      - pattern-not-regex: .*A[01][0-9]:[0-9]{4}\s+.*
+      - pattern-not-regex: 'owasp:'
   metadata:
     category: best-practice
     technology:


### PR DESCRIPTION
- Modify `owasp` metadata rule lint to handle lists for multiple OWASP years
- Modify semgrep-rule-lints workflow to use local files