### PR TITLE
Fix false positive in nginx alias-path-traversal rule

### DIFF
--- a/generic/nginx/security/alias-path-traversal.conf
+++ b/generic/nginx/security/alias-path-traversal.conf
@@ -10,4 +10,9 @@ server {
   location /i/ {
     alias /data/w3/images/;
   }
+
+  # ok: alias-path-traversal
+  location /i {
+    alias /data/w3/images;
+  }
 }

--- a/generic/nginx/security/alias-path-traversal.yaml
+++ b/generic/nginx/security/alias-path-traversal.yaml
@@ -4,7 +4,7 @@ rules:
   - pattern: |
       location ... {
         ...
-        alias ...;
+        alias .../;
         ...
       }
   - pattern-not-inside: location /.../ { ... ... }


### PR DESCRIPTION
I noticed a false positive with this rule.

## How to reproduce

```
$ cat nginx.conf
events {
  worker_connections 200;
}

http {
  server {
    listen 80;

    location /notvulnerable {
      alias /tmp; # Note: no trailing slash
    }
  }
}

$ docker run -d --rm -v $(PWD)/nginx.conf:/etc/nginx/nginx.conf:ro -p 8000:80 nginx:1.21.3-alpine -d
$ curl 127.0.0.1:8000/notvulnerable../etc/passwd
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx/1.21.3</center>
</body>
</html>
```

And nginx logs:

```
open() "/tmp../etc/passwd" failed (2: No such file or directory)
```

This is because in order for this vulnerability to be exploitable, the path indicated in the `alias` directive must end with a trailing slash.

Example **exploitable** case:

```
$ cat nginx.conf
events {
  worker_connections 200;
}

http {
  server {
    listen 80;

    location /vulnerable {
      alias /tmp/; # Note: trailing slash
    }
  }
}

$ docker run -d --rm -v $(PWD)/nginx.conf:/etc/nginx/nginx.conf:ro -p 8000:80 nginx:1.21.3-alpine
$ curl 127.0.0.1:8000/vulnerable../etc/passwd
root:x:0:0:root:/root:/bin/ash
bin:x:1:1:bin:/bin:/sbin/nologin
daemon:x:2:2:daemon:/sbin:/sbin/nologin
adm:x:3:4:adm:/var/adm:/sbin/nologin
lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
sync:x:5:0:sync:/sbin:/bin/sync
...
```

## Fix

Ensure the rule only matches if both of the following are true:
- The path in the `location` statement does not end with a `/`
- The path in the `alias` statement **does** end with a `/`