### PR TITLE
Update GHA run-shell-injection rule after triaging real-world results

### DIFF
--- a/yaml/github-actions/security/pull-request-target-code-checkout.test.yaml
+++ b/yaml/github-actions/security/pull-request-target-code-checkout.test.yaml
@@ -59,3 +59,15 @@ jobs:
     - name: echo
       run: |
         echo "Hello, world"
+
+  # cf. https://github.com/justinsteven/advisories/blob/master/2021_github_actions_checkspelling_token_leak_via_advice_symlink.md
+  spelling:
+    name: Spell checking
+    runs-on: ubuntu-latest
+    steps:
+    # ruleid: pull-request-target-code-checkout
+    - name: checkout-merge
+      if: contains(github.event_name, 'pull_request')
+      uses: actions/checkout@v2
+      with:
+        ref: refs/pull/${{github.event.pull_request.number}}/merge

--- a/yaml/github-actions/security/pull-request-target-code-checkout.yaml
+++ b/yaml/github-actions/security/pull-request-target-code-checkout.yaml
@@ -21,6 +21,7 @@ rules:
     cwe: 'CWE-913: Improper Control of Dynamically-Managed Code Resources'
     references:
     - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    - https://github.com/justinsteven/advisories/blob/master/2021_github_actions_checkspelling_token_leak_via_advice_symlink.md
     technology:
     - github-actions
   patterns:
@@ -45,6 +46,7 @@ rules:
           steps:
             ...
   - pattern: |
+      ...
       uses: "$ACTION"
       with:
         ...

--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -43,8 +43,8 @@ jobs:
         # nicer to not have a "failing" CI job in the PR so don't even
         # try if we can detect is coming from a fork
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      # ok: run-shell-injection
       run: |
-        # ok: run-shell-injection
         tag=returntocorp/semgrep:${{ github.sha }}
         docker build -t "$tag" .
         docker push "$tag"
@@ -61,8 +61,8 @@ jobs:
         docker push returntocorp/semgrep-dev:develop
 
     - name: Check PR title
+      # ruleid: run-shell-injection
       run: |
-        # ruleid: run-shell-injection
         title="${{ github.event.pull_request.title }}"
         if [[ $title =~ ^octocat ]]; then
         echo "PR title starts with 'octocat'"
@@ -72,7 +72,33 @@ jobs:
         exit 1
         fi
 
-    run: |
+    - name: Show author email
+      # ruleid: run-shell-injection
+      run: |
+        echo "${{ github.event.commits.fix-bug.author.email }}"
+
+    - name: Show issue title
+      # ruleid: run-shell-injection
+      run: |
+        echo "${{ github.event.issue.title }}"
+
+    - name: benign
       # ok: run-shell-injection
-      AUTH_HEADER="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}";
-      HEADER="Accept: application/vnd.github.v3+json";
+      run: |
+        AUTH_HEADER="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}";
+        HEADER="Accept: application/vnd.github.v3+json";
+
+    # cf. https://github.com/magma/magma/blob/5caf0cb5151a9b0dce05985e6cb2cdcf70b94af5/.github/workflows/unit-test-workflow.yml
+    - name: Download and Extract Artifacts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # ok: run-shell-injection
+      run: |
+        mkdir -p artifacts && cd artifacts
+        artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+        gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+        do
+          IFS=$'\t' read name url <<< "$artifact"
+          gh api $url > "$name.zip"
+          unzip -d "$name" "$name.zip"
+        done

--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -13,6 +13,7 @@ rules:
     owasp: 'A1: Injection'
     references:
     - https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
+    - https://securitylab.github.com/research/github-actions-untrusted-input/
     technology:
     - github-actions
   patterns:
@@ -22,6 +23,26 @@ rules:
         ...
         run: ...
   - pattern: 'run: $SHELL'
-  - pattern-regex: \${{\s*github.*?\s*}}
-  - pattern-not-regex: github\..*?\.?sha
+  - metavariable-pattern:
+      language: generic
+      metavariable: $SHELL
+      patterns:
+      - pattern-either:
+        - pattern: ${{ github.event.issue.title }}
+        - pattern: ${{ github.event.issue.body }}
+        - pattern: ${{ github.event.pull_request.title }}
+        - pattern: ${{ github.event.pull_request.body }}
+        - pattern: ${{ github.event.comment.body }}
+        - pattern: ${{ github.event.review.body }}
+        - pattern: ${{ github.event.review_comment.body }}
+        - pattern: ${{ github.event.pages. ... .page_name}}
+        - pattern: ${{ github.event.head_commit.message }}
+        - pattern: ${{ github.event.head_commit.author.email }}
+        - pattern: ${{ github.event.head_commit.author.name }}
+        - pattern: ${{ github.event.commits ... .author.email }}
+        - pattern: ${{ github.event.commits ... .author.name }}
+        - pattern: ${{ github.event.pull_request.head.ref }}
+        - pattern: ${{ github.event.pull_request.head.label }}
+        - pattern: ${{ github.event.pull_request.head.repo.default_branch }}
+        - pattern: ${{ github.head_ref }}
   severity: ERROR


### PR DESCRIPTION
Uses a list of user input for run-shell-injection rule defined in https://securitylab.github.com/research/github-actions-untrusted-input/. This is to reduce false positives