### PR TITLE
Improve detection for host header injection

### DIFF
--- a/generic/nginx/security/request-host-used.conf
+++ b/generic/nginx/security/request-host-used.conf
@@ -7,3 +7,13 @@ server {
     proxy_pass http://backend;
   }
 }
+
+server {
+  listen 80;
+
+  location @app {
+    # ruleid: request-host-used
+    proxy_set_header Host $host;
+    proxy_pass http://backend;
+  }
+}

--- a/generic/nginx/security/request-host-used.yaml
+++ b/generic/nginx/security/request-host-used.yaml
@@ -15,7 +15,7 @@ rules:
   severity: WARNING
   message: >-
     '$http_host' and '$host' variables may contain a malicious value from attacker controlled 'Host' request header.
-    Use an explicitly configured host value or a whitelist for validation.
+    Use an explicitly configured host value or a allowlist for validation.
   metadata:
     references:
     - https://github.com/yandex/gixy/blob/master/docs/en/plugins/hostspoofing.md

--- a/generic/nginx/security/request-host-used.yaml
+++ b/generic/nginx/security/request-host-used.yaml
@@ -1,6 +1,8 @@
 rules:
 - id: request-host-used
-  pattern: $http_host
+  pattern-either:
+  - pattern: $http_host
+  - pattern: $host
   paths:
     include:
     - '*conf*'
@@ -12,11 +14,12 @@ rules:
   - generic
   severity: WARNING
   message: >-
-    '$http_host' uses the 'Host' request header which could be controlled by an attacker. Use the '$host'
-    variable instead, which will use server names listed in the 'server_name' directive.
+    '$http_host' and '$host' variables may contain a malicious value from attacker controlled 'Host' request header.
+    Use an explicitly configured host value or a whitelist for validation.
   metadata:
     references:
     - https://github.com/yandex/gixy/blob/master/docs/en/plugins/hostspoofing.md
+    - https://portswigger.net/web-security/host-header
     category: security
     technology:
     - nginx


### PR DESCRIPTION
Hi, I noticed that current recommendation for host header injection prevention is not correct.

> Use the '$host' variable instead, which will use server names listed in the 'server_name' directive

From [docs](http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host):

> $host
> in this order of precedence: host name from the request line, or host name from the “Host” request header field, or the server name matching a request

Request header is preferred *even* if server_name is present. Current message from the test is misleading and may result in insecure configurations while giving a false impression that value of `$host` can be trusted in backend applications.

Open issue in gixy: https://github.com/yandex/gixy/issues/93