### PR TITLE
ocaml/lang/performance/list: catch more suboptimal uses of List.length

### DIFF
--- a/ocaml/lang/best-practice/ifs.yaml
+++ b/ocaml/lang/best-practice/ifs.yaml
@@ -10,7 +10,7 @@ rules:
     - ocaml
 - id: ocamllint-backwards-if
   pattern: if $E then () else $E2
-  message: Backwards if. Rewrite the code as 'if not $E then $E2'.
+  message: Backwards if. Rewrite the code as 'if not ($E) then $E2'.
   languages: [ocaml]
   severity: WARNING
   metadata:

--- a/ocaml/lang/correctness/physical-vs-structural.yaml
+++ b/ocaml/lang/correctness/physical-vs-structural.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: physical-equal
   pattern: $X == $Y
-  message: You probably want the structural inequality operator =
+  message: You probably want the structural equality operator =
   languages: [ocaml]
   severity: WARNING
   metadata:

--- a/ocaml/lang/performance/list.ml
+++ b/ocaml/lang/performance/list.ml
@@ -1,11 +1,11 @@
 let test xs =
-  (* ruleid:ocamllint-length-list-zero *)
+  (* ruleid:ocamllint-length-list-zero,ocamllint-length-list-compare *)
   if List.length xs = 0
   then 1
   else 2
 
 let test2 xs =
-  (* ruleid:ocamllint-length-more-than-zero *)
+  (* ruleid:ocamllint-length-more-than-zero,ocamllint-length-list-compare *)
   if List.length xs > 0
   then 1
   else 2

--- a/ocaml/lang/performance/list.yaml
+++ b/ocaml/lang/performance/list.yaml
@@ -17,3 +17,48 @@ rules:
     category: performance
     technology:
     - ocaml
+- id: ocamllint-length-list-compare-length
+  pattern-either:
+  - pattern: List.length $X = List.length $Y
+  - pattern: List.length $X <= List.length $Y
+  - pattern: List.length $X >= List.length $Y
+  - pattern: List.length $X < List.length $Y
+  - pattern: List.length $X > List.length $Y
+  - pattern: List.length $X <> List.length $Y
+  message: You probably want to use List.compare_lengths $X $Y, which is faster.
+  languages: [ocaml]
+  severity: WARNING
+  metadata:
+    category: performance
+    technology:
+    - ocaml
+- id: ocamllint-length-list-compare
+  pattern-either:
+  - pattern: List.length $X = $Y
+  - pattern: List.length $X <= $Y
+  - pattern: List.length $X >= $Y
+  - pattern: List.length $X < $Y
+  - pattern: List.length $X > $Y
+  - pattern: List.length $X <> $Y
+  message: You probably want to use List.compare_length_with $X $Y, which is faster.
+  languages: [ocaml]
+  severity: WARNING
+  metadata:
+    category: performance
+    technology:
+    - ocaml
+- id: ocamllint-length-list-compare
+  pattern-either:
+  - pattern: $X = List.length $Y
+  - pattern: $X <= List.length $Y
+  - pattern: $X >= List.length $Y
+  - pattern: $X < List.length $Y
+  - pattern: $X > List.length $Y
+  - pattern: $X <> List.length $Y
+  message: You probably want to use List.compare_length_with $X $Y, which is faster.
+  languages: [ocaml]
+  severity: WARNING
+  metadata:
+    category: performance
+    technology:
+    - ocaml

--- a/ocaml/lang/performance/list.yaml
+++ b/ocaml/lang/performance/list.yaml
@@ -19,6 +19,7 @@ rules:
     - ocaml
 - id: ocamllint-length-list-compare-length
   pattern-either:
+  - pattern: compare (List.length $X) (List.length $Y)
   - pattern: List.length $X = List.length $Y
   - pattern: List.length $X <= List.length $Y
   - pattern: List.length $X >= List.length $Y
@@ -34,6 +35,7 @@ rules:
     - ocaml
 - id: ocamllint-length-list-compare
   pattern-either:
+  - pattern: compare (List.length $X) $Y
   - pattern: List.length $X = $Y
   - pattern: List.length $X <= $Y
   - pattern: List.length $X >= $Y
@@ -49,6 +51,7 @@ rules:
     - ocaml
 - id: ocamllint-length-list-compare
   pattern-either:
+  - pattern: compare $Y (List.length $X)
   - pattern: $X = List.length $Y
   - pattern: $X <= List.length $Y
   - pattern: $X >= List.length $Y


### PR DESCRIPTION
This PR adds some patterns to the `list.yaml` file. Specifically, it catches patterns that compare lengths with a constant or to each others.

Note that the suggestions the tool makes are only valid for OCaml versions >= 4.05.0 which I think is a reasonable bound.

It's the first PR I open, let me know if I need to do something else than just these changes.