### PR TITLE
Disable GH Actions workflow rule-benchmarks on forks

### DIFF
--- a/.github/workflows/rule-benchmarks.yaml
+++ b/.github/workflows/rule-benchmarks.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   run_benchmarks:
     runs-on: ubuntu-latest
+    if: github.repository == 'returntocorp/semgrep-rules'
     name: Run benchmarks for each rule
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The run_benchmarks job runs for ~5 hours due to a python crash, disabling it on forks to avoid noise.