### PR TITLE
add monaco-hover-htmlsupport

### DIFF
--- a/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.js
+++ b/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.js
@@ -1,0 +1,51 @@
+import { editor, languages, Range } from "monaco-editor";
+
+function test1 (userInput) {
+  languages.registerHoverProvider('mySpecialLanguage', {
+    provideHover: function (model) {
+      return {
+        range: new Range(1, 1, model.getLineCount(), model.getLineMaxColumn(model.getLineCount())),
+        contents: [
+          // ruleid:monaco-hover-htmlsupport
+          {
+            value: `<a href="${userInput}">Hello</a>`,
+            supportHtml: true,
+            isTrusted: true
+          },
+        ]
+      }
+    }
+  });
+}
+
+function okTest1 () {
+  languages.registerHoverProvider('mySpecialLanguage', {
+    provideHover: function (model) {
+      return {
+        range: new Range(1, 1, model.getLineCount(), model.getLineMaxColumn(model.getLineCount())),
+        contents: [
+          {
+            value: `<a href="//google.com">Hello</a>`,
+            supportHtml: true,
+            isTrusted: true
+          },
+        ]
+      }
+    }
+  });
+}
+
+function okTest2 (userInput) {
+  languages.registerHoverProvider('mySpecialLanguage', {
+    provideHover: function (model) {
+      return {
+        range: new Range(1, 1, model.getLineCount(), model.getLineMaxColumn(model.getLineCount())),
+        contents: [
+          {
+            value: `** Hello ${userInput}`,
+          },
+        ]
+      }
+    }
+  });
+}

--- a/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.yaml
+++ b/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.yaml
@@ -21,7 +21,7 @@ rules:
     cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     owasp: 'A7: Cross-Site Scripting (XSS)'
     references:
-    - https://medium.com/dailyjs/exploiting-script-injection-flaws-in-reactjs-883fb1fe36c1
+    - https://github.com/microsoft/monaco-editor/issues/801
     category: security
     technology:
     - monaco

--- a/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.yaml
+++ b/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.yaml
@@ -1,0 +1,33 @@
+rules:
+- id: monaco-hover-htmlsupport
+  patterns:
+  - pattern-either:
+    - pattern-inside: |
+        import "monaco-editor"
+        ...
+    - pattern-inside: |
+        require("monaco-editor")
+        ...
+  - pattern-either:
+    - pattern: |
+        {value: $VAL, supportHtml: true}
+    - pattern: |
+        {value: $VAL, isTrusted: true}
+  - pattern-inside: |
+      {range: $R, contents: [...]}
+  - pattern-not: |
+      {..., value: "...", ...}
+  metadata:
+    cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp: 'A7: Cross-Site Scripting (XSS)'
+    references:
+    - https://medium.com/dailyjs/exploiting-script-injection-flaws-in-reactjs-883fb1fe36c1
+    category: security
+    technology:
+    - monaco
+    - monaco-editor
+  message: >-
+    If user input reaches `HoverProvider` while `supportHml` is set to `true` it may introduce an XSS vulnerability.
+    Do not produce HTML for hovers with dynamically generated input.
+  languages: [typescript, javascript]
+  severity: WARNING


### PR DESCRIPTION
this is a specific rule for preventing user controlled HTML output for hover messages in `monaco-editor`