### PR TITLE
Filter go mod

### DIFF
--- a/generic/secrets/security/detected-telegram-bot-api-key.php
+++ b/generic/secrets/security/detected-telegram-bot-api-key.php
@@ -4,4 +4,7 @@
 define('BOT_TOKEN', '12345678:AA101703Wd8JLT6GCtKzxatRHQREQUk_CpK');
 define('API_URL', 'https://api.telegram.org/bot'.BOT_TOKEN.'/');
 
+// ok: detected-telegram-bot-api-key
+define('GO.MOD', 'github.com/gorilla/mux v1.7.4/go.mod 11:AAbg23sWSpFRCP0SfiEN6jmj59UnWan46BH5rLB7');
+
 ?>

--- a/generic/secrets/security/detected-telegram-bot-api-key.yaml
+++ b/generic/secrets/security/detected-telegram-bot-api-key.yaml
@@ -1,7 +1,10 @@
 rules:
 - id: detected-telegram-bot-api-key
-  pattern-regex: '[0-9]+:AA[0-9A-Za-z\-_]{33}'
-  languages: [regex]
+  patterns:
+  - pattern-regex: '[0-9]+:AA[0-9A-Za-z\-_]{33}'
+  - pattern-not-regex: go\.mod.*
+  languages:
+  - regex
   message: Telegram Bot API Key detected
   severity: ERROR
   metadata:
@@ -10,3 +13,4 @@ rules:
     technology:
     - secrets
     - telegram
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep-rules/issues/1526.

In rare cases, a line in a `go.sum` file will match the format of a telegram API key. Filter out go.mod specifically.