### PR TITLE
update useless-innerfunction rule

### DIFF
--- a/python/lang/maintainability/useless-innerfunction.py
+++ b/python/lang/maintainability/useless-innerfunction.py
@@ -21,6 +21,11 @@ def A():
     def C():
         print_error('another')
 
+    # ok:useless-inner-function
+    @something
+    def D():
+        print_error('with decorator')
+
     return B(), C()
 
 def foo():
@@ -44,7 +49,6 @@ def create_decorating_metaclass(decorators, prefix='test_'):
     return DecoratingMethodsMetaclass
 
 def dec(f):
-    @functools.wraps(f)
     # ok:useless-inner-function
     def inner(*args, **kwargs):
         return f(*args, **kwargs)

--- a/python/lang/maintainability/useless-innerfunction.yaml
+++ b/python/lang/maintainability/useless-innerfunction.yaml
@@ -19,15 +19,19 @@ rules:
         def $FF(...):
            ...
         ...
-  # We want to report where the inner function is defined, so
-  # we add a "pattern" match for the inner function only
   - pattern: |
       def $FF(...):
         ...
+  - pattern-not: |
+      @$DECORATOR
+      def $FF(...):
+        ...
   message: function `$FF` is defined inside a function but never used
-  languages: [python]
+  languages:
+  - python
   severity: ERROR
   metadata:
     category: maintainability
     technology:
     - python
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]


### PR DESCRIPTION
Closes https://github.com/returntocorp/semgrep-rules/issues/563
I believe it is safe to assume that if a function has a decorator we can skip it because there is a high chance of FP