### PR TITLE
Rule for md5 used as a password hashing algorithm in Java

### DIFF
--- a/java/lang/security/audit/md5-used-as-password.java
+++ b/java/lang/security/audit/md5-used-as-password.java
@@ -1,0 +1,68 @@
+package website.controller;
+
+import website.RandomUtil;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import org.hibernate.service.spi.ServiceException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import java.security.MessageDigest;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/user")
+public class UserController extends BaseController {
+
+    private final UserService service;
+
+    @Autowired
+    public UserController(UserService service) {
+        this.service = service;
+    }
+
+    @RequestMapping(value = "addUser", method = RequestMethod.POST)
+    public Result addUser(@RequestBody UserModel user) {
+        UserModel userModel = service.findUserByEmail(user.getEmail());
+        if (userModel != null) {
+            return new Result<>(CodeConst.USER_REPEAT.getResultCode(), CodeConst.USER_REPEAT.getMessage());
+        }
+
+        String salt = RandomUtil.createSalt();
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        md.update(user.getPassword());
+
+        // ruleid: md5-used-as-password
+        user.setPassword(md.digest(), salt);
+
+        user.setValidateCode(Md5Util.encode(user.getEmail(), ""));
+        user.setSalt(salt);
+        service.addUser(user);
+        return new Result<>(user);
+    }
+
+    @RequestMapping(value = "addUserOk", method = RequestMethod.POST)
+    public Result addUserOk(@RequestBody UserModel user) {
+        UserModel userModel = service.findUserByEmail(user.getEmail());
+        if (userModel != null) {
+            return new Result<>(CodeConst.USER_REPEAT.getResultCode(), CodeConst.USER_REPEAT.getMessage());
+        }
+
+        String salt = RandomUtil.createSalt();
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        md.update(user.getPassword());
+
+        // ok: md5-used-as-password
+        user.setPassword(md.digest(), salt);
+
+        user.setValidateCode(Md5Util.encode(user.getEmail(), ""));
+        user.setSalt(salt);
+        service.addUser(user);
+        return new Result<>(user);
+    }
+}

--- a/java/lang/security/audit/md5-used-as-password.yaml
+++ b/java/lang/security/audit/md5-used-as-password.yaml
@@ -1,0 +1,33 @@
+rules:
+- id: md5-used-as-password
+  languages: [java]
+  severity: WARNING
+  message: >-
+    It looks like MD5 is used as a password hash. MD5 is not considered a
+    secure password hash because it can be cracked by an attacker in a short
+    amount of time. Use SHA-256 for password hashes
+    (`MessageDigest.getInstance("SHA-256")`) instead.
+  metadata:
+    category: security
+    technology:
+    - java
+    - md5
+    references:
+    - https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html
+    owasp:
+    - A02:2017 - Broken Authentication
+    - A02:2021 - Cryptographic Failures
+    cwe: 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-inside: |
+        $TYPE $MD = MessageDigest.getInstance("MD5");
+        ...
+    - pattern: $MD.digest(...);
+  pattern-sinks:
+  - patterns:
+    - pattern: $MODEL.$METHOD(...);
+    - metavariable-regex:
+        metavariable: $METHOD
+        regex: (?i)(.*password.*)


### PR DESCRIPTION
This is an idea I had while scanning a bunch of open source code.
This rule checks if MD5 reaches a method with `password` in the name, giving it a higher indication that it is used as a password hash.

This is a little more precise than the usual "flag every md5 occurrence".

Preliminary scans of OSS show no findings, so I theorize it will not produce a ton of noise.