### PR TITLE
Add rule to detect Kolide API keys

### DIFF
--- a/generic/secrets/security/detected-kolide-api-key.txt
+++ b/generic/secrets/security/detected-kolide-api-key.txt
@@ -1,0 +1,2 @@
+# ruleid: detected-kolide-api-key
+k2sk_v1_K2UYhW7OPt2jKKLqmFacGNK7

--- a/generic/secrets/security/detected-kolide-api-key.yaml
+++ b/generic/secrets/security/detected-kolide-api-key.yaml
@@ -1,0 +1,11 @@
+rules:
+- id: detected-kolide-api-key
+  pattern-regex: 'k2sk_v[0-9]_[0-9a-zA-Z]{24}'
+  languages: [regex]
+  message: Kolide API Key detected
+  severity: ERROR
+  metadata:
+    category: security
+    technology:
+    - secrets
+    - kolide


### PR DESCRIPTION
This commit:
 - adds a rule to detect [Kolide](https://k2.kolide.com) api keys, as
 documented at https://kolidek2.readme.io/docs/kolide-api-token-format