### PR TITLE
Update test expectations after returntocorp/semgrep#4173

### DIFF
--- a/python/django/security/injection/tainted-sql-string.py
+++ b/python/django/security/injection/tainted-sql-string.py
@@ -44,7 +44,7 @@ def get_user_age5(request):
 
 def get_user_age6(request):
   query = "SELECT user_age FROM myapp_person where user_name = {}"
-  # todoruleid: tainted-sql-string
+  # ruleid: tainted-sql-string
   user_age = Person.objects.raw(query.format(request.GET.get('user_name')))
   html = "<html><body>User Age %s.</body></html>" % user_age
   return HttpResponse(html)

--- a/python/django/security/injection/tainted-url-host.py
+++ b/python/django/security/injection/tainted-url-host.py
@@ -62,8 +62,8 @@ def ex7(request):
 def ex8(request):
   env = request.POST.get('env')
   user_name = request.POST.get('user_name')
-  # todoruleid: tainted-url-host
   url = "https://{}/{}/age"
+  # ruleid: tainted-url-host
   user_age = requests.get(url.format(env, user_name))
   return HttpResponse(user_age)
 


### PR DESCRIPTION
These "todoruleid"s can now become "ruleid"s after
returntocorp/semgrep/pull/4173 fixes #PA-588.