### PR TITLE
[Kotlin] remove semicolon to fix parse error

### DIFF
--- a/kotlin/lang/security/use-of-md5.kt
+++ b/kotlin/lang/security/use-of-md5.kt
@@ -15,7 +15,7 @@ public class WeakHashes {
   public fun md5(password: String): ByteArray {
     // ruleid: use-of-md5
     val md5Digest: MessageDigest = MessageDigest.getInstance("MD5")
-    md5Digest.update(password.getBytes());
+    md5Digest.update(password.getBytes())
     val hashValue: ByteArray = md5Digest.digest()
     return hashValue
   }


### PR DESCRIPTION
This prevents https://github.com/returntocorp/semgrep/pull/4174 to
pass

test plan:
make test