### PR TITLE
Remove dead website reference

### DIFF
--- a/typescript/react/security/react-controlled-component-password.yaml
+++ b/typescript/react/security/react-controlled-component-password.yaml
@@ -11,8 +11,6 @@ rules:
   message: >-
     Password can be leaked if CSS injection exists on the page.
   metadata:
-    references:
-    - https://no-csp-css-keylogger.badsite.io/
     category: security
     technology:
     - react


### PR DESCRIPTION
The website referenced in this rule is no longer available and redirects to a parking site of GoDaddy.