### PR TITLE
New Rule - contains-bidirectional-characters

### DIFF
--- a/generic/unicode/security/bidi.py
+++ b/generic/unicode/security/bidi.py
@@ -4,10 +4,10 @@ from types import SimpleNamespace
 # A useful lookup table for the bidirectional (bidi) characters
 bidi = SimpleNamespace(
     **{
-        "LRE": "\u202A",  # left-to-right embedding (LRE)
-        "RLE": "\u202B",  # right-to-left embedding (RLE)
-        "LRO": "\u202D",  # left-to-right override (LRO)
-        "RLO": "\u202E",  # right-to-left override (RLO)
+        "LRE": "\u202a",  # left-to-right embedding (LRE)
+        "RLE": "\u202b",  # right-to-left embedding (RLE)
+        "LRO": "\u202d",  # left-to-right override (LRO)
+        "RLO": "\u202e",  # right-to-left override (RLO)
         "LRI": "\u2066",  # left-to-right isolate (LRI)
         "RLI": "\u2067",  # right-to-left isolate (RLI)
         "FSI": "\u2068",  # first strong isolate (FSI)

--- a/generic/unicode/security/bidi.py
+++ b/generic/unicode/security/bidi.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+# A useful lookup table for the bidirectional (bidi) characters
+bidi = SimpleNamespace(
+    **{
+        "LRE": "\u202A",  # left-to-right embedding (LRE)
+        "RLE": "\u202B",  # right-to-left embedding (RLE)
+        "LRO": "\u202D",  # left-to-right override (LRO)
+        "RLO": "\u202E",  # right-to-left override (RLO)
+        "LRI": "\u2066",  # left-to-right isolate (LRI)
+        "RLI": "\u2067",  # right-to-left isolate (RLI)
+        "FSI": "\u2068",  # first strong isolate (FSI)
+        "PDF": "\u202c",  # pop directional formatting (PDF)
+        "PDI": "\u2069",  # pop directional isolate (PDI)
+    }
+)
+
+# Currently all bidi characters are forbidden
+FORBIDDEN_BIDI_CHARACTERS = list(vars(bidi).values())
+
+
+def test_forbidden_bidi_characters():
+    # type: () -> None
+    assert has_bidi("hello world") is False
+
+    # Proper unicode display of this string should be: d e f a b c
+    assert (
+        has_bidi(
+            "{}{}a b c{} {}d e f{}{}".format(
+                bidi.RLI, bidi.LRI, bidi.PDI, bidi.LRI, bidi.PDI, bidi.PDI
+            )
+        )
+        is True
+    )
+
+    # The same string as above but with the unicode bidi characters instead of a
+    # mapping to them
+
+    # If this shows up as "d e f a b c" in your code review without being blocked
+    # or flagged, then it indicates that you may be vulnerable to trojan.codes.
+    # ruleid: contains-bidirectional-characters
+    assert has_bidi("⁧⁦a b c⁩ ⁦d e f⁩⁩") is True
+
+
+def has_bidi(testable_string):
+    # type: (str) -> bool
+    return any(char in testable_string for char in FORBIDDEN_BIDI_CHARACTERS)

--- a/generic/unicode/security/bidi.yml
+++ b/generic/unicode/security/bidi.yml
@@ -17,7 +17,6 @@ rules:
       of right-to-left languages such as Arabic or Hebrew, it can also be used to trick
       language parsers into executing code in a manner that is different from how it is
       displayed in code editing and review tools.
-
       If this is not what you were expecting, please review this code in an editor that
       can reveal hidden Unicode characters.
     metadata:

--- a/generic/unicode/security/bidi.yml
+++ b/generic/unicode/security/bidi.yml
@@ -1,0 +1,42 @@
+# note: this runs about 30-300% faster with pattern-regex vs pattern
+rules:
+  - id: contains-bidirectional-characters
+    patterns:
+      - pattern-either:
+        - pattern-regex: "\u202A"  # left-to-right embedding (LRE)
+        - pattern-regex: "\u202B"  # right-to-left embedding (RLE)
+        - pattern-regex: "\u202D"  # left-to-right override (LRO)
+        - pattern-regex: "\u202E"  # right-to-left override (RLO)
+        - pattern-regex: "\u2066"  # left-to-right isolate (LRI)
+        - pattern-regex: "\u2067"  # right-to-left isolate (RLI)
+        - pattern-regex: "\u2068"  # first strong isolate (FSI)
+        - pattern-regex: "\u202c"  # pop directional formatting (PDF)
+        - pattern-regex: "\u2069"  # pop directional isolate (PDI)
+    message: >
+      This code contains bidirectional (bidi) characters. While this is useful for support
+      of right-to-left languages such as Arabic or Hebrew, it can also be used to trick
+      language parsers into executing code in a manner that is different from how it is
+      displayed in code editing and review tools.
+
+      If this is not what you were expecting, please review this code in an editor that
+      can reveal hidden Unicode characters.
+    languages:
+      - bash
+      - c
+      - csharp
+      - go
+      - java
+      - javascript
+      - json
+      - kotlin
+      - lua
+      - ocaml
+      - php
+      - python
+      - ruby
+      - rust
+      - scala
+      - sh
+      - typescript
+      - yaml
+    severity: WARNING

--- a/generic/unicode/security/bidi.yml
+++ b/generic/unicode/security/bidi.yml
@@ -3,10 +3,10 @@ rules:
   - id: contains-bidirectional-characters
     patterns:
       - pattern-either:
-        - pattern-regex: "\u202A"  # left-to-right embedding (LRE)
-        - pattern-regex: "\u202B"  # right-to-left embedding (RLE)
-        - pattern-regex: "\u202D"  # left-to-right override (LRO)
-        - pattern-regex: "\u202E"  # right-to-left override (RLO)
+        - pattern-regex: "\u202a"  # left-to-right embedding (LRE)
+        - pattern-regex: "\u202b"  # right-to-left embedding (RLE)
+        - pattern-regex: "\u202d"  # left-to-right override (LRO)
+        - pattern-regex: "\u202e"  # right-to-left override (RLO)
         - pattern-regex: "\u2066"  # left-to-right isolate (LRI)
         - pattern-regex: "\u2067"  # right-to-left isolate (RLI)
         - pattern-regex: "\u2068"  # first strong isolate (FSI)

--- a/generic/unicode/security/bidi.yml
+++ b/generic/unicode/security/bidi.yml
@@ -12,7 +12,7 @@ rules:
         - pattern-regex: "\u2068"  # first strong isolate (FSI)
         - pattern-regex: "\u202c"  # pop directional formatting (PDF)
         - pattern-regex: "\u2069"  # pop directional isolate (PDI)
-    message: >
+    message: >-
       This code contains bidirectional (bidi) characters. While this is useful for support
       of right-to-left languages such as Arabic or Hebrew, it can also be used to trick
       language parsers into executing code in a manner that is different from how it is
@@ -20,6 +20,12 @@ rules:
 
       If this is not what you were expecting, please review this code in an editor that
       can reveal hidden Unicode characters.
+    metadata:
+      category: security
+      technology:
+      - unicode
+      references:
+      - https://trojansource.codes/
     languages:
       - bash
       - c


### PR DESCRIPTION
This semgrep rule effectively tests for the [trojansource.codes](https://trojansource.codes/) vulnerability, by essentially doing the same thing that Github is doing: looking for bidirectional characters in code.

This is an unusual rule - it wants to scan across all code but NOT any binary files (like movies and images), so it can't use "generic". There's also no option to have "all" as a language instead. So it currently lists every language, and that can be revisited over time.

One significant downside of this rule is that the time it takes semgrep to process a large number of files seems to scale linearly with the number of languages listed, not the number of files scanned. Two languages takes about as long as one. Four languages takes twice as long as two, and so on.

On my local system (i9 MBP):

• Only `yaml`: 14279 files, 0 findings, 12.40s
• All the languages listed, same directory: 17425 files, 125.34s

About 20% more files had rules run against them, but it took about 10x as long to do so.