### PR TITLE
ocaml: Do not warn about Hashtbl.find inside match-with

### DIFF
--- a/ocaml/lang/best-practice/hashtbl.ml
+++ b/ocaml/lang/best-practice/hashtbl.ml
@@ -11,3 +11,10 @@ let test2 xs =
    then 1
    else 2
  with Not_found -> 3
+
+let test3 xs =
+ (* ok *)
+ match Hashtbl.find h 1 with
+ | true -> 1
+ | false -> 2
+ | exception Not_found -> 3

--- a/ocaml/lang/best-practice/hashtbl.yaml
+++ b/ocaml/lang/best-practice/hashtbl.yaml
@@ -5,6 +5,14 @@ rules:
       Hashtbl.find ...
   - pattern-not-inside: |
       try ... with ... -> ...
+  # TODO:
+  # We should restrict this to match-with plus exception pattern:
+  #
+  #     match ... with | exception ... -> ... | ... -> ...
+  #
+  # But first we need to switch to tree-sitter-ocaml for parsing patterns.
+  - pattern-not-inside: |
+      match ... with | ... -> ...
   message: You should not use Hashtbl.find outside of a try, or you should use Hashtbl.find_opt
   languages: [ocaml]
   severity: WARNING


### PR DESCRIPTION
Note that it is also possible to catch a exception within a match-with
using exception patterns.

As far as I can tell, at this point it is not possible to write a
pattern like:

    match ... with | exception ... -> ... | ... -> ...

So I just overapproximated and silenced all warnings for any match-with.

Closes #1505

test plan:
make test # test updated