### PR TITLE
Update md5-used-as-password messages to recommend proper password hashing functions.

### DIFF
--- a/go/lang/security/audit/md5-used-as-password.yaml
+++ b/go/lang/security/audit/md5-used-as-password.yaml
@@ -5,8 +5,8 @@ rules:
   message: >-
     It looks like MD5 is used as a password hash. MD5 is not considered a
     secure password hash because it can be cracked by an attacker in a short
-    amount of time. Use SHA-256 for password hashes
-    (`crypto/sha256`) instead.
+    amount of time. Use a suitable password hashing function such as bcrypt.
+    You can use the `golang.org/x/crypto/bcrypt` package.
   metadata:
     category: security
     technology:
@@ -14,6 +14,8 @@ rules:
     references:
     - https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html
     - https://security.stackexchange.com/questions/211/how-to-securely-hash-passwords
+    - https://github.com/returntocorp/semgrep-rules/issues/1609
+    - https://pkg.go.dev/golang.org/x/crypto/bcrypt
     owasp:
     - A02:2017 - Broken Authentication
     - A02:2021 - Cryptographic Failures

--- a/java/lang/security/audit/md5-used-as-password.yaml
+++ b/java/lang/security/audit/md5-used-as-password.yaml
@@ -5,8 +5,9 @@ rules:
   message: >-
     It looks like MD5 is used as a password hash. MD5 is not considered a
     secure password hash because it can be cracked by an attacker in a short
-    amount of time. Use SHA-256 for password hashes
-    (`MessageDigest.getInstance("SHA-256")`) instead.
+    amount of time. Use a suitable password hashing function such as PBKDF2 or bcrypt.
+    You can use `javax.crypto.SecretKeyFactory` with `SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1")`
+    or, if using Spring, `org.springframework.security.crypto.bcrypt`.
   metadata:
     category: security
     technology:
@@ -14,6 +15,9 @@ rules:
     - md5
     references:
     - https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html
+    - https://github.com/returntocorp/semgrep-rules/issues/1609
+    - https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SecretKeyFactory
+    - https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/crypto/bcrypt/BCryptPasswordEncoder.html
     owasp:
     - A02:2017 - Broken Authentication
     - A02:2021 - Cryptographic Failures

--- a/javascript/lang/security/audit/md5-used-as-password.yaml
+++ b/javascript/lang/security/audit/md5-used-as-password.yaml
@@ -5,8 +5,8 @@ rules:
   message: >-
     It looks like MD5 is used as a password hash. MD5 is not considered a
     secure password hash because it can be cracked by an attacker in a short
-    amount of time. Use SHA-256 for password hashes
-    (`crypto.createHash('sha256')`) instead.
+    amount of time. Use a suitable password hashing function such as bcrypt.
+    You can use the `bcrypt` node.js package.
   metadata:
     category: security
     technology:
@@ -15,6 +15,8 @@ rules:
     references:
     - https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html
     - https://security.stackexchange.com/questions/211/how-to-securely-hash-passwords
+    - https://github.com/returntocorp/semgrep-rules/issues/1609
+    - https://www.npmjs.com/package/bcrypt
     owasp:
     - A02:2017 - Broken Authentication
     - A02:2021 - Cryptographic Failures

--- a/php/lang/security/md5-used-as-password.yaml
+++ b/php/lang/security/md5-used-as-password.yaml
@@ -4,7 +4,8 @@ rules:
   message: >-
     It looks like MD5 is used as a password hash. MD5 is not considered a
     secure password hash because it can be cracked by an attacker in a short
-    amount of time. Use SHA-256 or higher for password hashes (for example: `hash('sha256', ...)`)
+    amount of time. Use a suitable password hashing function such as bcrypt.
+    You can use `password_hash($PASSWORD, PASSWORD_BCRYPT, $OPTIONS);`.
   languages: [php]
   metadata:
     cwe: 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
@@ -15,6 +16,8 @@ rules:
     - https://tools.ietf.org/html/rfc6151
     - https://crypto.stackexchange.com/questions/44151/how-does-the-flame-malware-take-advantage-of-md5-collision
     - https://security.stackexchange.com/questions/211/how-to-securely-hash-passwords
+    - https://github.com/returntocorp/semgrep-rules/issues/1609
+    - https://www.php.net/password_hash
     category: security
     technology:
     - md5

--- a/python/lang/security/audit/md5-used-as-password.yaml
+++ b/python/lang/security/audit/md5-used-as-password.yaml
@@ -4,7 +4,8 @@ rules:
   message: >-
     It looks like MD5 is used as a password hash. MD5 is not considered a
     secure password hash because it can be cracked by an attacker in a short
-    amount of time. Use SHA-256 or higher for password hashes (for example: `hashlib.sha256(...)`)
+    amount of time. Use a suitable password hashing function such as scrypt.
+    You can use `hashlib.script`.
   languages: [python]
   metadata:
     cwe: 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
@@ -16,6 +17,8 @@ rules:
     - https://crypto.stackexchange.com/questions/44151/how-does-the-flame-malware-take-advantage-of-md5-collision
     - https://pycryptodome.readthedocs.io/en/latest/src/hash/sha3_256.html
     - https://security.stackexchange.com/questions/211/how-to-securely-hash-passwords
+    - https://github.com/returntocorp/semgrep-rules/issues/1609
+    - https://docs.python.org/3/library/hashlib.html#hashlib.scrypt
     category: security
     technology:
     - pycryptodome

--- a/ruby/lang/security/md5-used-as-password.yaml
+++ b/ruby/lang/security/md5-used-as-password.yaml
@@ -5,8 +5,8 @@ rules:
   message: >-
     It looks like MD5 is used as a password hash. MD5 is not considered a
     secure password hash because it can be cracked by an attacker in a short
-    amount of time. Use SHA-256 for password hashes
-    (`Digest::SHA256`) instead.
+    amount of time. Instead, use a suitable password hashing function such as
+    bcrypt. You can use the `bcrypt` gem.
   metadata:
     category: security
     technology:
@@ -14,6 +14,7 @@ rules:
     references:
     - https://tools.ietf.org/id/draft-lvelvindron-tls-md5-sha1-deprecate-01.html
     - https://security.stackexchange.com/questions/211/how-to-securely-hash-passwords
+    - https://github.com/returntocorp/semgrep-rules/issues/1609
     owasp:
     - A02:2017 - Broken Authentication
     - A02:2021 - Cryptographic Failures


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep-rules/issues/1609