### PR TITLE
Fix ci

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,5 +1,2 @@
 yaml/semgrep/*.test.yaml
-contrib/nodejsscan/
-contrib/owasp/
-contrib/react/
 template.yaml

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,2 +1,1 @@
-yaml/semgrep/*.test.yaml
 template.yaml


### PR DESCRIPTION
This PR removes the `yaml/` files and the `contrib/` files from `.semgrepignore`, which actually works now!!!! 

This results in semgrep NOT ignoring the `yaml/` and `contrib/` files, and therefore actually running and producing results we can then compare with expected results. 