### PR TITLE
added support for logging error without handling

### DIFF
--- a/python/lang/best-practice/logging-error-without-handling.py
+++ b/python/lang/best-practice/logging-error-without-handling.py
@@ -1,0 +1,105 @@
+# logger.error
+try:
+  pass
+except:
+  pass
+  # ruleid:logging-error-without-handling
+  logger.error("")
+  raise
+
+try:
+  pass
+except Exception as e:
+  # ruleid:logging-error-without-handling
+  logger.error("")
+  raise e
+
+try:
+  pass
+except ValueError as e:
+  # ruleid:logging-error-without-handling
+  logger.error("")
+  raise e
+except Exception:
+  pass
+
+try:
+  pass
+except Exception:
+  pass
+except ValueError as e:
+  # ruleid:logging-error-without-handling
+  logger.error("")
+  raise e
+
+try:
+  pass
+except Exception:
+  # ruleid:logging-error-without-handling
+  logger.error("")
+  raise
+
+try:
+  pass
+except Exception as e:
+  # ruleid:logging-error-without-handling
+  logger.error("")
+  raise ValueError() from e
+
+
+# logger.exception
+
+try:
+  pass
+except:
+  pass
+  # ruleid:logging-error-without-handling
+  logger.exception("")
+  raise
+
+try:
+  pass
+except Exception as e:
+  # ruleid:logging-error-without-handling
+  logger.exception("")
+  raise e
+
+try:
+  pass
+except ValueError as e:
+  # ruleid:logging-error-without-handling
+  logger.exception("")
+  raise e
+except Exception:
+  pass
+
+try:
+  pass
+except Exception:
+  pass
+except ValueError as e:
+  # ruleid:logging-error-without-handling
+  logger.exception("")
+  raise e
+
+try:
+  pass
+except Exception:
+  # ruleid:logging-error-without-handling
+  logger.exception("")
+  raise
+
+try:
+  pass
+except Exception as e:
+  # ruleid:logging-error-without-handling
+  logger.exception("")
+  raise ValueError() from e
+
+# Make sure we don't match info/warning
+try:
+  pass
+except Exception as e:
+  logger.info("")
+  logger.warning("")
+  raise ValueError() from e

--- a/python/lang/best-practice/logging-error-without-handling.yaml
+++ b/python/lang/best-practice/logging-error-without-handling.yaml
@@ -1,0 +1,29 @@
+rules:
+  - id: logging-error-without-handling
+    patterns:
+      - pattern-inside: |
+          try:
+            ...
+          except ...:
+            ...
+          ...
+      - pattern-either:
+          - pattern: |
+              logger.$FUNC(...)
+              ...
+              raise
+          - pattern: |
+              logger.$FUNC(...)
+              ...
+              raise $EX
+          - pattern: |
+              logger.$FUNC(...)
+              ...
+              raise $EX from $EX2
+      - metavariable-regex:
+          metavariable: $FUNC
+          regex: (error|exception)
+    message: Errors should only be logged when handled. The code logs the error and propogates the exception, consider reducing the level to warning or info.
+    languages:
+      - python
+    severity: WARNING

--- a/python/lang/best-practice/logging-error-without-handling.yaml
+++ b/python/lang/best-practice/logging-error-without-handling.yaml
@@ -1,29 +1,33 @@
 rules:
-  - id: logging-error-without-handling
-    patterns:
-      - pattern-inside: |
-          try:
-            ...
-          except ...:
-            ...
+- id: logging-error-without-handling
+  patterns:
+    - pattern-inside: |
+        try:
           ...
-      - pattern-either:
-          - pattern: |
-              logger.$FUNC(...)
-              ...
-              raise
-          - pattern: |
-              logger.$FUNC(...)
-              ...
-              raise $EX
-          - pattern: |
-              logger.$FUNC(...)
-              ...
-              raise $EX from $EX2
-      - metavariable-regex:
-          metavariable: $FUNC
-          regex: (error|exception)
-    message: Errors should only be logged when handled. The code logs the error and propogates the exception, consider reducing the level to warning or info.
-    languages:
-      - python
-    severity: WARNING
+        except ...:
+          ...
+        ...
+    - pattern-either:
+        - pattern: |
+            logger.$FUNC(...)
+            ...
+            raise
+        - pattern: |
+            logger.$FUNC(...)
+            ...
+            raise $EX
+        - pattern: |
+            logger.$FUNC(...)
+            ...
+            raise $EX from $EX2
+    - metavariable-regex:
+        metavariable: $FUNC
+        regex: (error|exception)
+  message: Errors should only be logged when handled. The code logs the error and propogates the exception, consider reducing the level to warning or info.
+  languages:
+    - python
+  severity: WARNING
+  metadata:
+    category: best-practice
+    technology:
+    - python


### PR DESCRIPTION
Following the thread in [slack](https://r2c-community.slack.com/archives/C018NJRRCJ0/p1638992547208200?thread_ts=1638944288.203100&cid=C018NJRRCJ0), I opened a PR for this rule.
It matches instances where an error is logged as an error/exception but not handled.