### PR TITLE
Java log4j security: Added Lookup injection rule.

### DIFF
--- a/java/log4j/security/log4j-message-lookup-injection.java
+++ b/java/log4j/security/log4j-message-lookup-injection.java
@@ -9,7 +9,7 @@ public class VulnerableLog4jExampleHandler implements HttpHandler {
 
   public void handle(HttpExchange he) throws IOException {
     string userAgent = he.getRequestHeader("user-agent");
-
+    // ruleid: log4j-message-lookup-injection
     log.info("Request User Agent:" + userAgent);
 
   }

--- a/java/log4j/security/log4j-message-lookup-injection.java
+++ b/java/log4j/security/log4j-message-lookup-injection.java
@@ -1,0 +1,16 @@
+import org.apache.log4j.Logger;
+
+import java.io.*;
+import java.util.*;
+
+public class VulnerableLog4jExampleHandler implements HttpHandler {
+
+  static Logger log = Logger.getLogger(log4jExample.class.getName());
+
+  public void handle(HttpExchange he) throws IOException {
+    string userAgent = he.getRequestHeader("user-agent");
+
+    log.info("Request User Agent:" + userAgent);
+
+  }
+}

--- a/java/log4j/security/log4j-message-lookup-injection.yaml
+++ b/java/log4j/security/log4j-message-lookup-injection.yaml
@@ -1,0 +1,187 @@
+rules:
+- id: log4j-message-lookup-injection
+  metadata:
+    cwe: "CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')"
+    owasp: 'A1: Injection'
+    source-rule-url: https://www.lunasec.io/docs/blog/log4j-zero-day/
+    references:
+    - https://issues.apache.org/jira/browse/LOG4J2-3198
+    - https://www.lunasec.io/docs/blog/log4j-zero-day/
+    - https://logging.apache.org/log4j/2.x/manual/lookups.html
+    category: security
+    technology:
+    - java
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+  message: Possible Lookup injection into Log4j messages. Lookups provide a way to add values to the Log4j messages at arbitrary
+    places. If the message parameter contains an attacker controlled string, the attacker could inject arbitrary lookups,
+    for instance '${java:runtime}'. This cloud lead to information disclosure or even remove code execution if 'log4j2.formatMsgNoLookups'
+    is enabled. This was enabled by default until version 2.15.0.
+  patterns:
+  # Checks for error(...), warn(...), info(...), debug(...), fatal(...), trace(...), log(level, ...):
+  - pattern-either:
+    - pattern: $W.fatal($X + $Y, ...);
+    - pattern: |
+        String $MSG = $X + $Y;
+        ...
+        $W.fatal($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += $Y;
+        ...
+        $W.fatal($MSG, ...);
+    - pattern: $W.fatal(String.format($X, ...), ...);
+    - pattern: |
+        String $MSG = String.format($X, ...);
+        ...
+        $W.fatal($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += String.format(...);
+        ...
+        $W.fatal($MSG, ...);
+
+
+    - pattern: $W.error($X + $Y, ...);
+    - pattern: |
+        String $MSG = $X + $Y;
+        ...
+        $W.error($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += $Y;
+        ...
+        $W.error($MSG, ...);
+    - pattern: $W.error(String.format($X, ...), ...);
+    - pattern: |
+        String $MSG = String.format($X, ...);
+        ...
+        $W.error($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += String.format(...);
+        ...
+        $W.error($MSG, ...);
+
+    - pattern: $W.warn($X + $Y, ...);
+    - pattern: |
+        String $MSG = $X + $Y;
+        ...
+        $W.warn($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += $Y;
+        ...
+        $W.warn($MSG, ...);
+    - pattern: $W.warn(String.format($X, ...), ...);
+    - pattern: |
+        String $MSG = String.format($X, ...);
+        ...
+        $W.warn($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += String.format(...);
+        ...
+        $W.warn($MSG, ...);
+
+
+    - pattern: $W.info($X + $Y, ...);
+    - pattern: |
+        String $MSG = $X + $Y;
+        ...
+        $W.info($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += $Y;
+        ...
+        $W.info($MSG, ...);
+    - pattern: $W.info(String.format($X, ...), ...);
+    - pattern: |
+        String $MSG = String.format($X, ...);
+        ...
+        $W.info($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += String.format(...);
+        ...
+        $W.info($MSG, ...);
+
+
+    - pattern: $W.debug($X + $Y, ...);
+    - pattern: |
+        String $MSG = $X + $Y;
+        ...
+        $W.debug($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += $Y;
+        ...
+        $W.debug($MSG, ...);
+    - pattern: $W.debug(String.format($X, ...), ...);
+    - pattern: |
+        String $MSG = String.format($X, ...);
+        ...
+        $W.debug($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += String.format(...);
+        ...
+        $W.debug($MSG, ...);
+
+    - pattern: $W.trace($X + $Y, ...);
+    - pattern: |
+        String $MSG = $X + $Y;
+        ...
+        $W.trace($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += $Y;
+        ...
+        $W.trace($MSG, ...);
+    - pattern: $W.trace(String.format($X, ...), ...);
+    - pattern: |
+        String $MSG = String.format($X, ...);
+        ...
+        $W.trace($MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += String.format(...);
+        ...
+        $W.trace($MSG, ...);
+
+    - pattern: $W.log($LEVEL, $X + $Y, ...);
+    - pattern: |
+        String $MSG = $X + $Y;
+        ...
+        $W.log($LEVEL, $MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += $Y;
+        ...
+        $W.log($LEVEL, MSG, ...);
+    - pattern: $W.log($LEVEL, String.format($X, ...), ...);
+    - pattern: |
+        String $MSG = String.format($X, ...);
+        ...
+        $W.log($LEVEL, $MSG, ...);
+    - pattern: |
+        String $MSG = $X;
+        ...
+        $MSG += String.format(...);
+        ...
+        $W.log($LEVEL, $MSG, ...);
+  severity: WARNING
+  languages:
+  - java


### PR DESCRIPTION
Added a rule for possible Lookup injection into Log4j messages. Lookups provide a way to add values to the Log4j messages at arbitrary places. If the message parameter contains an attacker controlled string, the attacker could inject arbitrary lookups, for instance ``${java:runtime}``. This cloud lead to information disclosure or even remove code execution if ``log4j2.formatMsgNoLookups`` is enabled. This was enabled by default until version 2.15.0.

Reference: https://www.lunasec.io/docs/blog/log4j-zero-day/