### PR TITLE
Changed update-semgrep-dev workflow to only trigger on merge to "release" branch

### DIFF
--- a/.github/workflows/update-semgrep-dev.yml
+++ b/.github/workflows/update-semgrep-dev.yml
@@ -3,7 +3,7 @@ name: update-semgrep-live
 on:
   push:
     branches:
-    - develop
+    - release
 
 jobs:
   do-update:


### PR DESCRIPTION
So that changes to develop don't automatically affect the live registry. Will create the `release` branch after this is merged into `develop`