### PR TITLE
Fix pg-orm-sqli rule

### DIFF
--- a/go/lang/security/audit/sqli/pg-orm-sqli.go
+++ b/go/lang/security/audit/sqli/pg-orm-sqli.go
@@ -2,6 +2,7 @@ package main
 
 import (
     "fmt"
+    "path"
 
     "github.com/go-pg/pg/v10"
     "github.com/go-pg/pg/v10/orm"
@@ -135,4 +136,9 @@ func ok6(db *pg.DB) {
     // ok: pg-orm-sqli
     err := db.Model().
     ColumnExpr(fmt.Sprintf("SELECT * FROM users WHERE email=hello;"))
+}
+
+func ok7() {
+    // ok: pg-orm-sqli
+    path.Join("foo", fmt.Sprintf("%s.baz", "bar"))
 }

--- a/go/lang/security/audit/sqli/pg-orm-sqli.yaml
+++ b/go/lang/security/audit/sqli/pg-orm-sqli.yaml
@@ -33,6 +33,7 @@ rules:
               }
       - pattern-not: |
           $DB.$INTFUNC1(...).$METHOD(..., "..." + "...", ...).$INTFUNC2(...)
+      - pattern-not: path.Join(...)
       - metavariable-regex:
           metavariable: $METHOD
           regex: ^(Where|WhereOr|Join|GroupExpr|OrderExpr|ColumnExpr)$


### PR DESCRIPTION
https://github.com/returntocorp/semgrep-rules/pull/1235 missed adding a pattern-either outer filter for `$DB`, so `$DB` ends up being any variable. This causes issues with other functions that expose a `Join`, or really any other method filtered by `$METHOD`, since it matches it when it shouldn't have.

This just fixes that issue and adds a test that `path.Join` still works.

Signed-off-by: James Elias Sigurdarson <jamiees2@gmail.com>