### PR TITLE
Identify S3 buckets with 'authenticated-read' ACL

### DIFF
--- a/terraform/lang/security/s3-public-read-bucket.tf
+++ b/terraform/lang/security/s3-public-read-bucket.tf
@@ -10,6 +10,17 @@ resource "aws_s3_bucket" "a" {
 }
 
 resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket-b"
+  # ruleid: s3-public-read-bucket
+  acl    = "authenticated-read"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+}
+
+resource "aws_s3_bucket" "c" {
   bucket = "s3-website-test.hashicorp.com"
   # ok: s3-public-read-bucket
   acl    = "public-read"

--- a/terraform/lang/security/s3-public-read-bucket.yaml
+++ b/terraform/lang/security/s3-public-read-bucket.yaml
@@ -1,7 +1,9 @@
 rules:
 - id: s3-public-read-bucket
   patterns:
-  - pattern: acl = "public-read"
+  - pattern: 
+    - pattern: acl = "public-read"
+    - pattern: acl = "authenticated-read"
   - pattern-not-inside: |
       resource "aws_s3_bucket" "..." {
         ...


### PR DESCRIPTION
The `authenticated-read` canned ACL is often mistaken with: "_Any principal in my AWS account can access the bucket_", while it instead means "_Any user authenticated against **any AWS account** can access it". 

Consequently I added a statement to flag such buckets, which most of the time are misconfigurations.

Resources: https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl

