### PR TITLE
Identify RDS instances exposed to the Internet

### DIFF
--- a/terraform/lang/security/rds-public-access.tf
+++ b/terraform/lang/security/rds-public-access.tf
@@ -1,0 +1,30 @@
+resource "aws_db_instance" "good_with_defaults" {
+  # ok: rds-public-access
+  allocated_storage = 10
+  engine            = "mysql"
+  engine_version    = "5.7"
+  instance_class    = "db.t3.micro"
+  name              = "mydb"
+}
+
+resource "aws_db_instance" "good" {
+  allocated_storage   = 10
+  engine              = "mysql"
+  engine_version      = "5.7"
+  instance_class      = "db.t3.micro"
+  name                = "mydb"
+
+  # ok: rds-public-access
+  publicly_accessible = false
+}
+
+resource "aws_db_instance" "bad" {
+  allocated_storage   = 10
+  engine              = "mysql"
+  engine_version      = "5.7"
+  instance_class      = "db.t3.micro"
+  name                = "mydb"
+
+  # ruleid: rds-public-access
+  publicly_accessible = true
+}

--- a/terraform/lang/security/rds-public-access.yaml
+++ b/terraform/lang/security/rds-public-access.yaml
@@ -1,0 +1,21 @@
+rules:
+- id: rds-public-access
+  patterns: 
+  - pattern: publicly_accessible = true
+  - pattern-inside: |
+      resource "aws_db_instance" "..." {
+        ...
+      }
+  languages:
+  - hcl
+  severity: WARNING
+  message: RDS instance accessible from the Internet detected.
+  metadata:
+    references:
+    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#publicly_accessible
+    - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html#USER_VPC.Hiding
+    cwe: 'CWE-284: Improper Access Control'
+    category: security
+    technology:
+    - terraform
+    - aws


### PR DESCRIPTION
Adding a rule to flag RDS instances exposed directly to the Internet, in `WARNING` mode.