### PR TITLE
Identify SecretsManager secret policies that do not have the block_public_policy flag explicitly set

### DIFF
--- a/terraform/lang/security/secretsmanager-block-public-access.tf
+++ b/terraform/lang/security/secretsmanager-block-public-access.tf
@@ -1,0 +1,24 @@
+resource "aws_secretsmanager_secret" "example" {
+  name = "example"
+}
+
+
+# ok: secretsmanager-block-public-access
+resource "aws_secretsmanager_secret_policy" "ok" {
+  secret_arn          = aws_secretsmanager_secret.example.arn
+  policy              = "policy"
+  block_public_policy = true
+}
+
+# ruleid: secretsmanager-block-public-access
+resource "aws_secretsmanager_secret_policy" "block_public_access_false" {
+  secret_arn          = aws_secretsmanager_secret.example.arn
+  policy              = "policy"
+  block_public_policy = false
+}
+
+# ruleid: secretsmanager-block-public-access
+resource "aws_secretsmanager_secret_policy" "insecure_defaults" {
+  secret_arn          = aws_secretsmanager_secret.example.arn
+  policy              = "policy"
+}

--- a/terraform/lang/security/secretsmanager-block-public-access.yaml
+++ b/terraform/lang/security/secretsmanager-block-public-access.yaml
@@ -1,0 +1,30 @@
+rules:
+- id: secretsmanager-block-public-access
+  patterns:
+  - pattern: |
+      resource
+  - pattern-inside: |
+      resource "aws_secretsmanager_secret_policy" "..." {
+        ...
+      }
+  - pattern-not-inside: |
+      resource "aws_secretsmanager_secret_policy" "..." {
+        ...
+        block_public_policy = true
+        ...
+      }
+  languages:
+  - hcl
+  severity: WARNING
+  message: >-
+    SecretsManager secret policy without the 'block_public_policy' flag set. 
+    Explicitly set this flag to 'true' to ensure your secret cannot become public by mistake.
+  metadata:
+    references:
+    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy#block_public_policy
+    - https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_PutResourcePolicy.html#API_PutResourcePolicy_RequestSyntax
+    cwe: 'CWE-200: Exposure of Sensitive Information to an Unauthorized Actor'
+    category: security
+    technology:
+    - terraform
+    - aws


### PR DESCRIPTION
A big argument for this rule is that https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy#block_public_policy has an insecure example