### PR TITLE
Validate rules before running --test

### DIFF
--- a/.github/workflows/semgrep-rules-test-develop.yml
+++ b/.github/workflows/semgrep-rules-test-develop.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: validate rules
       run: |
-        docker run --rm -v $(PWD):/src returntocorp/semgrep:develop --validate
+        docker run --rm -v $(PWD):/src returntocorp/semgrep:develop --validate --config .
     - name: test with semgrep develop branch
       run: |
         docker run --rm -v $(PWD):/src returntocorp/semgrep:develop --test --test-ignore-todo

--- a/.github/workflows/semgrep-rules-test-develop.yml
+++ b/.github/workflows/semgrep-rules-test-develop.yml
@@ -14,5 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: |
+    - name: validate rules
+      run: |
+        docker run --rm -v $(PWD):/src returntocorp/semgrep:develop --validate
+    - name: test with semgrep develop branch
+      run: |
         docker run --rm -v $(PWD):/src returntocorp/semgrep:develop --test --test-ignore-todo

--- a/.github/workflows/semgrep-rules-test.yml
+++ b/.github/workflows/semgrep-rules-test.yml
@@ -19,5 +19,7 @@ jobs:
         python-version: 3.9.2
     - name: install semgrep
       run: pip3 install semgrep
+    - name: validate rules
+      run: semgrep --validate --config .
     - name: run semgrep
       run: semgrep --test --test-ignore-todo


### PR DESCRIPTION
Turns out that running `--test` swallows any invalid configs and doesn't produce an error:

```
➜  security git:(debugging) ✗ semgrep --validate --test
The following config files produced errors:
	s3-public-read-bucket.yaml: invalid configuration file found (1 configs were invalid)
18 yaml files tested
check id scoring:
--------------------------------------------------------------------------------
(TODO: 0) s3-public-rw-bucket.yaml
	✔ s3-public-rw-bucket                                          TP: 1 TN: 0 FP: 0 FN: 0
(TODO: 0) s3-cors-all-origins.yaml
	✔ all-origins-allowed                                          TP: 1 TN: 1 FP: 0 FN: 0
...
➜  security git:(debugging) ✗ echo $?
0
```

and this caused an issue where we released an invalid rule and broke the app for a while today.

This PR adds an explicit validation step.