### PR TITLE
Fix parse error that is causing semgrep CI to fail

### DIFF
--- a/ruby/rails/security/audit/rails-skip-forgery-protection.rb
+++ b/ruby/rails/security/audit/rails-skip-forgery-protection.rb
@@ -8,10 +8,10 @@ class CustomStrategy
     end
   end
   
-  class ApplicationController < ActionController:x:Base
+  class ApplicationController < ActionController::Base
     # ruleid: rails-skip-forgery-protection
     skip_forgery_protection 
   end
-  class ApplicationController2 < ActionController:x:Base
+  class ApplicationController2 < ActionController::Base
     # ok: rails-skip-forgery-protection
   end


### PR DESCRIPTION
See test failures here:
https://github.com/returntocorp/semgrep/runs/4713621483?check_suite_focus=true

test plan:
semgrep-core -lang ruby -dump_ast rails-skip-forgery-protection.rb
does not return any parse error anymore