### PR TITLE
Run test-develop with --strict to catch parse errors in test files

### DIFF
--- a/.github/workflows/semgrep-rules-test-develop.yml
+++ b/.github/workflows/semgrep-rules-test-develop.yml
@@ -19,4 +19,4 @@ jobs:
         docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --validate --config /src
     - name: test with semgrep develop branch
       run: |
-        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --quiet --test --test-ignore-todo /src
+        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --quiet --strict --test --test-ignore-todo /src


### PR DESCRIPTION
Depends on https://github.com/returntocorp/semgrep/pull/4489