### PR TITLE
Fix semgrep-rule-lints to actually error

### DIFF
--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: lints for semgrep rules
       run: |
         semgrep \
-          --error
+          --error \
           --config yaml/semgrep/duplicate-id.yaml \
           --config yaml/semgrep/duplicate-pattern.yaml \
           --config yaml/semgrep/unsatisfiable.yaml \

--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -19,6 +19,7 @@ jobs:
     - name: lints for semgrep rules
       run: |
         semgrep \
+          --error
           --config yaml/semgrep/duplicate-id.yaml \
           --config yaml/semgrep/duplicate-pattern.yaml \
           --config yaml/semgrep/unsatisfiable.yaml \

--- a/generic/ci/audit/changed-semgrepignore.yaml
+++ b/generic/ci/audit/changed-semgrepignore.yaml
@@ -8,7 +8,7 @@ rules:
   - metavariable-regex:
       metavariable: $LINE
       regex: ^.*$
-  message: |
+  message: >-
     $LINE has been added to the .semgrepignore list of ignored paths. Someone from app-sec may want to audit these changes.
   languages:
   - generic

--- a/java/jboss/security/session_sqli.yaml
+++ b/java/jboss/security/session_sqli.yaml
@@ -34,7 +34,7 @@ rules:
     technology:
     - jboss
     confidence: MEDIUM
-    cwe: "CWE-89"
+    cwe: "CWE-89: SQL Injection"
     owasp:
     - A01:2017 - Injection
     - A03:2021 - Injection

--- a/ruby/rails/security/audit/rails-skip-forgery-protection.yml
+++ b/ruby/rails/security/audit/rails-skip-forgery-protection.yml
@@ -5,6 +5,9 @@ rules:
   languages:
   - ruby
   severity: WARNING
-  metadata: 
+  metadata:
+    category: security
+    technology:
+    - rails
     references:
     - https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection/ClassMethods.html#method-i-skip_forgery_protection


### PR DESCRIPTION
semgrep-rule-lints wasn't actually erroring due to lack of `--error` flag