### PR TITLE
Add an ocaml rule to detect useless comparisons

### DIFF
--- a/ocaml/lang/correctness/useless-compare.ml
+++ b/ocaml/lang/correctness/useless-compare.ml
@@ -1,0 +1,14 @@
+let test a b =
+  (* ruleid:useless-compare *)
+  let c = compare (a+b) (a+b) in
+  if c <> 0 then c
+  else
+    compare a b
+
+let test a b =
+  (* ruleid:useless-compare *)
+  let c = Int.compare (a+b) (a+b) in
+  if c <> 0 then c
+  else
+    compare a b
+

--- a/ocaml/lang/correctness/useless-compare.yaml
+++ b/ocaml/lang/correctness/useless-compare.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: useless-compare
+  patterns:
+  - pattern-either:
+    - pattern: compare $X $X
+    - pattern: $MODULE.compare $X $X
+
+  message: >-
+    This comparison is useless because the arguments are always
+    identical. If this isn't actually a comparison, the function
+    shouldn't be called 'compare'.
+  languages: [ocaml]
+  severity: ERROR
+  metadata:
+    category: correctness
+    technology:
+    - ocaml

--- a/ocaml/lang/correctness/useless-compare.yaml
+++ b/ocaml/lang/correctness/useless-compare.yaml
@@ -6,9 +6,9 @@ rules:
     - pattern: $MODULE.compare $X $X
 
   message: >-
-    This comparison is useless because the arguments are always
-    identical. If this isn't actually a comparison, the function
-    shouldn't be called 'compare'.
+    This comparison is useless because the expressions being compared
+    are identical. This is expected to always return the same result,
+    0, unless your code is really strange.
   languages: [ocaml]
   severity: ERROR
   metadata:


### PR DESCRIPTION
This was modeled after the existing rule `useless-eq` that we already have for ocaml... after getting [caught](https://github.com/returntocorp/semgrep/pull/4488#pullrequestreview-847602344) by @IagoAbal during code review.