### PR TITLE
Only run push-dev-to-release on returntocorp repo

### DIFF
--- a/.github/workflows/push-dev-to-release.yml
+++ b/.github/workflows/push-dev-to-release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   create-pull-request:
+    if: github.repository == 'returntocorp/semgrep-rules'
     runs-on: ubuntu-latest
     steps:
     - name: Check out release


### PR DESCRIPTION
This will also run on forks: https://github.com/jamiees2/semgrep-rules/actions/runs/1683842680

Let's have it only run on our repo