### PR TITLE
Fix syntax errors in code samples

### DIFF
--- a/kotlin/lang/security/unencrypted-socket.kt
+++ b/kotlin/lang/security/unencrypted-socket.kt
@@ -36,7 +36,7 @@ public class UnencryptedSocket {
         doGetRequest(soc2)
     }
 
-    fun doGetRequest(Socket soc): Void {
+    fun doGetRequest(soc: Socket): Void {
         System.out.println("")
         soc.close()
     }

--- a/terraform/aws/best-practice/missing-alb-drop-http-headers.tf
+++ b/terraform/aws/best-practice/missing-alb-drop-http-headers.tf
@@ -66,4 +66,4 @@ resource "aws_alb" "disabled" {
   subnets            = var.public_subnet_ids
 
   drop_invalid_header_fields = false
-}missing-u
+}


### PR DESCRIPTION
While working on https://github.com/returntocorp/semgrep/pull/4489 for https://github.com/returntocorp/semgrep-rules/issues/1699, I came across a few sample files that failed to parse. This fixes them.