### PR TITLE
remove --quiet for better testing errors

### DIFF
--- a/.github/workflows/semgrep-rules-test-develop.yml
+++ b/.github/workflows/semgrep-rules-test-develop.yml
@@ -19,4 +19,4 @@ jobs:
         docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --validate --config /src
     - name: test with semgrep develop branch
       run: |
-        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --quiet --test --test-ignore-todo /src
+        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --test --test-ignore-todo /src


### PR DESCRIPTION
Removing quiet from from the `semgrep-rules-test-develop` workflow. 

This leads to better errors if `test.py` itself fails. 

_To Test:_
* change the name of a semgrep-rule rule id to something that doesn't exist, like 'dne'.
* run `semgrep --test <folder file exists in>`
* then run `semgrep --test --quiet <folder file exists in>`

You can see that `--quiet` silences the error. 