### PR TITLE
add SslCertificateTrust configuration correctness rule + tests

### DIFF
--- a/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.cs
+++ b/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.cs
@@ -1,0 +1,31 @@
+public class Foo{
+    private void SomeFunction(string arg1){
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,true);
+    }
+
+    private void SomeFunction2(string arg1){
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,sendTrustInHandshake=true);
+    }
+
+    private void SomeFunction3(string arg1){
+        //ok
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection);
+    }
+
+    private void SomeFunction4(string arg1){
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,true);
+    }
+
+    private void SomeFunction5(string arg1){
+        //ruleid: correctness-sslcertificatetrust-handshake-no-trust
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,sendTrustInHandshake=true);
+    }
+
+    private void SomeFunction6(string arg1){
+        //ok
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection);
+    }
+}

--- a/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.cs
+++ b/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.cs
@@ -1,12 +1,12 @@
 public class Foo{
     private void SomeFunction(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = CreateForX509Collection(...,false);
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,true);
     }
 
     private void SomeFunction2(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = CreateForX509Collection(...,false);
+        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,sendTrustInHandshake=true);
     }
 
     private void SomeFunction3(string arg1){
@@ -16,12 +16,12 @@ public class Foo{
 
     private void SomeFunction4(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = CreateForX509Store(...,false);
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,true);
     }
 
     private void SomeFunction5(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = CreateForX509Store(...,false);
+        var collection = SslCertificateTrust.CreateForX509Store(certCollection,sendTrustInHandshake=true);
     }
 
     private void SomeFunction6(string arg1){

--- a/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.cs
+++ b/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.cs
@@ -1,12 +1,12 @@
 public class Foo{
     private void SomeFunction(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,true);
+        var collection = CreateForX509Collection(...,false);
     }
 
     private void SomeFunction2(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = SslCertificateTrust.CreateForX509Collection(certCollection,sendTrustInHandshake=true);
+        var collection = CreateForX509Collection(...,false);
     }
 
     private void SomeFunction3(string arg1){
@@ -16,12 +16,12 @@ public class Foo{
 
     private void SomeFunction4(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = SslCertificateTrust.CreateForX509Store(certCollection,true);
+        var collection = CreateForX509Store(...,false);
     }
 
     private void SomeFunction5(string arg1){
         //ruleid: correctness-sslcertificatetrust-handshake-no-trust
-        var collection = SslCertificateTrust.CreateForX509Store(certCollection,sendTrustInHandshake=true);
+        var collection = CreateForX509Store(...,false);
     }
 
     private void SomeFunction6(string arg1){

--- a/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
+++ b/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
@@ -12,7 +12,8 @@ rules:
   languages: [csharp]
   metadata:
     references: 
-      - https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslcertificatetrust.createforx509collection?view=net-6.0
+      - https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslcertificatetrust.createforx509collection?view=net-6.0#remarks
+      - https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslcertificatetrust.createforx509store?view=net-6.0#remarks
     cwe: "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
     owasp: "A3: Sensitive Data Exposure"
     category: correctness

--- a/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
+++ b/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
@@ -7,7 +7,7 @@ rules:
     - metavariable-regex:
         metavariable: $METHOD
         regex: CreateForX509(Collection|Store)
-  fix: $METHOD($COLLECTION,false)
+  fix: SslCertificateTrust.$METHOD($COLLECTION,false)
   message: Sending the trusted CA list increases the size of the handshake request and can leak system configuration information.
   languages: [csharp]
   metadata:

--- a/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
+++ b/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
@@ -1,0 +1,20 @@
+rules:
+- id: correctness-sslcertificatetrust-handshake-no-trust
+  patterns:
+    - pattern-either:
+      - pattern: SslCertificateTrust.CreateForX509Collection(...,sendTrustInHandshake=true)
+      - pattern: SslCertificateTrust.CreateForX509Collection(...,true)
+      - pattern: SslCertificateTrust.CreateForX509Store(...,sendTrustInHandshake=true)
+      - pattern: SslCertificateTrust.CreateForX509Store(...,true)
+  message: Sending the trusted CA list increases the size of the handshake request and can leak system configuration information.
+  languages: [csharp]
+  metadata:
+    references: 
+      - https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslcertificatetrust.createforx509collection?view=net-6.0
+    cwe: "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+    owasp: "A3: Sensitive Data Exposure"
+    category: correctness
+    technology: 
+      - .net
+    confidence: HIGH
+  severity: WARNING

--- a/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
+++ b/csharp/lang/correctness/sslcertificatetrust/sslcertificatetrust-handshake-no-trust.yaml
@@ -2,10 +2,12 @@ rules:
 - id: correctness-sslcertificatetrust-handshake-no-trust
   patterns:
     - pattern-either:
-      - pattern: SslCertificateTrust.CreateForX509Collection(...,sendTrustInHandshake=true)
-      - pattern: SslCertificateTrust.CreateForX509Collection(...,true)
-      - pattern: SslCertificateTrust.CreateForX509Store(...,sendTrustInHandshake=true)
-      - pattern: SslCertificateTrust.CreateForX509Store(...,true)
+      - pattern: SslCertificateTrust.$METHOD($COLLECTION,sendTrustInHandshake=true)
+      - pattern: SslCertificateTrust.$METHOD($COLLECTION,true)
+    - metavariable-regex:
+        metavariable: $METHOD
+        regex: CreateForX509(Collection|Store)
+  fix: $METHOD($COLLECTION,false)
   message: Sending the trusted CA list increases the size of the handshake request and can leak system configuration information.
   languages: [csharp]
   metadata:


### PR DESCRIPTION
@clintgibler @minusworld @lejliu 

Background:

MSDN docs for `CreateForX509Collection` and `CreateForX509Store` discourage setting `sendTrustInHandshake=true`

https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslcertificatetrust.createforx509collection?view=net-6.0#remarks
https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslcertificatetrust.createforx509store?view=net-6.0#remarks

This is an easy win for C# correctness coverage, even if a cursory grep.app turns up 0 public-facing usage of this static method.