### PR TITLE
sqli and cmdi rules

### DIFF
--- a/java/lang/security/audit/sqli/tainted-sql-from-http-request.java
+++ b/java/lang/security/audit/sqli/tainted-sql-from-http-request.java
@@ -1,0 +1,289 @@
+/**
+ * OWASP Benchmark v1.2
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project. For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Dave Wichers
+ * @created 2015
+ */
+package org.owasp.benchmark.testcode;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(value = "/sqli-00/BenchmarkTest00008")
+public class bad1 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        if (request.getHeader("BenchmarkTest00008") != null) {
+            param = request.getHeader("BenchmarkTest00008");
+        }
+
+        // URL Decode the header value since req.getHeader() doesn't. Unlike req.getParameter().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        String sql = "{call " + param + "}";
+
+        try {
+            java.sql.Connection connection =
+                    org.owasp.benchmark.helpers.DatabaseHelper.getSqlConnection();
+            // ruleid: tainted-sql-from-http-request
+            java.sql.CallableStatement statement = connection.prepareCall(sql);
+            java.sql.ResultSet rs = statement.executeQuery();
+            org.owasp.benchmark.helpers.DatabaseHelper.printResults(rs, sql, response);
+
+        } catch (java.sql.SQLException e) {
+            if (org.owasp.benchmark.helpers.DatabaseHelper.hideSQLErrors) {
+                response.getWriter().println("Error processing request.");
+                return;
+            } else throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/sqli-00/BenchmarkTest00018")
+public class bad2 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        java.util.Enumeration<String> headers = request.getHeaders("BenchmarkTest00018");
+
+        if (headers != null && headers.hasMoreElements()) {
+            param = headers.nextElement(); // just grab first element
+        }
+
+        // URL Decode the header value since req.getHeaders() doesn't. Unlike req.getParameters().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        String sql = "INSERT INTO users (username, password) VALUES ('foo','" + param + "')";
+
+        try {
+            // ruleid: tainted-sql-from-http-request
+            java.sql.Statement statement =
+                    org.owasp.benchmark.helpers.DatabaseHelper.getSqlStatement();
+            int count = statement.executeUpdate(sql);
+            org.owasp.benchmark.helpers.DatabaseHelper.outputUpdateComplete(sql, response);
+        } catch (java.sql.SQLException e) {
+            if (org.owasp.benchmark.helpers.DatabaseHelper.hideSQLErrors) {
+                response.getWriter().println("Error processing request.");
+                return;
+            } else throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/sqli-00/BenchmarkTest00024")
+public class bad3 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = request.getParameter("BenchmarkTest00024");
+        if (param == null) param = "";
+
+        String sql = "SELECT * from USERS where USERNAME=? and PASSWORD='" + param + "'";
+
+        try {
+            java.sql.Connection connection =
+                    org.owasp.benchmark.helpers.DatabaseHelper.getSqlConnection();
+            // ruleid: tainted-sql-from-http-request
+            java.sql.PreparedStatement statement =
+                    connection.prepareStatement(
+                            sql,
+                            java.sql.ResultSet.TYPE_FORWARD_ONLY,
+                            java.sql.ResultSet.CONCUR_READ_ONLY,
+                            java.sql.ResultSet.CLOSE_CURSORS_AT_COMMIT);
+            statement.setString(1, "foo");
+            statement.execute();
+            org.owasp.benchmark.helpers.DatabaseHelper.printResults(statement, sql, response);
+        } catch (java.sql.SQLException e) {
+            if (org.owasp.benchmark.helpers.DatabaseHelper.hideSQLErrors) {
+                response.getWriter().println("Error processing request.");
+                return;
+            } else throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/sqli-00/BenchmarkTest00025")
+public class bad4 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = request.getParameter("BenchmarkTest00025");
+        if (param == null) param = "";
+
+        String sql = "SELECT userid from USERS where USERNAME='foo' and PASSWORD='" + param + "'";
+        try {
+            // Long results =
+            // org.owasp.benchmark.helpers.DatabaseHelper.JDBCtemplate.queryForLong(sql);
+            // ruleid: tainted-sql-from-http-request
+            Long results =
+                    org.owasp.benchmark.helpers.DatabaseHelper.JDBCtemplate.queryForObject(
+                            sql, Long.class);
+            response.getWriter().println("Your results are: " + String.valueOf(results));
+        } catch (org.springframework.dao.EmptyResultDataAccessException e) {
+            response.getWriter()
+                    .println(
+                            "No results returned for query: "
+                                    + org.owasp.esapi.ESAPI.encoder().encodeForHTML(sql));
+        } catch (org.springframework.dao.DataAccessException e) {
+            if (org.owasp.benchmark.helpers.DatabaseHelper.hideSQLErrors) {
+                response.getWriter().println("Error processing request.");
+            } else throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/sqli-00/BenchmarkTest00026")
+public class bad5 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = request.getParameter("BenchmarkTest00026");
+        if (param == null) param = "";
+
+        String sql = "SELECT  * from USERS where USERNAME='foo' and PASSWORD='" + param + "'";
+        try {
+            // ruleid: tainted-sql-from-http-request
+            org.springframework.jdbc.support.rowset.SqlRowSet results =
+                    org.owasp.benchmark.helpers.DatabaseHelper.JDBCtemplate.queryForRowSet(sql);
+            response.getWriter().println("Your results are: ");
+
+            //		System.out.println("Your results are");
+            while (results.next()) {
+                response.getWriter()
+                        .println(
+                                org.owasp
+                                                .esapi
+                                                .ESAPI
+                                                .encoder()
+                                                .encodeForHTML(results.getString("USERNAME"))
+                                        + " ");
+                //			System.out.println(results.getString("USERNAME"));
+            }
+        } catch (org.springframework.dao.EmptyResultDataAccessException e) {
+            response.getWriter()
+                    .println(
+                            "No results returned for query: "
+                                    + org.owasp.esapi.ESAPI.encoder().encodeForHTML(sql));
+        } catch (org.springframework.dao.DataAccessException e) {
+            if (org.owasp.benchmark.helpers.DatabaseHelper.hideSQLErrors) {
+                response.getWriter().println("Error processing request.");
+            } else throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/sqli-00/BenchmarkTest00008")
+public class bad1 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "test";
+
+        String sql = "{call " + param + "}";
+
+        try {
+            java.sql.Connection connection =
+                    org.owasp.benchmark.helpers.DatabaseHelper.getSqlConnection();
+            // ok: tainted-sql-from-http-request
+            java.sql.CallableStatement statement = connection.prepareCall(sql);
+            java.sql.ResultSet rs = statement.executeQuery();
+            org.owasp.benchmark.helpers.DatabaseHelper.printResults(rs, sql, response);
+
+        } catch (java.sql.SQLException e) {
+            if (org.owasp.benchmark.helpers.DatabaseHelper.hideSQLErrors) {
+                response.getWriter().println("Error processing request.");
+                return;
+            } else throw new ServletException(e);
+        }
+    }
+}

--- a/java/lang/security/audit/sqli/tainted-sql-from-http-request.yaml
+++ b/java/lang/security/audit/sqli/tainted-sql-from-http-request.yaml
@@ -1,0 +1,52 @@
+rules:
+  - id: tainted-sql-from-http-request 
+    message: >-
+      Detected input from a HTTPServletRequest going into a SQL sink or statement. This could lead to SQL
+      injection if variables in the SQL statement are not properly sanitized.
+      Use parameterized SQL queries or properly sanitize user input instead.
+    languages: [java]
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            (HttpServletRequest $REQ).$REQFUNC(...)
+    pattern-sinks:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            (java.sql.CallableStatement $STMT) = ...; 
+        - pattern: |
+            (java.sql.Statement $STMT) = ...;
+            ...
+            $OUTPUT = $STMT.$FUNC(...);
+        - pattern: |
+            (java.sql.PreparedStatement $STMT) = ...;
+        - pattern: |
+            $VAR = $CONN.prepareStatement(...)
+        - pattern: |
+            $PATH.queryForObject(...);
+        - pattern: |
+            (java.util.Map<String, Object> $STMT) = $PATH.queryForMap(...);
+        - pattern: |
+            (org.springframework.jdbc.support.rowset.SqlRowSet $STMT) = ...;
+        - patterns: 
+          - pattern-inside: |
+              (String $SQL) = "$SQLSTR" + ...;
+              ...
+          - pattern:
+              $PATH.$SQLCMD(..., $SQL, ...);
+          - metavariable-regex:
+              metavariable: $SQLSTR
+              regex: (?i)(^SELECT.* | ^INSERT.* | ^UPDATE.*)
+          - metavariable-regex:
+              metavariable: $SQLCMD
+              regex: (execute|query|executeUpdate)
+    metadata:
+      category: security
+      technology:
+        - sql
+        - java
+      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      owasp: "A01: Injection"

--- a/java/lang/security/audit/sqli/tainted-sql-from-http-request.yaml
+++ b/java/lang/security/audit/sqli/tainted-sql-from-http-request.yaml
@@ -9,9 +9,18 @@ rules:
     mode: taint
     pattern-sources:
     - patterns:
-      - pattern-either:
+      - pattern-either: # using this more specific pattern instead of (HttpServletRequest $REQ) reduces FP that are designed to trick taint
         - pattern: |
-            (HttpServletRequest $REQ).$REQFUNC(...)
+            (HttpServletRequest $REQ).$REQFUNC(...) 
+        - patterns: # this pattern is a hack to get the rule to recognize `map` as tainted source when `cookie.getValue(user_input)` is used.
+          - pattern-inside: |
+              (javax.servlet.http.Cookie[] $COOKIES) = (HttpServletRequest $REQ).getCookies(...);
+              ...
+              for (javax.servlet.http.Cookie $COOKIE: $COOKIES) {
+                ...
+              }
+          - pattern: |
+              $COOKIE.getValue(...)
     pattern-sinks:
     - patterns:
       - pattern-either:

--- a/java/lang/security/audit/tainted-cmd-from-http-request.java
+++ b/java/lang/security/audit/tainted-cmd-from-http-request.java
@@ -1,0 +1,323 @@
+/**
+ * OWASP Benchmark v1.2
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project. For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Dave Wichers
+ * @created 2015
+ */
+package org.owasp.benchmark.testcode;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(value = "/cmdi-00/BenchmarkTest00006")
+public class bad1 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        if (request.getHeader("BenchmarkTest00006") != null) {
+            param = request.getHeader("BenchmarkTest00006");
+        }
+
+        // URL Decode the header value since req.getHeader() doesn't. Unlike req.getParameter().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        java.util.List<String> argList = new java.util.ArrayList<String>();
+
+        String osName = System.getProperty("os.name");
+        if (osName.indexOf("Windows") != -1) {
+            argList.add("cmd.exe");
+            argList.add("/c");
+        } else {
+            argList.add("sh");
+            argList.add("-c");
+        }
+        // ruleid: tainted-cmd-from-http-request
+        argList.add("echo " + param);
+
+        ProcessBuilder pb = new ProcessBuilder();
+
+        pb.command(argList);
+
+        try {
+            Process p = pb.start();
+            org.owasp.benchmark.helpers.Utils.printOSCommandResults(p, response);
+        } catch (IOException e) {
+            System.out.println(
+                    "Problem executing cmdi - java.lang.ProcessBuilder(java.util.List) Test Case");
+            throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/cmdi-00/BenchmarkTest00007")
+public class bad2 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        if (request.getHeader("BenchmarkTest00007") != null) {
+            param = request.getHeader("BenchmarkTest00007");
+        }
+
+        // URL Decode the header value since req.getHeader() doesn't. Unlike req.getParameter().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        String cmd =
+                org.owasp.benchmark.helpers.Utils.getInsecureOSCommandString(
+                        this.getClass().getClassLoader());
+        String[] args = {cmd};
+        String[] argsEnv = {param};
+
+        Runtime r = Runtime.getRuntime();
+
+        try {
+            // ruleid: tainted-cmd-from-http-request
+            Process p = r.exec(args, argsEnv);
+            org.owasp.benchmark.helpers.Utils.printOSCommandResults(p, response);
+        } catch (IOException e) {
+            System.out.println("Problem executing cmdi - TestCase");
+            response.getWriter()
+                    .println(org.owasp.esapi.ESAPI.encoder().encodeForHTML(e.getMessage()));
+            return;
+        }
+    }
+}
+
+@WebServlet(value = "/cmdi-00/BenchmarkTest00091")
+public class bad3 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        javax.servlet.http.Cookie userCookie =
+                new javax.servlet.http.Cookie("BenchmarkTest00091", "FOO%3Decho+Injection");
+        userCookie.setMaxAge(60 * 3); // Store cookie for 3 minutes
+        userCookie.setSecure(true);
+        userCookie.setPath(request.getRequestURI());
+        userCookie.setDomain(new java.net.URL(request.getRequestURL().toString()).getHost());
+        response.addCookie(userCookie);
+        javax.servlet.RequestDispatcher rd =
+                request.getRequestDispatcher("/cmdi-00/BenchmarkTest00091.html");
+        rd.include(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+
+        javax.servlet.http.Cookie[] theCookies = request.getCookies();
+
+        String param = "noCookieValueSupplied";
+        if (theCookies != null) {
+            for (javax.servlet.http.Cookie theCookie : theCookies) {
+                if (theCookie.getName().equals("BenchmarkTest00091")) {
+                    param = java.net.URLDecoder.decode(theCookie.getValue(), "UTF-8");
+                    break;
+                }
+            }
+        }
+
+        String bar = param;
+
+        String cmd =
+                org.owasp.benchmark.helpers.Utils.getInsecureOSCommandString(
+                        this.getClass().getClassLoader());
+        String[] args = {cmd};
+        String[] argsEnv = {bar};
+
+        Runtime r = Runtime.getRuntime();
+
+        try {
+            // ruleid: tainted-cmd-from-http-request
+            Process p = r.exec(args, argsEnv);
+            org.owasp.benchmark.helpers.Utils.printOSCommandResults(p, response);
+        } catch (IOException e) {
+            System.out.println("Problem executing cmdi - TestCase");
+            response.getWriter()
+                    .println(org.owasp.esapi.ESAPI.encoder().encodeForHTML(e.getMessage()));
+            return;
+        }
+    }
+}
+
+@WebServlet(value = "/cmdi-00/BenchmarkTest00077")
+public class bad4 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        javax.servlet.http.Cookie userCookie =
+                new javax.servlet.http.Cookie("BenchmarkTest00077", "ECHOOO");
+        userCookie.setMaxAge(60 * 3); // Store cookie for 3 minutes
+        userCookie.setSecure(true);
+        userCookie.setPath(request.getRequestURI());
+        userCookie.setDomain(new java.net.URL(request.getRequestURL().toString()).getHost());
+        response.addCookie(userCookie);
+        javax.servlet.RequestDispatcher rd =
+                request.getRequestDispatcher("/cmdi-00/BenchmarkTest00077.html");
+        rd.include(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+
+        javax.servlet.http.Cookie[] theCookies = request.getCookies();
+
+        String param = "noCookieValueSupplied";
+        if (theCookies != null) {
+            for (javax.servlet.http.Cookie theCookie : theCookies) {
+                if (theCookie.getName().equals("BenchmarkTest00077")) {
+                    param = java.net.URLDecoder.decode(theCookie.getValue(), "UTF-8");
+                    break;
+                }
+            }
+        }
+
+        String bar;
+        String guess = "ABC";
+        char switchTarget = guess.charAt(2);
+
+        // Simple case statement that assigns param to bar on conditions 'A', 'C', or 'D'
+        switch (switchTarget) {
+            case 'A':
+                bar = param;
+                break;
+            case 'B':
+                bar = "bobs_your_uncle";
+                break;
+            case 'C':
+            case 'D':
+                bar = param;
+                break;
+            default:
+                bar = "bobs_your_uncle";
+                break;
+        }
+
+        java.util.List<String> argList = new java.util.ArrayList<String>();
+
+        String osName = System.getProperty("os.name");
+        if (osName.indexOf("Windows") != -1) {
+            argList.add("cmd.exe");
+            argList.add("/c");
+        } else {
+            argList.add("sh");
+            argList.add("-c");
+        }
+        // ruleid: tainted-cmd-from-http-request
+        argList.add("echo " + bar);
+
+        ProcessBuilder pb = new ProcessBuilder(argList);
+
+        try {
+            Process p = pb.start();
+            org.owasp.benchmark.helpers.Utils.printOSCommandResults(p, response);
+        } catch (IOException e) {
+            System.out.println(
+                    "Problem executing cmdi - java.lang.ProcessBuilder(java.util.List) Test Case");
+            throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/cmdi-00/BenchmarkTest00006")
+public class ok1 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        if (request.getHeader("BenchmarkTest00006") != null) {
+            param = request.getHeader("BenchmarkTest00006");
+        }
+
+        // URL Decode the header value since req.getHeader() doesn't. Unlike req.getParameter().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        java.util.List<String> argList = new java.util.ArrayList<String>();
+
+        String osName = System.getProperty("os.name");
+        if (osName.indexOf("Windows") != -1) {
+            argList.add("cmd.exe");
+            argList.add("/c");
+        } else {
+            argList.add("sh");
+            argList.add("-c");
+        }
+        // ok: tainted-cmd-from-http-request
+        argList.add("echo " + "param");
+
+        ProcessBuilder pb = new ProcessBuilder();
+
+        pb.command(argList);
+
+        try {
+            Process p = pb.start();
+            org.owasp.benchmark.helpers.Utils.printOSCommandResults(p, response);
+        } catch (IOException e) {
+            System.out.println(
+                    "Problem executing cmdi - java.lang.ProcessBuilder(java.util.List) Test Case");
+            throw new ServletException(e);
+        }
+    }
+}

--- a/java/lang/security/audit/tainted-cmd-from-http-request.yaml
+++ b/java/lang/security/audit/tainted-cmd-from-http-request.yaml
@@ -1,0 +1,54 @@
+rules:
+  - id: tainted-cmd-from-http-request 
+    message: >-
+      Detected input from a HTTPServletRequest going into a 'ProcessBuilder' or 'exec' command. 
+      This could lead to command injection if variables passed into the exec commands are not properly sanitized. 
+      Instead, avoid using these OS commands with user-supplied input, or, if you must use these commands, use a whitelist of specific values.
+    languages: [java]
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            (HttpServletRequest $REQ)
+        - patterns: # this pattern is a hack to get the rule to recognize `map` as tainted source when `cookie.getValue(user_input)` is used.
+          - pattern-inside: |
+              (javax.servlet.http.Cookie[] $COOKIES) = (HttpServletRequest $REQ).getCookies(...);
+              ...
+              for (javax.servlet.http.Cookie $COOKIE: $COOKIES) {
+                ...
+              }
+          - pattern: |
+              $COOKIE.getValue(...)
+    pattern-sinks:
+    - patterns:
+      - pattern-either:
+          - pattern: |
+              (ProcessBuilder $PB) = ...;
+          - pattern: |
+              (Process $P) = ...;
+          - patterns: # used in the case that commands are added to an argument list along with a user-inputted parameter and then executed. also a hack similar to line 15.
+            - pattern-either: 
+              - pattern-inside: |
+                  (java.util.List<$TYPE> $ARGLIST) = ...;  
+                  ...
+                  (ProcessBuilder $PB) = ...;
+                  ...
+                  $PB.command($ARGLIST);
+              - pattern-inside: |
+                  (java.util.List<$TYPE> $ARGLIST) = ...;  
+                  ...
+                  (ProcessBuilder $PB) = ...;
+              - pattern-inside: |
+                  (java.util.List<$TYPE> $ARGLIST) = ...;  
+                  ...
+                  (Process $P) = ...;
+            - pattern: |
+                $ARGLIST.add(...);
+    metadata:
+      category: security
+      technology:
+        - java
+      cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')" 
+      owasp: "A01: Injection"


### PR DESCRIPTION
SQLi rule and CMDi rule for OWASP java benchmark -- this improves the score from: 
* 2%-> 12% for cmdi
* 0% -> 18% for sqli

_To test:_
Run `semgrep --test .` on the `java/lang/security/audit` folder and check that all tests pass.

Run 
`semgrep -f ~/Desktop/semgrep_repos/semgrep-rules/java/lang/security/audit --json > results/Benchmark_1.2-semgrep.json`
`createScorecards.sh`

and check the scorecards for the benchmark.