### PR TITLE
Fix pipenv rule written for pip

### DIFF
--- a/generic/ci/security/use-frozen-lockfile.generic
+++ b/generic/ci/security/use-frozen-lockfile.generic
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN yarn install
 # trailing space
 # ruleid: use-frozen-lockfile-yarn
-RUN yarn install 
+RUN yarn install
 RUN yarn install --frozen-lockfile
 RUN yarn install some_package
 
@@ -29,11 +29,11 @@ RUN echo 'npm installing foo'
 
 
 # ruleid: use-frozen-lockfile-pip
-RUN pip install
+RUN pipenv install
 # another case with a trailing space
 # ruleid: use-frozen-lockfile-pip
-RUN pip install 
-RUN pip install some_package
-RUN pip install --ignore-pipfile
+RUN pipenv install
+RUN pipenv install some_package
+RUN pipenv install --ignore-pipfile
 
-RUN echo 'pip installing foo'
+RUN echo 'pipenv installing foo'

--- a/generic/ci/security/use-frozen-lockfile.generic
+++ b/generic/ci/security/use-frozen-lockfile.generic
@@ -28,10 +28,10 @@ RUN yarn build
 RUN echo 'npm installing foo'
 
 
-# ruleid: use-frozen-lockfile-pip
+# ruleid: use-frozen-lockfile-pipenv
 RUN pipenv install
 # another case with a trailing space
-# ruleid: use-frozen-lockfile-pip
+# ruleid: use-frozen-lockfile-pipenv
 RUN pipenv install
 RUN pipenv install some_package
 RUN pipenv install --ignore-pipfile

--- a/generic/ci/security/use-frozen-lockfile.yaml
+++ b/generic/ci/security/use-frozen-lockfile.yaml
@@ -36,14 +36,14 @@ rules:
         - javascript
         - typescript
         - npm
-  - id: use-frozen-lockfile-pip
+  - id: use-frozen-lockfile-pipenv
     patterns:
-      - pattern-regex: pip install\s
-      - pattern-not-regex: pip install --ignore-pipfile
-      - pattern-not-regex: pip install [\w]+
-    fix: pip install --ignore-pipfile
+      - pattern-regex: pipenv install\s
+      - pattern-not-regex: pipenv install --ignore-pipfile
+      - pattern-not-regex: pipenv install [\w]+
+    fix: pipenv install --ignore-pipfile
     message: >-
-      To ensure reproducable and deterministic builds, use `pip install --ignore-pipfile` rather than `pip install` in scripts. This will use the lockfile rather than updating it.
+      To ensure reproducable and deterministic builds, use `pipenv install --ignore-pipfile` rather than `pipenv install` in scripts. This will use the lockfile rather than updating it.
     languages:
       - generic
     severity: INFO
@@ -54,4 +54,4 @@ rules:
         - dockerfile
         - javascript
         - typescript
-        - pip
+        - pipenv


### PR DESCRIPTION
verified that the original suggestion is incorrect:

```
❯ pip install --ignore-pipfile

Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

no such option: --ignore-pipfile
```