### PR TITLE
Go path traversals

### DIFF
--- a/go/lang/correctness/use-filepath-join.go
+++ b/go/lang/correctness/use-filepath-join.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"path"
+	"filepath"
+)
+
+func main() {
+	dir := getDir()
+
+	// ruleid: use-filepath-join
+	var path = path.Join(getDir())
+	// ok: use-filepath-join
+	var fpath = filepath.Join(getDir())
+}

--- a/go/lang/correctness/use-filepath-join.yaml
+++ b/go/lang/correctness/use-filepath-join.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: use-filepath-join
+  languages: [go]
+  severity: WARNING
+  message: >-
+    `path.Join(...)` always joins using a forward slash. This may cause
+    issues on Windows or other systems using a different delimiter. Use
+    `filepath.Join(...)` instead which uses OS-specific path separators.
+  pattern: path.Join(...)
+  metadata:
+    category: correctness
+    references:
+    - https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
+    - https://go.dev/src/path/path.go?s=4034:4066#L145

--- a/go/lang/correctness/use-filepath-join.yaml
+++ b/go/lang/correctness/use-filepath-join.yaml
@@ -12,3 +12,5 @@ rules:
     references:
     - https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
     - https://go.dev/src/path/path.go?s=4034:4066#L145
+    technology:
+    - go

--- a/go/lang/security/filepath-clean-misuse.go
+++ b/go/lang/security/filepath-clean-misuse.go
@@ -49,6 +49,18 @@ func main() {
 		w.Write(contents)
 	})
 
+	mux.HandleFunc("/ok2", func(w http.ResponseWriter, r *http.Request) {
+		// ok: filepath-clean-misuse
+		filename := path.Clean("/" + r.URL.Path)
+		filename := filepath.Join(root, strings.Trim(filename, "/"))
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write(contents)
+	})
+
 	server := &http.Server{
 		Addr:    "127.0.0.1:50000",
 		Handler: mux,
@@ -56,3 +68,36 @@ func main() {
 
 	log.Fatal(server.ListenAndServe())
 }
+
+// TODO
+// func NewHandlerWithDefault(root http.FileSystem, handler http.Handler, defaultPath string, gatewayDomains []string) http.Handler {
+// 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		if isGatewayRequest(r) {
+// 			// s3 signed request reaching the ui handler, return an error response instead of the default path
+// 			o := operations.Operation{}
+// 			err := errors.Codes[errors.ERRLakeFSWrongEndpoint]
+// 			err.Description = fmt.Sprintf("%s (%v)", err.Description, gatewayDomains)
+// 			o.EncodeError(w, r, err)
+// 			return
+// 		}
+// 		urlPath := r.URL.Path
+// 		// We want this rule to only fire when urlPath does not have
+// 		// a slash in front. This if condition ensures there is a slash,
+// 		// so the line marked 'ok' below should not fire.
+// 		if !strings.HasPrefix(urlPath, "/") {
+// 			urlPath = "/" + urlPath
+// 			r.URL.Path = urlPath
+// 		}
+// 		// ok: filepath-clean-misuse
+// 		_, err := root.Open(path.Clean(urlPath))
+// 		if err != nil && os.IsNotExist(err) {
+// 			r.URL.Path = defaultPath
+// 		}
+// 		// consistent content-type
+// 		contentType := gomime.TypeByExtension(filepath.Ext(r.URL.Path))
+// 		if contentType != "" {
+// 			w.Header().Set("Content-Type", contentType)
+// 		}
+// 		handler.ServeHTTP(w, r)
+// 	})
+// }

--- a/go/lang/security/filepath-clean-misuse.go
+++ b/go/lang/security/filepath-clean-misuse.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"path/filepath"
+	"path"
+	"strings"
+)
+
+const root = "/tmp"
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/bad1", func(w http.ResponseWriter, r *http.Request) {
+		// ruleid: filepath-clean-misuse
+		filename := filepath.Clean(r.URL.Path)
+		filename := filepath.Join(root, strings.Trim(filename, "/"))
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write(contents)
+	})
+
+	mux.HandleFunc("/bad2", func(w http.ResponseWriter, r *http.Request) {
+		// ruleid: filepath-clean-misuse
+		filename := path.Clean(r.URL.Path)
+		filename := filepath.Join(root, strings.Trim(filename, "/"))
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write(contents)
+	})
+
+	mux.HandleFunc("/ok", func(w http.ResponseWriter, r *http.Request) {
+		filename := r.URL.Path
+		// ok: filepath-clean-misuse
+		filename := filepath.Join(root, strings.Trim(filename, "/"))
+		contents, err := ioutil.ReadFile(filename)
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Write(contents)
+	})
+
+	server := &http.Server{
+		Addr:    "127.0.0.1:50000",
+		Handler: mux,
+	}
+
+	log.Fatal(server.ListenAndServe())
+}

--- a/go/lang/security/filepath-clean-misuse.yaml
+++ b/go/lang/security/filepath-clean-misuse.yaml
@@ -5,9 +5,9 @@ rules:
     This function is for finding the shortest path name equivalent to the given input.
     Using `Clean` to sanitize file reads may expose this application to
     path traversal attacks, where an attacker could access arbitrary files on the server.
-    To fix this easily, prepend a slash ("/") at the beginning of the input, like this:
-    `Clean("/"+...)`. However, a better solution is using the `SecureJoin` function
-    in the package `filepath-securejoin`. See https://pkg.go.dev/github.com/cyphar/filepath-securejoin#section-readme.
+    To fix this easily, write this: `filepath.FromSlash(path.Clean("/"+strings.Trim(req.URL.Path, "/")))`
+    However, a better solution is using the `SecureJoin` function in the package `filepath-securejoin`.
+    See https://pkg.go.dev/github.com/cyphar/filepath-securejoin#section-readme.
   severity: ERROR
   languages: [go]
   mode: taint
@@ -29,6 +29,7 @@ rules:
     - https://pkg.go.dev/path#Clean
     - http://technosophos.com/2016/03/31/go-quickly-cleaning-filepaths.html
     - https://labs.detectify.com/2021/12/15/zero-day-path-traversal-grafana/
+    - https://dzx.cz/2021/04/02/go_path_traversal/
     - https://pkg.go.dev/github.com/cyphar/filepath-securejoin#section-readme
     cwe: 'CWE-22: Path Traversal'
     owasp:

--- a/go/lang/security/filepath-clean-misuse.yaml
+++ b/go/lang/security/filepath-clean-misuse.yaml
@@ -16,3 +16,15 @@ rules:
   - pattern-either:
     - pattern: filepath.Clean(...)
     - pattern: path.Clean(...)
+  metadata:
+    references:
+    - https://pkg.go.dev/path#Clean
+    - http://technosophos.com/2016/03/31/go-quickly-cleaning-filepaths.html
+    - https://labs.detectify.com/2021/12/15/zero-day-path-traversal-grafana/
+    cwe: 'CWE-22: Path Traversal'
+    owasp:
+    - 'A03:2021 - Injection'
+    - 'A01:2017 - Injection'
+    category: security
+    technology:
+    - go

--- a/go/lang/security/filepath-clean-misuse.yaml
+++ b/go/lang/security/filepath-clean-misuse.yaml
@@ -6,7 +6,8 @@ rules:
     Using `Clean` to sanitize file reads may expose this application to
     path traversal attacks, where an attacker could access arbitrary files on the server.
     To fix this easily, prepend a slash ("/") at the beginning of the input, like this:
-    `Clean("/"+...)`. However, a better solution is 
+    `Clean("/"+...)`. However, a better solution is using the `SecureJoin` function
+    in the package `filepath-securejoin`. See https://pkg.go.dev/github.com/cyphar/filepath-securejoin#section-readme.
   severity: ERROR
   languages: [go]
   mode: taint
@@ -28,6 +29,7 @@ rules:
     - https://pkg.go.dev/path#Clean
     - http://technosophos.com/2016/03/31/go-quickly-cleaning-filepaths.html
     - https://labs.detectify.com/2021/12/15/zero-day-path-traversal-grafana/
+    - https://pkg.go.dev/github.com/cyphar/filepath-securejoin#section-readme
     cwe: 'CWE-22: Path Traversal'
     owasp:
     - 'A03:2021 - Injection'

--- a/go/lang/security/filepath-clean-misuse.yaml
+++ b/go/lang/security/filepath-clean-misuse.yaml
@@ -11,11 +11,18 @@ rules:
   languages: [go]
   mode: taint
   pattern-sources:
-  - pattern: "($REQUEST : *http.Request).$ANYTHING"
-  pattern-sinks:
   - pattern-either:
-    - pattern: filepath.Clean(...)
-    - pattern: path.Clean(...)
+    - pattern: "($REQUEST : *http.Request).$ANYTHING"
+    - pattern: "($REQUEST : http.Request).$ANYTHING"
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: filepath.Clean(...)
+      - pattern: path.Clean(...)
+  pattern-sanitizers:
+  - pattern-either:
+    - pattern: |
+        "/" + ...
   metadata:
     references:
     - https://pkg.go.dev/path#Clean

--- a/go/lang/security/filepath-clean-misuse.yaml
+++ b/go/lang/security/filepath-clean-misuse.yaml
@@ -1,0 +1,18 @@
+rules:
+- id: filepath-clean-misuse
+  message: >-
+    `Clean` is not intended to sanitize against path traversal attacks.
+    This function is for finding the shortest path name equivalent to the given input.
+    Using `Clean` to sanitize file reads may expose this application to
+    path traversal attacks, where an attacker could access arbitrary files on the server.
+    To fix this easily, prepend a slash ("/") at the beginning of the input, like this:
+    `Clean("/"+...)`. However, a better solution is 
+  severity: ERROR
+  languages: [go]
+  mode: taint
+  pattern-sources:
+  - pattern: "($REQUEST : *http.Request).$ANYTHING"
+  pattern-sinks:
+  - pattern-either:
+    - pattern: filepath.Clean(...)
+    - pattern: path.Clean(...)


### PR DESCRIPTION
Rule checking for misuse of `path.Clean` and `filepath.Clean`.
Inspired by [CVE-2021-43798](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-43798)
References:
- https://twitter.com/TomNomNom/status/1468521389623808002?s=20
- https://labs.detectify.com/2021/12/15/zero-day-path-traversal-grafana/