### PR TITLE
xpath and path traversal rules

### DIFF
--- a/java/lang/security/audit/tainted-xpath-from-http-request.java
+++ b/java/lang/security/audit/tainted-xpath-from-http-request.java
@@ -1,0 +1,252 @@
+/**
+ * OWASP Benchmark Project v1.2
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project. For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Nick Sanidas
+ * @created 2015
+ */
+package org.owasp.benchmark.testcode;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(value = "/xpathi-00/BenchmarkTest00207")
+public class BenchmarkTest00207 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        if (request.getHeader("BenchmarkTest00207") != null) {
+            param = request.getHeader("BenchmarkTest00207");
+        }
+
+        // URL Decode the header value since req.getHeader() doesn't. Unlike req.getParameter().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        String bar = "";
+        if (param != null) {
+            bar =
+                    new String(
+                            org.apache.commons.codec.binary.Base64.decodeBase64(
+                                    org.apache.commons.codec.binary.Base64.encodeBase64(
+                                            param.getBytes())));
+        }
+
+        try {
+            java.io.FileInputStream file =
+                    new java.io.FileInputStream(
+                            org.owasp.benchmark.helpers.Utils.getFileFromClasspath(
+                                    "employees.xml", this.getClass().getClassLoader()));
+            javax.xml.parsers.DocumentBuilderFactory builderFactory =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance();
+            // Prevent XXE
+            builderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            javax.xml.parsers.DocumentBuilder builder = builderFactory.newDocumentBuilder();
+            org.w3c.dom.Document xmlDocument = builder.parse(file);
+            javax.xml.xpath.XPathFactory xpf = javax.xml.xpath.XPathFactory.newInstance();
+            javax.xml.xpath.XPath xp = xpf.newXPath();
+
+            String expression = "/Employees/Employee[@emplid='" + bar + "']";
+            // ruleid: tainted-xpath-from-http-request
+            String result = xp.evaluate(expression, xmlDocument);
+
+            response.getWriter().println("Your query results are: " + result + "<br/>");
+
+        } catch (javax.xml.xpath.XPathExpressionException
+                | javax.xml.parsers.ParserConfigurationException
+                | org.xml.sax.SAXException e) {
+            response.getWriter()
+                    .println(
+                            "Error parsing XPath input: '"
+                                    + org.owasp.esapi.ESAPI.encoder().encodeForHTML(bar)
+                                    + "'");
+            throw new ServletException(e);
+        }
+    }
+}
+
+@WebServlet(value = "/xpathi-00/BenchmarkTest01223")
+public class BenchmarkTest01223 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        java.util.Enumeration<String> headers = request.getHeaders("BenchmarkTest01223");
+
+        if (headers != null && headers.hasMoreElements()) {
+            param = headers.nextElement(); // just grab first element
+        }
+
+        // URL Decode the header value since req.getHeaders() doesn't. Unlike req.getParameters().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        String bar = new Test().doSomething(request, param);
+
+        try {
+            java.io.FileInputStream file =
+                    new java.io.FileInputStream(
+                            org.owasp.benchmark.helpers.Utils.getFileFromClasspath(
+                                    "employees.xml", this.getClass().getClassLoader()));
+            javax.xml.parsers.DocumentBuilderFactory builderFactory =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance();
+            // Prevent XXE
+            builderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            javax.xml.parsers.DocumentBuilder builder = builderFactory.newDocumentBuilder();
+            org.w3c.dom.Document xmlDocument = builder.parse(file);
+            javax.xml.xpath.XPathFactory xpf = javax.xml.xpath.XPathFactory.newInstance();
+            javax.xml.xpath.XPath xp = xpf.newXPath();
+
+            String expression = "/Employees/Employee[@emplid='" + bar + "']";
+            // ruleid: tainted-xpath-from-http-request
+            org.w3c.dom.NodeList nodeList = (org.w3c.dom.NodeList) xp.compile(expression).evaluate(xmlDocument, javax.xml.xpath.XPathConstants.NODESET);
+
+            response.getWriter().println("Your query results are: <br/>");
+
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                org.w3c.dom.Element value = (org.w3c.dom.Element) nodeList.item(i);
+                response.getWriter().println(value.getTextContent() + "<br/>");
+            }
+        } catch (javax.xml.xpath.XPathExpressionException
+                | javax.xml.parsers.ParserConfigurationException
+                | org.xml.sax.SAXException e) {
+            response.getWriter()
+                    .println(
+                            "Error parsing XPath input: '"
+                                    + org.owasp.esapi.ESAPI.encoder().encodeForHTML(bar)
+                                    + "'");
+            throw new ServletException(e);
+        }
+    } // end doPost
+
+    private class Test {
+
+        public String doSomething(HttpServletRequest request, String param)
+                throws ServletException, IOException {
+
+            String bar;
+            String guess = "ABC";
+            char switchTarget = guess.charAt(2);
+
+            // Simple case statement that assigns param to bar on conditions 'A', 'C', or 'D'
+            switch (switchTarget) {
+                case 'A':
+                    bar = param;
+                    break;
+                case 'B':
+                    bar = "bobs_your_uncle";
+                    break;
+                case 'C':
+                case 'D':
+                    bar = param;
+                    break;
+                default:
+                    bar = "bobs_your_uncle";
+                    break;
+            }
+
+            return bar;
+        }
+    } // end innerclass Test
+} // end DataflowThruInnerClass
+
+@WebServlet(value = "/xpathi-00/BenchmarkTest00207")
+public class BenchmarkTest00207 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+
+        String param = "";
+        if (request.getHeader("BenchmarkTest00207") != null) {
+            param = request.getHeader("BenchmarkTest00207");
+        }
+
+        // URL Decode the header value since req.getHeader() doesn't. Unlike req.getParameter().
+        param = java.net.URLDecoder.decode(param, "UTF-8");
+
+        String bar = "";
+        if (param != null) {
+            bar =
+                    new String(
+                            org.apache.commons.codec.binary.Base64.decodeBase64(
+                                    org.apache.commons.codec.binary.Base64.encodeBase64(
+                                            param.getBytes())));
+        }
+
+        try {
+            java.io.FileInputStream file =
+                    new java.io.FileInputStream(
+                            org.owasp.benchmark.helpers.Utils.getFileFromClasspath(
+                                    "employees.xml", this.getClass().getClassLoader()));
+            javax.xml.parsers.DocumentBuilderFactory builderFactory =
+                    javax.xml.parsers.DocumentBuilderFactory.newInstance();
+            // Prevent XXE
+            builderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            javax.xml.parsers.DocumentBuilder builder = builderFactory.newDocumentBuilder();
+            org.w3c.dom.Document xmlDocument = builder.parse(file);
+            javax.xml.xpath.XPathFactory xpf = javax.xml.xpath.XPathFactory.newInstance();
+            javax.xml.xpath.XPath xp = xpf.newXPath();
+
+            String expression = "/Employees/Employee[@emplid='1234']";
+            // ok: tainted-xpath-from-http-request
+            String result = xp.evaluate(expression, xmlDocument);
+
+            response.getWriter().println("Your query results are: " + result + "<br/>");
+
+        } catch (javax.xml.xpath.XPathExpressionException
+                | javax.xml.parsers.ParserConfigurationException
+                | org.xml.sax.SAXException e) {
+            response.getWriter()
+                    .println(
+                            "Error parsing XPath input: '"
+                                    + org.owasp.esapi.ESAPI.encoder().encodeForHTML(bar)
+                                    + "'");
+            throw new ServletException(e);
+        }
+    }
+}

--- a/java/lang/security/audit/tainted-xpath-from-http-request.yaml
+++ b/java/lang/security/audit/tainted-xpath-from-http-request.yaml
@@ -1,0 +1,27 @@
+rules:
+  - id: tainted-xpath-from-http-request 
+    message: >-
+      Detected input from a HTTPServletRequest going into a XPath evaluate or compile command. 
+      This could lead to xpath injection if variables passed into the evaluate or compile commands are not properly sanitized.
+      Xpath injection could lead to unauthorized access to sensitive information in XML documents.
+      Instead, thoroughly sanitize user input or use parameterized xpath queries if you can.
+    languages: [java]
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+    - patterns:
+      - pattern: |
+          (HttpServletRequest $REQ).$FUNC(...)
+    pattern-sinks:
+    - patterns:
+      - pattern-either:
+        - pattern: |
+            (javax.xml.xpath.XPath $XP).evaluate(...)
+        - pattern: |
+            (javax.xml.xpath.XPath $XP).compile(...).evaluate(...)
+    metadata:
+      category: security
+      technology:
+        - java
+      cwe: "CWE-643: Improper Neutralization of Data within XPath Expressions ('XPath Injection')"
+      owasp: "A01: Injection"

--- a/java/lang/security/httpservlet-path-traversal.java
+++ b/java/lang/security/httpservlet-path-traversal.java
@@ -19,8 +19,8 @@ public class Cls extends HttpServlet
     public void doPost(HttpServletRequest request, HttpServletResponse response)
     throws ServletException, IOException
     {
-        // ruleid:httpservlet-path-traversal
         String image = request.getParameter("image");
+        // ruleid:httpservlet-path-traversal
         File file = new File("static/images/", image);
 
         if (!file.exists()) {
@@ -46,3 +46,74 @@ public class Cls extends HttpServlet
         response.sendRedirect("/index.html");
     }
 }
+
+/**
+ * OWASP Benchmark v1.2
+ *
+ * <p>This file is part of the Open Web Application Security Project (OWASP) Benchmark Project. For
+ * details, please see <a
+ * href="https://owasp.org/www-project-benchmark/">https://owasp.org/www-project-benchmark/</a>.
+ *
+ * <p>The OWASP Benchmark is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU General Public License as published by the Free Software Foundation, version 2.
+ *
+ * <p>The OWASP Benchmark is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ * PURPOSE. See the GNU General Public License for more details.
+ *
+ * @author Dave Wichers
+ * @created 2015
+ */
+package org.owasp.benchmark.testcode;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet(value = "/pathtraver-00/BenchmarkTest00045")
+public class BenchmarkTest00045 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        // some code
+        response.setContentType("text/html;charset=UTF-8");
+
+        String[] values = request.getParameterValues("BenchmarkTest00045");
+        String param;
+        if (values != null && values.length > 0) param = values[0];
+        else param = "";
+
+        String fileName = org.owasp.benchmark.helpers.Utils.TESTFILES_DIR + param;
+
+        try (
+        // Create the file first so the test won't throw an exception if it doesn't exist.
+        // Note: Don't actually do this because this method signature could cause a tool to find
+        // THIS file constructor
+        // as a vuln, rather than the File signature we are trying to actually test.
+        // If necessary, just run the benchmark twice. The 1st run should create all the necessary
+        // files.
+        // new java.io.File(org.owasp.benchmark.helpers.Utils.TESTFILES_DIR +
+        // param).createNewFile();
+
+        // ruleid: httpservlet-path-traversal
+        java.io.FileOutputStream fos = new java.io.FileOutputStream(new java.io.FileInputStream(fileName).getFD()); ) {
+            response.getWriter()
+                    .println(
+                            "Now ready to write to file: "
+                                    + org.owasp.esapi.ESAPI.encoder().encodeForHTML(fileName));
+
+        } catch (Exception e) {
+            System.out.println("Couldn't open FileOutputStream on file: '" + fileName + "'");
+        }

--- a/java/lang/security/httpservlet-path-traversal.yaml
+++ b/java/lang/security/httpservlet-path-traversal.yaml
@@ -16,20 +16,38 @@ rules:
       variables in file paths are sanitized. You may also consider using a utility
       method such as org.apache.commons.io.FilenameUtils.getName(...) to only
       retrieve the file name from the path.
-    patterns:
-      - pattern-inside: |
-          $RETURNTYPE $FUNC (..., HttpServletRequest $REQ, ...) {
-            ...
-          }
+    mode: taint
+    pattern-sources:
+    - patterns: 
+      - pattern-either: 
+        - pattern: |
+            (HttpServletRequest $REQ)
+        - patterns: # this pattern is a hack to get the rule to recognize `map` as tainted source when `map = cookie.getValue(user_input)` is used.
+          - pattern-inside: |
+              (javax.servlet.http.Cookie[] $COOKIES) = (HttpServletRequest $REQ).getCookies(...);
+              ...
+              for (javax.servlet.http.Cookie $COOKIE: $COOKIES) {
+                ...
+              }
+          - pattern: |
+              $COOKIE.getValue(...)
+        - patterns: # use this pattern to catch cases where tainted array values are assigned to a variable (not caught by taint)
+          - pattern-inside: |
+              $TYPE[] $VALS = (HttpServletRequest $REQ).$GETFUNC(...);
+              ...
+          - pattern: |
+              $PARAM = $VALS[$INDEX];
+    pattern-sanitizers:
+    - pattern: org.apache.commons.io.FilenameUtils.getName(...)
+    pattern-sinks:
+    - patterns:
       - pattern-either:
-          - pattern: |
-              $VAR = ($TYPE)$REQ.getParameter(...);
-              ...
-              new File(..., $VAR, ...);
-          - pattern: |
-              $VAR = $REQ.getParameter(...);
-              ...
-              new File(..., $VAR, ...);
+        - pattern: |
+            (java.io.File $FILE) = ...
+        - pattern: |
+            (java.io.FileOutputStream $FOS) = ...
+        - pattern: |
+            new java.io.FileInputStream(...)
     severity: ERROR
     languages:
       - java


### PR DESCRIPTION
improves the path traversal rule (changes it to taint mode) and creates xpath rule for OWASP java benchmark -- this improves the score from: 
* 0%-> 12% for path traversal
* 0% -> 40% for xpath

_To test:_
Run `semgrep --test .` on the `java/lang/security` folder and check that all tests pass.

Run 
`semgrep -f ~/Desktop/semgrep_repos/semgrep-rules/java/lang/security/audit --json > results/Benchmark_1.2-semgrep.json`
`createScorecards.sh`

and check the scorecards for the benchmark.