### PR TITLE
Add tracing rules for ASP web configs

### DIFF
--- a/csharp/dotnet/security/net-webconfig-trace-enabled.web.config
+++ b/csharp/dotnet/security/net-webconfig-trace-enabled.web.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <system.web>
+    <compilation
+      defaultLanguage="c#"
+      debug="true"
+    />
+    # ruleid: net-webconfig-trace-enabled
+    <trace enabled="true" requestLimit="10" pageOutput="false" traceMode="SortByTime" localOnly="true"/>
+  </system.web>
+</configuration>
+
+<configuration>
+  <system.web>
+    # ok: net-webconfig-trace-enabled
+    <compilation
+      defaultLanguage="c#"
+    />
+  </system.web>
+</configuration>
+
+<configuration>
+  <system.web>
+    <compilation
+      defaultLanguage="c#"
+    />
+    # ok: net-webconfig-trace-enabled
+    <trace enabled="false" requestLimit="10" pageOutput="false" traceMode="SortByTime" localOnly="true"/>
+  </system.web>
+</configuration>

--- a/csharp/dotnet/security/net-webconfig-trace-enabled.yaml
+++ b/csharp/dotnet/security/net-webconfig-trace-enabled.yaml
@@ -1,0 +1,26 @@
+rules:
+- id: net-webconfig-trace-enabled
+  patterns:
+  - pattern: |
+      <trace ... enabled = "true" ... />
+  - pattern-inside: |
+      <system.web>
+        ...
+      </system.web>
+  message: >-
+    OWASP guidance recommends disabling tracing for production applications to prevent accidental leakage of sensitive application information.
+  languages: [generic]
+  severity: WARNING
+  paths:
+    include:
+      - "*web.config*"
+  metadata: 
+    category: security
+    cwe: "CWE-1323: Improper Management of Sensitive Trace Data"
+    owasp: 'A5: Security Misconfiguration'
+    technology:
+      - .net
+    confidence: HIGH
+    references:
+      - https://cheatsheetseries.owasp.org/cheatsheets/DotNet_Security_Cheat_Sheet.html#asp-net-web-forms-guidance
+      - https://msdn.microsoft.com/en-us/library/e8z01xdh.aspx


### PR DESCRIPTION
see https://cheatsheetseries.owasp.org/cheatsheets/DotNet_Security_Cheat_Sheet.html#asp-net-web-forms-guidance.

Used existing debug build rules as a template: 
https://github.com/returntocorp/semgrep-rules/compare/kb/asp-web-config-trace