### PR TITLE
standard lib XML parser XXE rules

### DIFF
--- a/csharp/lang/security/xxe/xmldocument-unsafe-parser-override.cs
+++ b/csharp/lang/security/xxe/xmldocument-unsafe-parser-override.cs
@@ -1,0 +1,21 @@
+public void LoadBad(string input)
+{
+  string fileName = @"C:\Users\user\Documents\test.xml";
+  XmlDocument xmlDoc = new XmlDocument();
+  xmlDoc.XmlResolver = new XmlUrlResolver();
+  // ruleid: xmldocument-unsafe-parser-override
+  xmlDoc.Load(input);
+  Console.WriteLine(xmlDoc.InnerText);
+
+    Console.ReadLine();
+}
+
+public void LoadBad(string input)
+{
+  XmlDocument xmlDoc = new XmlDocument();
+  // ok: xmldocument-unsafe-parser-override
+  xmlDoc.Load(input);
+  Console.WriteLine(xmlDoc.InnerText);
+
+    Console.ReadLine();
+}

--- a/csharp/lang/security/xxe/xmldocument-unsafe-parser-override.cs
+++ b/csharp/lang/security/xxe/xmldocument-unsafe-parser-override.cs
@@ -1,21 +1,35 @@
-public void LoadBad(string input)
-{
-  string fileName = @"C:\Users\user\Documents\test.xml";
-  XmlDocument xmlDoc = new XmlDocument();
-  xmlDoc.XmlResolver = new XmlUrlResolver();
-  // ruleid: xmldocument-unsafe-parser-override
-  xmlDoc.Load(input);
-  Console.WriteLine(xmlDoc.InnerText);
+public class Foo{
+    public void LoadBad(string input)
+    {
+        string fileName = @"C:\Users\user\Documents\test.xml";
+        XmlDocument xmlDoc = new XmlDocument();
+        xmlDoc.XmlResolver = new XmlUrlResolver();
+        // ruleid: xmldocument-unsafe-parser-override
+        xmlDoc.Load(input);
+        Console.WriteLine(xmlDoc.InnerText);
 
-    Console.ReadLine();
-}
+        Console.ReadLine();
+    }
 
-public void LoadBad(string input)
-{
-  XmlDocument xmlDoc = new XmlDocument();
-  // ok: xmldocument-unsafe-parser-override
-  xmlDoc.Load(input);
-  Console.WriteLine(xmlDoc.InnerText);
+    public static void StaticLoadBad(string input)
+    {
+        string fileName = @"C:\Users\user\Documents\test.xml";
+        XmlDocument xmlDoc = new XmlDocument();
+        xmlDoc.XmlResolver = new XmlUrlResolver();
+        // ruleid: xmldocument-unsafe-parser-override
+        xmlDoc.Load(input);
+        Console.WriteLine(xmlDoc.InnerText);
 
-    Console.ReadLine();
+        Console.ReadLine();
+    }
+    
+    public void LoadGood(string input)
+    {
+        XmlDocument xmlDoc = new XmlDocument();
+        // ok: xmldocument-unsafe-parser-override
+        xmlDoc.Load(input);
+        Console.WriteLine(xmlDoc.InnerText);
+
+        Console.ReadLine();
+    }
 }

--- a/csharp/lang/security/xxe/xmldocument-unsafe-parser-override.yaml
+++ b/csharp/lang/security/xxe/xmldocument-unsafe-parser-override.yaml
@@ -1,0 +1,38 @@
+rules:
+  - id: xmldocument-unsafe-parser-override
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $ARG
+          - pattern-inside: |
+              public $T $M(...,string $ARG,...){...}
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              $XMLDOCUMENT.$METHOD(...)
+          - pattern-inside: |
+              XmlDocument $XMLDOCUMENT = new XmlDocument(...);
+              ...
+              $XMLDOCUMENT.XmlResolver = new XmlUrlResolver(...);
+              ...  
+    message: XmlReaderSettings found with DtdProcessing.Parse on an XmlReader
+      handling a string argument from a public method.  Enabling Document Type
+      Definition (DTD) parsing may cause XML External Entity (XXE) injection if
+      supplied with user-controllable data.
+    languages:
+      - csharp
+    severity: WARNING
+    metadata:
+      category: security
+      license: MIT
+      references:
+        - https://www.jardinesoftware.net/2016/05/26/xxe-and-net/
+        - https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmldocument.xmlresolver?view=net-6.0#remarks
+      technology:
+        - .net
+        - xml
+      cwe:
+        - "CWE-611: Improper Restriction of XML External Entity Reference"
+      owasp:
+        - A04:2017 - XML External Entities (XXE)
+        - A05:2021 - Security Misconfiguration

--- a/csharp/lang/security/xxe/xmlreadersettings-unsafe-parser-override.cs
+++ b/csharp/lang/security/xxe/xmlreadersettings-unsafe-parser-override.cs
@@ -1,0 +1,102 @@
+public void ParseBad(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    // ruleid:xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(input),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+
+public void ParseBad2(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    // ruleid:xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(input,rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+
+public void ParseBad3(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    using(var reader = new StringReader(input)){
+        // ruleid:xmlreadersettings-unsafe-parser-override
+        XmlReader myReader = XmlReader.Create(reader,rs);
+                
+        while (myReader.Read())
+        {
+            Console.WriteLine(myReader.Value);
+        }
+        Console.ReadLine();
+    }
+}
+
+public void ParseGood(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Ignore;
+
+    // ok: xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(input),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+
+public void ParseGood2(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    // pre-override, not broken
+    // ok: xmlreadersettings-unsafe-parser-override
+    using(var reader = new StringReader(input,rs)){
+        XmlReader myReader = XmlReader.Create(reader);
+                
+        while (myReader.Read())
+        {
+            Console.WriteLine(myReader.Value);
+        }
+        Console.ReadLine();
+    }
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    // post-override, not providing reader settings, not broken
+    // ok: xmlreadersettings-unsafe-parser-override
+    using(var reader = new StringReader(input)){
+        XmlReader myReader = XmlReader.Create(reader);
+                
+        while (myReader.Read())
+        {
+            Console.WriteLine(myReader.Value);
+        }
+        Console.ReadLine();
+    }
+}
+public void ParseGood3(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    // ok: xmlreadersettings-unsafe-parser-override
+    var something = input;
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    var notInput = someSafeLoad();
+    // ok: xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(notInput),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+

--- a/csharp/lang/security/xxe/xmlreadersettings-unsafe-parser-override.cs
+++ b/csharp/lang/security/xxe/xmlreadersettings-unsafe-parser-override.cs
@@ -12,6 +12,20 @@ public void ParseBad(string input){
     Console.ReadLine();
 }
 
+public static void StaticParseBad(string input){
+    XmlReaderSettings rs = new XmlReaderSettings();
+    rs.DtdProcessing = DtdProcessing.Parse;
+
+    // ruleid:xmlreadersettings-unsafe-parser-override
+    XmlReader myReader = XmlReader.Create(new StringReader(input),rs);
+            
+    while (myReader.Read())
+    {
+        Console.WriteLine(myReader.Value);
+    }
+    Console.ReadLine();
+}
+
 public void ParseBad2(string input){
     XmlReaderSettings rs = new XmlReaderSettings();
     rs.DtdProcessing = DtdProcessing.Parse;

--- a/csharp/lang/security/xxe/xmlreadersettings-unsafe-parser-override.yaml
+++ b/csharp/lang/security/xxe/xmlreadersettings-unsafe-parser-override.yaml
@@ -1,0 +1,38 @@
+rules:
+  - id: xmlreadersettings-unsafe-parser-override
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $ARG
+          - pattern-inside: |
+              public $T $M(...,string $ARG,...){...}
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              XmlReader $READER = XmlReader.Create(...,$RS,...);
+          - pattern-inside: |
+              XmlReaderSettings $RS = new XmlReaderSettings();
+              ...
+              $RS.DtdProcessing = DtdProcessing.Parse;
+              ...        
+    message: XmlReaderSettings found with DtdProcessing.Parse on an XmlReader
+      handling a string argument from a public method.  Enabling Document Type
+      Definition (DTD) parsing may cause XML External Entity (XXE) injection if
+      supplied with user-controllable data.
+    languages:
+      - csharp
+    severity: WARNING
+    metadata:
+      category: security
+      license: MIT
+      references:
+        - https://www.jardinesoftware.net/2016/05/26/xxe-and-net/
+        - https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmldocument.xmlresolver?view=net-6.0#remarks
+      technology:
+        - .net
+        - xml
+      cwe:
+        - "CWE-611: Improper Restriction of XML External Entity Reference"
+      owasp:
+        - A04:2017 - XML External Entities (XXE)
+        - A05:2021 - Security Misconfiguration

--- a/csharp/lang/security/xxe/xmltextreader-unsafe-defaults.cs
+++ b/csharp/lang/security/xxe/xmltextreader-unsafe-defaults.cs
@@ -1,0 +1,35 @@
+namespace SomeNamespace{
+    public class Foo{
+        public void ReaderBad(string userInput)
+        {
+            XmlTextReader myReader = new XmlTextReader(new StringReader(userInput));
+
+            // ruleid: xmltextreader-unsafe-defaults
+            while (myReader.Read())
+            {
+                if (myReader.NodeType == XmlNodeType.Element)
+                {
+                    // ruleid: xmltextreader-unsafe-defaults
+                    Console.WriteLine(myReader.ReadElementContentAsString());
+                }
+            }
+            Console.ReadLine();
+        }
+
+        public void ReaderGood(string userInput)
+        {
+            XmlTextReader myReader = new XmlTextReader(new StringReader(userInput));
+            myReader.DtdProcessing = DtdProcessing.Prohibit;
+            // ok: xmltextreader-unsafe-defaults
+            while (myReader.Read())
+            {
+                if (myReader.NodeType == XmlNodeType.Element)
+                {
+                    // ok: xmltextreader-unsafe-defaults
+                    Console.WriteLine(myReader.ReadElementContentAsString());
+                }
+            }
+            Console.ReadLine();
+        }
+    }
+}

--- a/csharp/lang/security/xxe/xmltextreader-unsafe-defaults.cs
+++ b/csharp/lang/security/xxe/xmltextreader-unsafe-defaults.cs
@@ -16,6 +16,22 @@ namespace SomeNamespace{
             Console.ReadLine();
         }
 
+        public static void StaticReaderBad(string userInput)
+        {
+            XmlTextReader myReader = new XmlTextReader(new StringReader(userInput));
+
+            // ruleid: xmltextreader-unsafe-defaults
+            while (myReader.Read())
+            {
+                if (myReader.NodeType == XmlNodeType.Element)
+                {
+                    // ruleid: xmltextreader-unsafe-defaults
+                    Console.WriteLine(myReader.ReadElementContentAsString());
+                }
+            }
+            Console.ReadLine();
+        }
+
         public void ReaderGood(string userInput)
         {
             XmlTextReader myReader = new XmlTextReader(new StringReader(userInput));

--- a/csharp/lang/security/xxe/xmltextreader-unsafe-defaults.yaml
+++ b/csharp/lang/security/xxe/xmltextreader-unsafe-defaults.yaml
@@ -1,0 +1,39 @@
+rules:
+  - id: xmltextreader-unsafe-defaults
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $ARG
+          - pattern-inside: |
+              public $T $M(...,string $ARG,...){...}
+    pattern-sinks:
+      - patterns:
+          - pattern: |
+              $READER.$METHOD(...)
+          - pattern-not-inside: |
+              $READER.DtdProcessing = DtdProcessing.Prohibit;
+              ...
+          - pattern-inside: |
+              XmlTextReader $READER = new XmlTextReader(...);
+              ...
+    message: XmlReaderSettings found with DtdProcessing.Parse on an XmlReader
+      handling a string argument from a public method.  Enabling Document Type
+      Definition (DTD) parsing may cause XML External Entity (XXE) injection if
+      supplied with user-controllable data.
+    languages:
+      - csharp
+    severity: WARNING
+    metadata:
+      category: security
+      license: MIT
+      references:
+        - https://www.jardinesoftware.net/2016/05/26/xxe-and-net/
+        - https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmldocument.xmlresolver?view=net-6.0#remarks
+      technology:
+        - .net
+        - xml
+      cwe:
+        - "CWE-611: Improper Restriction of XML External Entity Reference"
+      owasp:
+        - A04:2017 - XML External Entities (XXE)
+        - A05:2021 - Security Misconfiguration


### PR DESCRIPTION
reference: https://www.jardinesoftware.net/2016/05/26/xxe-and-net/

Rules for the "big 3" .NET parsers:

- `XmlTextReader`
- `XmlReaderSettings` as related to `XmlReader`
- `XmlDocument`