### PR TITLE
add basic path traversal rules for Path.Combine

### DIFF
--- a/csharp/lang/security/filesystem/unsafe-path-combine.cs
+++ b/csharp/lang/security/filesystem/unsafe-path-combine.cs
@@ -47,4 +47,14 @@ public class Foo{
         string filepath = Path.Combine("\\FILESHARE\images", filename); 
         return File.ReadAllBytes(filepath);
     }
+
+    public static bytes[] GetFileSafe3(string filename) { 
+        // Ensure that all path elements are safe path elements. 
+        if (string.IsNullOrEmpty(filename)) 
+        {   
+            throw new ArgumentNullException("error"); 
+        }
+        // ok: unsafe-path-combine
+        string filepath = Path.Combine("\\FILESHARE\images", Path.GetFileName(filename)); 
+        
 }	

--- a/csharp/lang/security/filesystem/unsafe-path-combine.cs
+++ b/csharp/lang/security/filesystem/unsafe-path-combine.cs
@@ -1,0 +1,50 @@
+public class Foo{
+
+    public static bytes[] GetFileBad(string filename) { 
+        // Ensure that all path elements are safe path elements. 
+        if (string.IsNullOrEmpty(filename)) 
+        {   
+            throw new ArgumentNullException("error"); 
+        }
+        // ruleid: unsafe-path-combine
+        string filepath = Path.Combine("\\FILESHARE\images", filename); 
+        return File.ReadAllBytes(filepath);
+    }
+
+    public static bytes[] GetFileBad(string filename) { 
+        // Ensure that all path elements are safe path elements. 
+        if (string.IsNullOrEmpty(filename)) 
+        {   
+            throw new ArgumentNullException("error"); 
+        }
+        string otherPath = Path.GetFileName(filename);
+        // ruleid: unsafe-path-combine
+        string filepath = Path.Combine("\\FILESHARE\images", filename); 
+        // ok: unsafe-path-combine
+        string safePath = Path.Combine("\\FILESHARE\images",otherPath);
+        return File.ReadAllBytes(filepath);
+    }
+
+    public static bytes[] GetFileSafe(string filename) { 
+        // Ensure that all path elements are safe path elements. 
+        if (string.IsNullOrEmpty(filename)) 
+        {   
+            throw new ArgumentNullException("error"); 
+        }
+        filename = Path.GetFileName(filename);
+        // ok: unsafe-path-combine
+        string filepath = Path.Combine("\\FILESHARE\images", filename); 
+        return File.ReadAllBytes(filepath);
+    }
+
+    public static bytes[] GetFileSafe2(string filename) { 
+        // Ensure that all path elements are safe path elements. 
+        if (string.IsNullOrEmpty(filename) || Path.GetFileName(filename) != filename) 
+        {   
+            throw new ArgumentNullException("error"); 
+        }
+        // ok: unsafe-path-combine
+        string filepath = Path.Combine("\\FILESHARE\images", filename); 
+        return File.ReadAllBytes(filepath);
+    }
+}	

--- a/csharp/lang/security/filesystem/unsafe-path-combine.yaml
+++ b/csharp/lang/security/filesystem/unsafe-path-combine.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: unsafe-path-combine
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $ARG
+          - pattern-inside: |
+                public $T $M(...,string $ARG,...){...}
+    pattern-sinks:
+      - patterns: 
+        - pattern: $ARG
+        - pattern-inside: |
+            Path.Combine(...)
+    pattern-sanitizers:
+      - patterns:
+        - pattern: $ARG
+        - pattern-either:
+          - pattern-inside: |
+              $ARG = Path.GetFileName(...);
+              ...
+          - pattern-inside: |
+              <... Path.GetFileName(...) != $ARG ...>;
+              ...
+    message: String method argument $ARG passed to Path.Combine without sanitization.
+    languages:
+      - csharp
+    severity: WARNING
+    metadata:
+      category: security
+      license: MIT
+      references:
+        - https://www.praetorian.com/blog/pathcombine-security-issues-in-aspnet-applications/
+        - https://docs.microsoft.com/en-us/dotnet/api/system.io.path.combine?view=net-6.0#remarks
+      technology:
+        - .net
+      cwe:
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+      owasp:
+        - A05:2017 - Broken Access Control
+        - A01:2021 - Broken Access Control 

--- a/csharp/lang/security/filesystem/unsafe-path-combine.yaml
+++ b/csharp/lang/security/filesystem/unsafe-path-combine.yaml
@@ -11,6 +11,8 @@ rules:
         - pattern: $ARG
         - pattern-inside: |
             Path.Combine(...)
+        - pattern-not-inside: |
+            Path.Combine(...,Path.GetFileName(...),...)
     pattern-sanitizers:
       - patterns:
         - pattern: $ARG
@@ -21,7 +23,7 @@ rules:
           - pattern-inside: |
               <... Path.GetFileName(...) != $ARG ...>;
               ...
-    message: String method argument $ARG passed to Path.Combine without sanitization.
+    message: String method argument $ARG passed to Path.Combine without sanitization via Path.GetFileName.  If user-supplied data is supplied this can lead to path traversal.
     languages:
       - csharp
     severity: WARNING


### PR DESCRIPTION
taint rule for public method string arguments passed to `Path.Combine` without either overwriting with `Path.GetFileName` or comparison of `Path.GetFileName` with the original string.