### PR TITLE
Fix confusion between ruby and rails

### DIFF
--- a/ruby/lang/security/file-disclosure.yaml
+++ b/ruby/lang/security/file-disclosure.yaml
@@ -2,7 +2,7 @@ rules:
   - id: file-disclosure
     message: >-
       Special requests can determine whether a file exists on a filesystem that's outside
-      the Ruby app's
+      the Rails app's
       root directory. To fix this, set config.serve_static_assets = false.
     metadata:
       references:

--- a/ruby/lang/security/json-encoding.yaml
+++ b/ruby/lang/security/json-encoding.yaml
@@ -4,7 +4,7 @@ rules:
       When a 'Hash' with user-supplied input is encoded in JSPN, Rails doesn't provide
       adequate escaping.
       If the JSON string is supplied into HTML, the page will be vulnerable to XXS attacks.
-      The affected ruby versions are 3.0.x, 3.1.x, 3.2.x, 4.1.x, 4.2.x.
+      The affected Rails versions are 3.0.x, 3.1.x, 3.2.x, 4.1.x, 4.2.x.
       To fix, either upgrade or add an initializer.
     metadata:
       references:

--- a/ruby/lang/security/model-attributes-attr-accessible.yaml
+++ b/ruby/lang/security/model-attributes-attr-accessible.yaml
@@ -20,7 +20,7 @@ rules:
       of which variables can be manipulated
       through mass assignment. For newer Rails applications, parameters should be allowlisted
       using strong parameters.
-      For older Ruby versions, they should be allowlisted using strong_attributes.
+      For older Rails versions, they should be allowlisted using strong_attributes.
     metadata:
       references:
         - https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_model_attributes.rb

--- a/ruby/lang/security/model-attributes-attr-protected.yaml
+++ b/ruby/lang/security/model-attributes-attr-protected.yaml
@@ -4,7 +4,7 @@ rules:
       Checks for models that use attr_protected, as use of allowlist instead of denylist
       is better practice.
       Attr_protected was also found to be vulnerable to bypass. The fixed versions of
-      Ruby are: 3.2.12, 3.1.11, 2.3.17.
+      Rails are: 3.2.12, 3.1.11, 2.3.17.
       To prevent bypass, use attr_accessible instead.
     metadata:
       references:

--- a/ruby/lang/security/nested-attributes.yaml
+++ b/ruby/lang/security/nested-attributes.yaml
@@ -4,8 +4,8 @@ rules:
       Checks for models that enable nested attributes. A vulnerability in nested_attributes_for
       results in an attacker
       begin able to change parameters apart from the ones intended by the developer.
-      Affected Ruby versions: 3.0.0, 2.3.9.
-      Fix: don't use accepts_nested_attributes_for or upgrade Ruby version.
+      Affected Rails versions: 3.0.0, 2.3.9.
+      Fix: don't use accepts_nested_attributes_for or upgrade Rails version.
     metadata:
       references:
         - https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_nested_attributes.rb


### PR DESCRIPTION
In some documents, the In some documents, the word "ruby" was used when it should have been "rails".