### PR TITLE
Note that strcpy_s is an optional part of C11

### DIFF
--- a/c/lang/security/insecure-use-string-copy-fn.yaml
+++ b/c/lang/security/insecure-use-string-copy-fn.yaml
@@ -5,11 +5,12 @@ rules:
       - pattern: strncpy(...)
     message: >-
       Finding triggers whenever there is a strcpy or strncpy used.
-      This is an issue because strcpy does not affirm the size of the destination array 
-      and strncpy will not automatically NULL-terminate strings. 
-      This can lead to buffer overflows, which can cause program crashes 
+      This is an issue because strcpy does not affirm the size of the destination array
+      and strncpy will not automatically NULL-terminate strings.
+      This can lead to buffer overflows, which can cause program crashes
       and potentially let an attacker inject code in the program.
-      Fix this by using strcpy_s instead.
+      Fix this by using strcpy_s instead (although note that strcpy_s is an
+      optional part of the C11 standard, and so may not be available).
     metadata:
       references:
         - https://cwe.mitre.org/data/definitions/676


### PR DESCRIPTION
See https://stackoverflow.com/questions/57915149/using-c11-standard-with-clang-for-use-of-strcpy-s