### PR TITLE
fix(py-check): update log credential pattern

### DIFF
--- a/python/lang/security/audit/logging/logger-credential-leak.yaml
+++ b/python/lang/security/audit/logging/logger-credential-leak.yaml
@@ -2,13 +2,16 @@ rules:
   - id: python-logger-credential-disclosure
     patterns:
       - pattern: |
-          logger.$LOGGER_CALL($FORMAT_STRING,...)
+          $LOGGER_OBJ.$LOGGER_CALL($FORMAT_STRING,...)
+      - metavariable-regex:
+          metavariable: $LOGGER_OBJ
+          regex: (?i)(_logger|logger|self.logger|log)
       - metavariable-regex:
           metavariable: $LOGGER_CALL
-          regex: (info|error|exception)
+          regex: (debug|info|warn|warning|error|exception|critical)
       - metavariable-regex:
           metavariable: $FORMAT_STRING
-          regex: (?i).*(api.key|secret|credential|token).*\%s.*
+          regex: (?i).*(api.key|secret|credential|token|password).*\%s.*
     message: >-
       Logger call may be exposing a secret credential in $FORMAT_STRING
     severity: WARNING


### PR DESCRIPTION
Updating the credential exposure check in logs for all the levels of Python logging with all the possible object of logging object a developer would use in production.