### PR TITLE
Add tainted-html-response rule for AWS Lambda

### DIFF
--- a/javascript/aws-lambda/security/tainted-html-response.js
+++ b/javascript/aws-lambda/security/tainted-html-response.js
@@ -1,13 +1,19 @@
 exports.handler = function (event, context) {
     const html = `<div>${event.name}</div>`;
 
+    const someRandomStuff = {
+        // ok: tainted-html-response
+        data: event.foo
+    }
+    bar(someRandomStuff)
+
     const response = {
         statusCode: 200,
+        // ruleid: tainted-html-response
+        body: html,
         headers: {
             'Content-Type': 'text/html',
-        },
-        // ruleid: tainted-html-response
-        body: html
+        }
     };
 
     return response

--- a/javascript/aws-lambda/security/tainted-html-response.js
+++ b/javascript/aws-lambda/security/tainted-html-response.js
@@ -1,0 +1,14 @@
+exports.handler = function (event, context) {
+    const html = `<div>${event.name}</div>`;
+
+    const response = {
+        statusCode: 200,
+        headers: {
+            'Content-Type': 'text/html',
+        },
+        // ruleid: tainted-html-response
+        body: html
+    };
+
+    return response
+}

--- a/javascript/aws-lambda/security/tainted-html-response.yaml
+++ b/javascript/aws-lambda/security/tainted-html-response.yaml
@@ -1,0 +1,34 @@
+rules:
+- id: tainted-html-response
+  severity: WARNING
+  message: >-
+    Detected user input flowing into a manually constructed HTML string. You may be
+    accidentally bypassing secure methods
+    of rendering HTML by manually constructing HTML and this could create a cross-site
+    scripting vulnerability, which could
+    let attackers steal sensitive user data.
+  languages:
+  - javascript
+  - typescript
+  mode: taint
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern-inside: |
+          exports.handler = function ($EVENT, ...) {
+            ...
+          }
+      - pattern-inside: |
+          function $FUNC ($EVENT, ...) {...}
+          ...
+          exports.handler = $FUNC
+      - pattern-inside: |
+          $FUNC = function ($EVENT, ...) {...}
+          ...
+          exports.handler = $FUNC
+    - pattern: $EVENT
+  pattern-sinks:
+  - patterns:
+    - pattern: $BODY
+    - pattern-inside: |
+        {..., headers: {..., 'Content-Type': 'text/html', ...}, body: $BODY, ... }

--- a/javascript/aws-lambda/security/tainted-html-response.yaml
+++ b/javascript/aws-lambda/security/tainted-html-response.yaml
@@ -2,11 +2,19 @@ rules:
 - id: tainted-html-response
   severity: WARNING
   message: >-
-    Detected user input flowing into a manually constructed HTML string. You may be
+    Detected user input flowing into an HTML response. You may be
     accidentally bypassing secure methods
     of rendering HTML by manually constructing HTML and this could create a cross-site
-    scripting vulnerability, which could
-    let attackers steal sensitive user data.
+    scripting vulnerability, which could let attackers steal sensitive user data.
+  metadata:
+    cwe:
+      "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+    owasp:
+      - A07:2017
+      - A03:2021
+    category: security
+    technology:
+      - aws-lambda
   languages:
   - javascript
   - typescript


### PR DESCRIPTION
if response is HTML content and it is tainted by `event` object it is likely an XSS