### PR TITLE
Add tainted-html-response rule for AWS Lambda (Python)

### DIFF
--- a/python/aws-lambda/security/tainted-html-response.py
+++ b/python/aws-lambda/security/tainted-html-response.py
@@ -1,0 +1,18 @@
+def lambda_handler(event, context):
+	html = f"<div>{event['input']}</div>"
+
+	foo = {
+		# ok: tainted-html-response
+		"data": event['foo']
+	}
+	bar(foo)
+
+	result = {
+		"statusCode": 200,
+		# ruleid: tainted-html-response
+		"body": html,
+		"headers": {
+			"Content-Type": "text/html"
+		}
+	}
+	return result

--- a/python/aws-lambda/security/tainted-html-response.yaml
+++ b/python/aws-lambda/security/tainted-html-response.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: tainted-html-response
+    mode: taint
+    pattern-sources:
+    - patterns:
+      - pattern: event
+      - pattern-inside: |
+          def $HANDLER(event, context):
+            ...
+    pattern-sinks:
+    - patterns:
+      - pattern: $BODY
+      - pattern-inside: |
+          {..., "headers": {..., "Content-Type": "text/html", ...}, "body": $BODY, ... }
+    message: >-
+      Detected user input flowing into an HTML response. You may be
+      accidentally bypassing secure methods
+      of rendering HTML by manually constructing HTML and this could create a cross-site
+      scripting vulnerability, which could let attackers steal sensitive user data.
+    metadata:
+      cwe:
+        "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
+      owasp:
+        - A07:2017
+        - A03:2021
+      category: security
+      technology:
+        - aws-lambda
+    languages:
+      - python
+    severity: WARNING


### PR DESCRIPTION
same as https://github.com/returntocorp/semgrep-rules/pull/1831 but for Python