### PR TITLE
Path Traversal rule improvements

### DIFF
--- a/csharp/lang/security/filesystem/unsafe-path-combine.cs
+++ b/csharp/lang/security/filesystem/unsafe-path-combine.cs
@@ -6,22 +6,8 @@ public class Foo{
         {   
             throw new ArgumentNullException("error"); 
         }
-        // ruleid: unsafe-path-combine
         string filepath = Path.Combine("\\FILESHARE\images", filename); 
-        return File.ReadAllBytes(filepath);
-    }
-
-    public static bytes[] GetFileBad(string filename) { 
-        // Ensure that all path elements are safe path elements. 
-        if (string.IsNullOrEmpty(filename)) 
-        {   
-            throw new ArgumentNullException("error"); 
-        }
-        string otherPath = Path.GetFileName(filename);
         // ruleid: unsafe-path-combine
-        string filepath = Path.Combine("\\FILESHARE\images", filename); 
-        // ok: unsafe-path-combine
-        string safePath = Path.Combine("\\FILESHARE\images",otherPath);
         return File.ReadAllBytes(filepath);
     }
 
@@ -43,8 +29,8 @@ public class Foo{
         {   
             throw new ArgumentNullException("error"); 
         }
-        // ok: unsafe-path-combine
         string filepath = Path.Combine("\\FILESHARE\images", filename); 
+        // ok: unsafe-path-combine
         return File.ReadAllBytes(filepath);
     }
 
@@ -56,5 +42,17 @@ public class Foo{
         }
         // ok: unsafe-path-combine
         string filepath = Path.Combine("\\FILESHARE\images", Path.GetFileName(filename)); 
-        
-}	
+    }
+
+    public static bytes[] GetFileSafe4(string filename) { 
+        // Ensure that all path elements are safe path elements. 
+        if (string.IsNullOrEmpty(filename)) 
+        {   
+            throw new ArgumentNullException("error"); 
+        }
+        string otherPath = Path.GetFileName(filename);
+        string safePath = Path.Combine("\\FILESHARE\images",otherPath);
+        // ok: unsafe-path-combine
+        return File.ReadAllBytes(safePath);
+    }    
+}

--- a/csharp/lang/security/filesystem/unsafe-path-combine.yaml
+++ b/csharp/lang/security/filesystem/unsafe-path-combine.yaml
@@ -3,27 +3,40 @@ rules:
     mode: taint
     pattern-sources:
       - patterns:
-          - pattern: $ARG
+          - pattern: $A
           - pattern-inside: |
-                public $T $M(...,string $ARG,...){...}
+              Path.Combine(...,$A,...)
+          - pattern-inside: |
+              public $TYPE $M(...,$A,...){...}
+          - pattern-not-inside: |
+              <... Path.GetFileName($A) != $A ...>
     pattern-sinks:
-      - patterns: 
-        - pattern: $ARG
-        - pattern-inside: |
-            Path.Combine(...)
-        - pattern-not-inside: |
-            Path.Combine(...,Path.GetFileName(...),...)
-    pattern-sanitizers:
       - patterns:
-        - pattern: $ARG
-        - pattern-either:
+          - pattern: $X
           - pattern-inside: |
-              $ARG = Path.GetFileName(...);
-              ...
+              File.$METHOD($X,...)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: (?i)^(read|write)
+    pattern-sanitizers:
+      - pattern: |
+          Path.GetFileName(...)
+      - patterns:
           - pattern-inside: |
-              <... Path.GetFileName(...) != $ARG ...>;
+              $X = Path.GetFileName(...);
               ...
-    message: String method argument $ARG passed to Path.Combine without sanitization via Path.GetFileName.  If user-supplied data is supplied this can lead to path traversal.
+          - pattern: $X
+      - patterns:
+          - pattern: $X
+          - pattern-inside: |
+              if(<... Path.GetFileName($X) != $X ...>){
+                ...
+                throw new $EXCEPTION(...);
+              }
+              ...
+    message: String argument $A is used to read or write data from a file via
+      Path.Combine without direct sanitization via Path.GetFileName. If the path is user-supplied
+      data this can lead to path traversal.
     languages:
       - csharp
     severity: WARNING
@@ -36,7 +49,8 @@ rules:
       technology:
         - .net
       cwe:
-        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory
+          ('Path Traversal')"
       owasp:
         - A05:2017 - Broken Access Control
-        - A01:2021 - Broken Access Control 
+        - A01:2021 - Broken Access Control


### PR DESCRIPTION
Changes:

- Test case facelifts (update ruleid markers, remove some odd/useless components and make methods check single TPs/TNs)
- Update taint to use function argument as source and `File.$METHOD` where `$METHOD` matches `(?i)(read|write)`

This is a straight improvement from the old path traversal rule and should perform better for end users.