### PR TITLE
Add websocket-missing-origin-check rule

### DIFF
--- a/go/gorilla/security/audit/websocket-missing-origin-check.go
+++ b/go/gorilla/security/audit/websocket-missing-origin-check.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+		return true
+	},
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+var upgrader2 = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+func handler_check_origin(w http.ResponseWriter, r *http.Request) {
+	// ok: websocket-missing-origin-check
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}
+
+func handler_check_origin2(w http.ResponseWriter, r *http.Request) {
+	upgrader2.CheckOrigin = func(r *http.Request) bool { return true }
+	// ok: websocket-missing-origin-check
+	conn, err := upgrader2.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}
+
+func handler_doesnt_check_origin(w http.ResponseWriter, r *http.Request) {
+	// ruleid: websocket-missing-origin-check
+	conn, err := upgrader2.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+}

--- a/go/gorilla/security/audit/websocket-missing-origin-check.yaml
+++ b/go/gorilla/security/audit/websocket-missing-origin-check.yaml
@@ -1,0 +1,30 @@
+rules:
+  - id: websocket-missing-origin-check
+    patterns:
+      - pattern-inside: |
+          import ("github.com/gorilla/websocket")
+          ...
+      - patterns:
+          - pattern-not-inside: |
+              $UPGRADER = websocket.Upgrader{..., CheckOrigin: $FN ,...}
+              ...
+          - pattern-not-inside: |
+              $UPGRADER.CheckOrigin = $FN2
+              ...
+          - pattern: |
+              $UPGRADER.Upgrade(...)
+    message: >-
+      The Origin header in the HTTP WebSocket handshake is used to guarantee that the
+      connection accepted by the WebSocket is from a trusted origin domain. Failure to enforce can
+      lead to Cross Site Request Forgery (CSRF). As per "gorilla/websocket" documentation: "A CheckOrigin 
+      function should carefully validate the request origin to prevent cross-site request forgery."
+    languages: [go]
+    severity: WARNING
+    metadata:
+      category: security
+      cwe: "CWE-352: Cross-Site Request Forgery (CSRF)"
+      references:
+        - https://pkg.go.dev/github.com/gorilla/websocket#Upgrader
+      technology:
+        - gorilla
+      confidence: MEDIUM

--- a/go/gorilla/security/audit/websocket-missing-origin-check.yaml
+++ b/go/gorilla/security/audit/websocket-missing-origin-check.yaml
@@ -23,6 +23,8 @@ rules:
     metadata:
       category: security
       cwe: "CWE-352: Cross-Site Request Forgery (CSRF)"
+      owasp:
+      - 'A05:2021 - Security Misconfiguration'
       references:
         - https://pkg.go.dev/github.com/gorilla/websocket#Upgrader
       technology:


### PR DESCRIPTION
Verify that "CheckOrigin" function is defined in order to avoid CSRF attacks when using websockets.
Thanks to @minusworld for the help!