### PR TITLE
Unquoted csv writer fix

### DIFF
--- a/python/lang/security/unquoted-csv-writer.py
+++ b/python/lang/security/unquoted-csv-writer.py
@@ -4,3 +4,4 @@ import csv
 csv.writer(csvfile, delimiter=',', quotechar='"')
 # ok:unquoted-csv-writer
 csv.writer(csvfile, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL)
+csv.writer(csvfile, delimiter=',', quotechar='"', quoting=1)

--- a/python/lang/security/unquoted-csv-writer.yaml
+++ b/python/lang/security/unquoted-csv-writer.yaml
@@ -2,6 +2,7 @@ rules:
   - id: unquoted-csv-writer
     patterns:
       - pattern-not: csv.writer(..., quoting=csv.QUOTE_ALL, ...)
+      - pattern-not: csv.writer(..., quoting=1, ...)
       - pattern: csv.writer(...)
     message: Found an unquoted CSV writer. This is susceptible to injection. Use 'quoting=csv.QUOTE_ALL'.
     metadata:


### PR DESCRIPTION
Running on my code, I encountered an FP missing the keyword argument quoting getting the value 1, equivalent to csv.QUOTE_ALL 