### PR TITLE
Add tainted-slick-sqli rule

### DIFF
--- a/scala/play/security/tainted-slick-sqli.scala
+++ b/scala/play/security/tainted-slick-sqli.scala
@@ -1,0 +1,54 @@
+package controllers
+
+import play.api.mvc._
+import javax.inject._
+import slick.jdbc.H2Profile.api._
+import models.UserModel
+
+@Singleton
+class HomeController @Inject()(val controllerComponents: ControllerComponents) extends BaseController{
+  val db = Database.forConfig("h2mem1")
+
+  def oneAction() = Action { implicit request: Request[AnyContent] =>
+    val bodyVals = request.body.asFormUrlEncoded
+    val smth = bodyVals.get("username").head
+    // ruleid: tainted-slick-sqli
+    val action = sql"select ID, NAME, AGE from #$smth".as[(Int,String,Int)]
+    db.run(action)
+    Ok("ok")
+  }
+
+  def twoAction(name: String) = Action { implicit request: Request[AnyContent] =>
+    val people = TableQuery[People]
+
+    // ruleid: tainted-slick-sqli
+    people.map(p => (p.id,p.name,p.age)).result.overrideSql(s"SELECT id, name, age FROM Person WHERE $name")
+
+    Ok("ok")
+  }
+
+  def helloWorldPage() = Action { implicit request: Request[AnyContent] =>
+    // ok: tainted-slick-sqli
+    Ok(views.html.helloWorld())
+  }
+
+  def okAction1() = Action { implicit request: Request[AnyContent] =>
+    val smth = "hardcoded_value"
+    // ok: tainted-slick-sqli
+    val action = sql"select ID, NAME, AGE from #$smth".as[(Int,String,Int)]
+    db.run(action)
+    Ok("ok")
+  }
+
+  def okAction2(name: String) = Action { implicit request: Request[AnyContent] =>
+    val people = TableQuery[People]
+
+    people.map(p => (p.id,p.name,p.age))
+      .result
+      // ok: tainted-slick-sqli
+      .overrideSql(s"SELECT id, name, age FROM Person WHERE name = 'FooBar'")
+
+    Ok("ok")
+  }
+
+}

--- a/scala/play/security/tainted-slick-sqli.yaml
+++ b/scala/play/security/tainted-slick-sqli.yaml
@@ -1,0 +1,45 @@
+rules:
+- id: tainted-slick-sqli
+  mode: taint
+  metadata:
+    references:
+    - https://scala-slick.org/doc/3.3.3/sql.html#splicing-literal-values
+    - https://scala-slick.org/doc/3.2.0/sql-to-slick.html#non-optimal-sql-code
+    category: security
+    cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+    owasp: "A1: Injection"
+    technology:
+    - scala
+    - slick
+    - play
+  message: >-
+    Detected a tainted SQL statement. This could lead to SQL
+    injection if variables in the SQL statement are not properly sanitized.
+    Avoid using using user input for generating SQL strings.
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - patterns:
+        - pattern: request
+        - pattern-inside: |
+            Action {
+              request: Request[$T] => 
+                ...
+            }
+      - patterns:
+        - pattern: $PARAM
+        - pattern-inside: |
+            def $CTRL(..., $PARAM: $TYPE, ...) = Action {
+              ...
+            }
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: $MODEL.overrideSql(...)
+      - pattern: sql"..."
+    - pattern-inside: |
+        import slick.$DEPS
+        ...
+  severity: WARNING
+  languages:
+    - scala


### PR DESCRIPTION
Tainted version of `Slick` rules for Scala:
https://github.com/returntocorp/semgrep-rules/blob/develop/scala/slick/security/scala-slick-overrideSql-literal.yaml
https://github.com/returntocorp/semgrep-rules/blob/develop/scala/slick/security/scala-slick-sql-non-literal.yaml