### PR TITLE
add httponly audit rules for cookies 

### DIFF
--- a/csharp/dotnet/security/web-config-httponly-cookies-disabled.web.config
+++ b/csharp/dotnet/security/web-config-httponly-cookies-disabled.web.config
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.web>
+      // ok: web-config-httponly-cookies-disabled
+      <httpCookies httpOnlyCookies="true" requireSSL="true" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="dotnet" arguments=".\Microsoft.IIS.Administration.dll" forwardWindowsAuthToken="true" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" />
+    <security>
+      <authentication>
+        <windowsAuthentication enabled="true" />
+      </authentication>
+      <authorization>
+        <clear />
+        <add accessType="Allow" roles="Administrators,IIS Administrators" />
+      </authorization>
+    </security>
+  </system.webServer>
+  </location>
+</configuration>
+
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.web>
+      // ruleid: web-config-httponly-cookies-disabled
+      <httpCookies requireSSL="true" />
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="dotnet" arguments=".\Microsoft.IIS.Administration.dll" forwardWindowsAuthToken="true" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" />
+    <security>
+      <authentication mode="Forms">
+        <forms loginUrl="member_login.aspx"
+          cookieless="UseCookies"
+          // ruleid: web-config-insecure-cookie-settings
+          requireSSL="false"
+          path="/MyApplication" />
+      </authentication>
+      <authorization>
+        <clear />
+        <add accessType="Allow" roles="Administrators,IIS Administrators" />
+      </authorization>
+    </security>
+  </system.webServer>
+  </location>
+</configuration>
+
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.web>
+      // ruleid: web-config-httponly-cookies-disabled
+      <someSetting/>
+  </system.web>
+  <system.webServer>
+    <handlers>
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="dotnet" arguments=".\Microsoft.IIS.Administration.dll" forwardWindowsAuthToken="true" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" />
+    <security>
+      <authentication mode="Forms">
+        <forms loginUrl="member_login.aspx"
+          cookieless="UseCookies"
+          // ruleid: web-config-insecure-cookie-settings
+          requireSSL="false"
+          path="/MyApplication" />
+      </authentication>
+      <authorization>
+        <clear />
+        <add accessType="Allow" roles="Administrators,IIS Administrators" />
+      </authorization>
+    </security>
+  </system.webServer>
+  </location>
+</configuration>

--- a/csharp/dotnet/security/web-config-httponly-cookies-disabled.yaml
+++ b/csharp/dotnet/security/web-config-httponly-cookies-disabled.yaml
@@ -1,0 +1,40 @@
+rules:
+- id: web-config-httponly-cookies-disabled
+  patterns:
+    - pattern-either:
+      - pattern: |
+          httpOnlyCookies="false"
+      - pattern-not: |
+          httpOnlyCookies="true"
+    - pattern-either:
+        - pattern-inside: |
+            <httpCookies ...>
+        - pattern-not: |
+          <httpCookies ...>
+    - pattern-inside: |
+        <system.web>
+        ...
+        </system.web>
+  message: Cookie HTTPOnly flag is not set or explicitly disabled. You
+    should enforce this value to prevent script from reading sensitive cookie values.
+  languages:
+    - generic
+  severity: WARNING
+  paths:
+    include:
+      - "*web.config"
+  metadata:
+    category: security
+    license: MIT
+    references:
+      - https://docs.microsoft.com/en-us/aspnet/web-api/overview/advanced/http-cookies
+      - https://docs.microsoft.com/en-us/dotnet/api/system.web.security.formsauthentication.requiressl?redirectedfrom=MSDN&view=netframework-4.8#System_Web_Security_FormsAuthentication_RequireSSL
+      - https://docs.microsoft.com/en-us/dotnet/api/system.web.security.roles.cookierequiressl?redirectedfrom=MSDN&view=netframework-4.8#System_Web_Security_Roles_CookieRequireSSL
+    technology:
+      - .net
+      - asp
+      - webforms
+    cwe: "CWE-1004: Sensitive Cookie Without 'HttpOnly' Flag"
+    owasp:
+      - A06:2017 - Security Misconfiguration
+      - A05:2021 - Security Misconfiguration

--- a/csharp/dotnet/security/web-config-httponly-cookies-disabled.yaml
+++ b/csharp/dotnet/security/web-config-httponly-cookies-disabled.yaml
@@ -10,7 +10,7 @@ rules:
         - pattern-inside: |
             <httpCookies ...>
         - pattern-not: |
-          <httpCookies ...>
+            <httpCookies ...>
     - pattern-inside: |
         <system.web>
         ...


### PR DESCRIPTION
this will be noisy for most older ASP apps so it shouldn't be in CI rulepacks.

There is a Pumascan rule for this as well