### PR TITLE
add confidence - medium to unsafe-path-combine

### DIFF
--- a/csharp/lang/security/filesystem/unsafe-path-combine.yaml
+++ b/csharp/lang/security/filesystem/unsafe-path-combine.yaml
@@ -29,6 +29,7 @@ rules:
     severity: WARNING
     metadata:
       category: security
+      confidence: MEDIUM
       license: MIT
       references:
         - https://www.praetorian.com/blog/pathcombine-security-issues-in-aspnet-applications/


### PR DESCRIPTION
For client-side apps this rule is noisy.  Could use some user feedback on this rule.