### PR TITLE
adding metavariable-entropy to generic secrets rules

### DIFF
--- a/generic/secrets/security/detected-aws-account-id.txt
+++ b/generic/secrets/security/detected-aws-account-id.txt
@@ -3,3 +3,6 @@ aws_account_id = 123456789012
 
 # ruleid: detected-aws-account-id
 aws_account_id:123456789012
+
+# ok: detected-aws-account-id
+aws_account_id_fake:123456789012123

--- a/generic/secrets/security/detected-aws-account-id.txt
+++ b/generic/secrets/security/detected-aws-account-id.txt
@@ -4,5 +4,53 @@ aws_account_id = 123456789012
 # ruleid: detected-aws-account-id
 aws_account_id:123456789012
 
+{
+    "version": "0",
+    "id": "a76750eb-b69f-ae47-b183-4d3cb0700618",
+    "detail-type": "AWS API Call via CloudTrail",
+    "source": "aws.s3",
+    # ruleid: detected-aws-account-id
+    "account": "123456790012",
+    "time": "2018-05-22T12:44:24Z",
+    "region": "us-east-1",
+    "resources": [],
+    "detail": {
+       "eventVersion": "1.05",
+       "userIdentity": {},
+       "eventTime": "2018-05-22T12:44:24Z",
+       "eventSource": "s3.amazonaws.com",
+       "eventName": "DeleteBucket",
+       "awsRegion": "us-east-1",
+       "sourceIPAddress": "209.6.231.175",
+       "userAgent": "[S3Console/0.4, aws-internal/3]",
+       "requestParameters": {},
+       "responseElements": null,
+       "additionalEventData": {
+          "vpcEndpointId": "vpce-6d72a204"
+       },
+       "requestID": "51A7870C114C931C",
+       "eventID": "d687e2af-5a29-4acb-bc41-6892b36420bf",
+       "eventType": "AwsApiCall",
+       "vpcEndpointId": "vpce-6d72a204"
+    }
+}
+
+Mappings:
+  ElbService:
+    # https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#access-logging-bucket-permissions
+    us-east-1:
+      # ruleid: detected-aws-account-id
+      AccountId: "123456789012"
+
+# ruleid: detected-aws-account-id
+aws_account_id = "287139315271"
+
+aws s3api put-bucket-inventory-configuration \
+              --bucket my-bucket \
+              --id 2 \
+# ruleid: detected-aws-account-id
+              --inventory-configuration '{"Destination": { "S3BucketDestination": { "AccountId": "123456789012", "Bucket": "arn:aws:s3:::my-bucket", "Format": "CSV" }}, "IsEnabled": true, "Id": "2", "IncludedObjectVersions": "Current", "Schedule": { "Frequency": "Daily" }}'
+
+
 # ok: detected-aws-account-id
 aws_account_id_fake:123456789012123

--- a/generic/secrets/security/detected-aws-account-id.yaml
+++ b/generic/secrets/security/detected-aws-account-id.yaml
@@ -8,6 +8,18 @@ rules:
           $ACCOUNT_ID : $SECRET
       - pattern: |
           $ACCOUNT_ID => $SECRET
+      - pattern: |
+          $ACCOUNT_ID = "$SECRET"
+      - pattern: |
+          $ACCOUNT_ID : "$SECRET"
+      - pattern: |
+          $ACCOUNT_ID => "$SECRET"
+      - pattern: |
+          "$ACCOUNT_ID" = "$SECRET"
+      - pattern: |
+          "$ACCOUNT_ID" : "$SECRET"
+      - pattern: |
+          "$ACCOUNT_ID" => "$SECRET"
     - metavariable-analysis:
         metavariable: $SECRET
         analyzer: entropy

--- a/generic/secrets/security/detected-aws-account-id.yaml
+++ b/generic/secrets/security/detected-aws-account-id.yaml
@@ -1,8 +1,23 @@
 rules:
   - id: detected-aws-account-id
-    pattern-regex: |-
-      ("|')?(AWS|aws|Aws)?_?(ACCOUNT|account|Account)_?(ID|id|Id)?("|')?\s*(:|=>|=)\s*("|')?[0-9]{12}("|')?
-    languages: [regex]
+    patterns:
+    - pattern-either:
+      - pattern: |
+          $ACCOUNT_ID = $SECRET
+      - pattern: |
+          $ACCOUNT_ID : $SECRET
+      - pattern: |
+          $ACCOUNT_ID => $SECRET
+    - metavariable-analysis:
+        metavariable: $SECRET
+        analyzer: entropy
+    - metavariable-regex:
+        metavariable: $SECRET
+        regex: ^[0-9]{12}$
+    - metavariable-regex:
+        metavariable: $ACCOUNT_ID
+        regex: (AWS|aws|Aws)?_?(ACCOUNT|account|Account)_?(ID|id|Id)?("|')?
+    languages: [generic]
     message: AWS Account ID detected. This is a sensitive credential and should not be hardcoded here. Instead, read the value from an environment variable or keep the value in a separate, private file. 
     severity: ERROR
     metadata:

--- a/generic/secrets/security/detected-github-token.txt
+++ b/generic/secrets/security/detected-github-token.txt
@@ -3,3 +3,6 @@ GITHUB_TOKEN=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
 
 # ruleid: detected-github-token
 github_token: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
+
+# ok: detected-github-token
+gitfake_token:ghp_abababababababababababababababababab

--- a/generic/secrets/security/detected-github-token.txt
+++ b/generic/secrets/security/detected-github-token.txt
@@ -4,5 +4,11 @@ GITHUB_TOKEN=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
 # ruleid: detected-github-token
 github_token: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
 
+# ruleid: detected-github-token
+clone="git clone https://phaticusthiccy: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@github.com/phaticusthiccy/WhatsAsenaDuplicated"
+
+# ruleid: detected-github-token
+githubToken = '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'
+
 # ok: detected-github-token
 gitfake_token:ghp_abababababababababababababababababab

--- a/generic/secrets/security/detected-github-token.yaml
+++ b/generic/secrets/security/detected-github-token.yaml
@@ -32,13 +32,3 @@ rules:
         - secrets
         - github
       confidence: MEDIUM
-
-
-
-
-
-
-
-
-
-

--- a/generic/secrets/security/detected-github-token.yaml
+++ b/generic/secrets/security/detected-github-token.yaml
@@ -6,6 +6,16 @@ rules:
           $VAR = $SECRET
       - pattern: |
           $VAR: $SECRET
+      - pattern: |
+          $VAR = '$SECRET'
+      - pattern: |
+          $VAR: '$SECRET'
+      - pattern: |
+          '$VAR' = '$SECRET'
+      - pattern: |
+          '$VAR': '$SECRET'
+      - pattern: |
+          "[hH][tT][tT][pP][sS]?://.*$SECRET.*"
     - metavariable-regex:
         metavariable: $SECRET
         regex: gh[pousr]_[A-Za-z0-9_]{36,251}

--- a/generic/secrets/security/detected-github-token.yaml
+++ b/generic/secrets/security/detected-github-token.yaml
@@ -1,8 +1,18 @@
 rules:
   - id: detected-github-token
-    pattern-regex: |-
-      gh[pousr]_[A-Za-z0-9_]{36,251}
-    languages: [regex]
+    patterns:
+    - pattern-either:
+      - pattern: |
+          $VAR = $SECRET
+      - pattern: |
+          $VAR: $SECRET
+    - metavariable-regex:
+        metavariable: $SECRET
+        regex: gh[pousr]_[A-Za-z0-9_]{36,251}
+    - metavariable-analysis:
+        analyzer: entropy
+        metavariable: $SECRET
+    languages: [generic]
     message: GitHub Token detected
     severity: ERROR
     metadata:
@@ -12,3 +22,13 @@ rules:
         - secrets
         - github
       confidence: MEDIUM
+
+
+
+
+
+
+
+
+
+

--- a/generic/secrets/security/detected-private-key.txt
+++ b/generic/secrets/security/detected-private-key.txt
@@ -21,3 +21,7 @@ MIIEogIBAAKCAQEAjosMtDUqbE1/8zxZac1t8fkh2SxGuMXHk9yxniyM2m76donW
 # ruleid: detected-private-key
 -----BEGIN ENCRYPTED PRIVATE KEY-----
 MIIEogIBAAKCAQEAjosMtDUqbE1/8zxZac1t8fkh2SxGuMXHk9yxniyM2m76donW
+
+# ok: detected-private-key
+-----BEGIN ENCRYPTED PRIVATE KEY-----
+abababababababababababababababab

--- a/generic/secrets/security/detected-private-key.yaml
+++ b/generic/secrets/security/detected-private-key.yaml
@@ -1,7 +1,22 @@
 rules:
   - id: detected-private-key
-    pattern-regex: (?i)-{5}begin( [dr]sa| ec| openssh| encrypted)? private key-{5}
-    languages: [regex]
+    patterns:
+    - pattern-either:
+      - patterns:
+        - pattern:
+            -----BEGIN $TYPE PRIVATE KEY-----
+            $KEY
+        - metavariable-regex:
+            metavariable: $TYPE
+            regex: (?i)([dr]sa|ec|openssh|encrypted)?
+      - patterns:
+        - pattern: |
+            -----BEGIN PRIVATE KEY-----
+            $KEY
+    - metavariable-analysis:
+        metavariable: $KEY
+        analyzer: entropy
+    languages: [generic]
     message: Private Key detected. This is a sensitive credential and should not be hardcoded here. Instead, store this in a separate, private file.
     severity: ERROR
     metadata:


### PR DESCRIPTION
Adding these to some of the rules with a LOT of findings and large number of negative developer sentiment.

Refer to: https://docs.google.com/document/d/1Q8qCi6imMv_z__TUeRomEgRLsthOmsEw7uihSSrvyTI/edit?usp=sharing for the link to the analysis

To test:
Run `semgrep --test .` in the `generic/secrets/security` directory and check that all tests pass.