### PR TITLE
add scalac-debug rule

### DIFF
--- a/scala/lang/security/audit/scalac-debug.sbt
+++ b/scala/lang/security/audit/scalac-debug.sbt
@@ -1,0 +1,38 @@
+name := """seed1"""
+organization := "testing"
+
+version := "1.0-SNAPSHOT"
+
+lazy val root = (project in file(".")).enablePlugins(PlayScala)
+
+scalaVersion := "2.13.8"
+
+libraryDependencies += guice
+libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
+libraryDependencies += ws
+
+// ok: scalac-debug
+scalacOptions ++= Seq(
+  "-no-specialization"
+)
+
+// ruleid: scalac-debug
+scalacOptions ++= Seq(
+  "-encoding", "utf8", // Option and arguments on same line
+  "-Xfatal-warnings",  // New lines for each options
+  "-deprecation",
+  "-Vdebug",
+  "-language:implicitConversions",
+  "-language:higherKinds",
+  "-language:existentials",
+  "-language:postfixOps"
+)
+
+// ok: scalac-debug
+scalacOptions ++= Seq(
+  "-Xsource-reader", "CLASSNAME",
+  "-opt-inline-from", "PATTERNS1"
+)
+
+// ruleid: scalac-debug
+scalacOptions += "-Ydebug"

--- a/scala/lang/security/audit/scalac-debug.yaml
+++ b/scala/lang/security/audit/scalac-debug.yaml
@@ -4,7 +4,7 @@ rules:
   - pattern-either:
     - pattern: scalacOptions ... "-Vdebug"
     - pattern: scalacOptions ... "-Ydebug"
-  message: |
+  message: >-
     Scala applications built with `debug` set to true in production may leak debug information to attackers.
     Debug mode also affects performance and reliability.
     Remove it from configuration.

--- a/scala/lang/security/audit/scalac-debug.yaml
+++ b/scala/lang/security/audit/scalac-debug.yaml
@@ -1,0 +1,24 @@
+rules:
+- id: scalac-debug
+  patterns:
+  - pattern-either:
+    - pattern: scalacOptions ... "-Vdebug"
+    - pattern: scalacOptions ... "-Ydebug"
+  message: |
+    Scala applications built with `debug` set to true in production may leak debug information to attackers.
+    Debug mode also affects performance and reliability.
+    Remove it from configuration.
+  languages: [generic]
+  severity: WARNING
+  paths:
+    include:
+      - "*.sbt*"
+  metadata: 
+    category: security
+    cwe: "CWE-489: Active Debug Code"
+    owasp: 'A5: Security Misconfiguration'
+    technology:
+    - scala
+    - sbt
+    references:
+      - https://docs.scala-lang.org/overviews/compiler-options/index.html


### PR DESCRIPTION
"Creating Debug binary" bug,
Similar to this rule: https://github.com/returntocorp/semgrep-rules/blob/develop/csharp/dotnet/security/net-webconfig-debug.yaml but for Scala.
