### PR TITLE
Add parsing-external-entities-enabled rule

### DIFF
--- a/go/lang/security/audit/xxe/parsing-external-entities-enabled.go
+++ b/go/lang/security/audit/xxe/parsing-external-entities-enabled.go
@@ -1,0 +1,30 @@
+import (
+	"fmt"
+	"github.com/lestrrat-go/libxml2/parser"
+)
+
+func vuln() {
+	const s = "<!DOCTYPE d [<!ENTITY e SYSTEM \"file:///etc/passwd\">]><t>&e;</t>"
+	// ruleid: parsing-external-entities-enabled
+	p := parser.New(parser.XMLParseNoEnt)
+	doc, err := p.ParseString(s)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Doc successfully parsed!")
+	fmt.Println(doc)
+}
+
+func not_vuln() {
+	const s = "<!DOCTYPE d [<!ENTITY e SYSTEM \"file:///etc/passwd\">]><t>&e;</t>"
+	// ok: parsing-external-entities-enabled
+	p := parser.New()
+	doc, err := p.ParseString(s)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println("Doc successfully parsed!")
+	fmt.Println(doc)
+}

--- a/go/lang/security/audit/xxe/parsing-external-entities-enabled.yaml
+++ b/go/lang/security/audit/xxe/parsing-external-entities-enabled.yaml
@@ -1,0 +1,30 @@
+rules:
+  - id: parsing-external-entities-enabled
+    patterns:
+      - pattern-inside: |
+          import ("github.com/lestrrat-go/libxml2/parser")
+          ...
+      - pattern: $PARSER := parser.New(parser.XMLParseNoEnt)
+    message: >-
+      Even though Go ships with a native XML parser (encoding/xml) that can
+      be used for mere XML data parsing and manipulation, it does not support
+      advanced XML features like validation. Developers that use the native XML
+      solution should not usually concern themselves with any security aspects. If a
+      parser with more features is required, then developers must rely on
+      third-parties libraries, for example https://github.com/lestrrat-go/libxml2.
+      Parsing of external entities is disabled by default, and care must be taken to
+      avoid processing untrusted XML data when this option is enabled. Parsing of
+      external entities can be enabled with "XMLParseNoEnt" and can lead to XXE
+      vulnerability if user controlled data is parsed by the library.
+    languages:
+      - go
+    severity: WARNING
+    metadata:
+      category: security
+      cwe: "CWE-611: Improper Restriction of XML External Entity Reference"
+      owasp:
+        - "A05:2021 - Security Misconfiguration"
+      references:
+        - https://knowledge-base.secureflag.com/vulnerabilities/xml_injection/xml_entity_expansion_go_lang.html
+        - https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
+      confidence: MEDIUM

--- a/go/lang/security/audit/xxe/parsing-external-entities-enabled.yaml
+++ b/go/lang/security/audit/xxe/parsing-external-entities-enabled.yaml
@@ -27,4 +27,6 @@ rules:
       references:
         - https://knowledge-base.secureflag.com/vulnerabilities/xml_injection/xml_entity_expansion_go_lang.html
         - https://owasp.org/www-community/vulnerabilities/XML_External_Entity_(XXE)_Processing
+      technology:
+        - libxml2
       confidence: MEDIUM

--- a/go/lang/security/audit/xxe/parsing-external-entities-enabled.yaml
+++ b/go/lang/security/audit/xxe/parsing-external-entities-enabled.yaml
@@ -6,16 +6,10 @@ rules:
           ...
       - pattern: $PARSER := parser.New(parser.XMLParseNoEnt)
     message: >-
-      Even though Go ships with a native XML parser (encoding/xml) that can
-      be used for mere XML data parsing and manipulation, it does not support
-      advanced XML features like validation. Developers that use the native XML
-      solution should not usually concern themselves with any security aspects. If a
-      parser with more features is required, then developers must rely on
-      third-parties libraries, for example https://github.com/lestrrat-go/libxml2.
-      Parsing of external entities is disabled by default, and care must be taken to
-      avoid processing untrusted XML data when this option is enabled. Parsing of
-      external entities can be enabled with "XMLParseNoEnt" and can lead to XXE
-      vulnerability if user controlled data is parsed by the library.
+      Detected enabling of "XMLParseNoEnt", which allows parsing of 
+      external entities and can lead to XXE if user controlled data is parsed 
+      by the library. Instead, do not enable "XMLParseNoEnt" or be sure
+      to adequately sanitize user-controlled data when it is being parsed by this library.
     languages:
       - go
     severity: WARNING


### PR DESCRIPTION
When using [libxml2](https://github.com/lestrrat-go/libxml2) for advanced XML features (which are not supported in "encoding/xml") parsing user controlled input can lead to XXE.
Reference: 
- [https://knowledge-base.secureflag.com/vulnerabilities/xml_injection/xml_entity_expansion_go_lang.html](https://knowledge-base.secureflag.com/vulnerabilities/xml_injection/xml_entity_expansion_go_lang.html)