### PR TITLE
Filter request.user.id from django access-foreign-keys

### DIFF
--- a/python/django/performance/access-foreign-keys.py
+++ b/python/django/performance/access-foreign-keys.py
@@ -1,0 +1,10 @@
+from django.http import HttpResponse
+from models import User
+
+def cool_view(request):
+    # ok: access-foreign-keys
+    return HttpResponse({'user_id': request.user.id})
+
+def other():
+    # ruleid: access-foreign-keys
+    print(User.user.id)

--- a/python/django/performance/access-foreign-keys.yaml
+++ b/python/django/performance/access-foreign-keys.yaml
@@ -1,6 +1,8 @@
 rules:
   - id: access-foreign-keys
-    pattern: $X.user.id
+    patterns:
+    - pattern: $X.user.id
+    - pattern-not: request.user.id
     message: You should use ITEM.user_id rather than ITEM.user.id to prevent running an extra query.
     languages: [python]
     severity: WARNING

--- a/python/django/performance/access-foreign-keys.yaml
+++ b/python/django/performance/access-foreign-keys.yaml
@@ -1,6 +1,13 @@
 rules:
   - id: access-foreign-keys
     patterns:
+    - pattern-either:
+      - pattern-inside: |
+          from django.$Y import $Z
+          ...
+      - pattern-inside: |
+          import django
+          ...
     - pattern: $X.user.id
     - pattern-not: request.user.id
     message: You should use ITEM.user_id rather than ITEM.user.id to prevent running an extra query.


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep-rules/issues/1644