### PR TITLE
Tainted SQL String rules for Scala

### DIFF
--- a/scala/lang/security/audit/tainted-sql-string.scala
+++ b/scala/lang/security/audit/tainted-sql-string.scala
@@ -40,7 +40,7 @@ object Smth {
   }
 
   def call5(name: String) = {
-    // todoruleid: tainted-sql-string
+    // ruleid: tainted-sql-string
     val sql = s"SELECT * FROM table WHERE name = ${name + "smth"};"
     val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
     val stmt = conn.createStatement()

--- a/scala/lang/security/audit/tainted-sql-string.scala
+++ b/scala/lang/security/audit/tainted-sql-string.scala
@@ -1,0 +1,77 @@
+package com.test.test
+
+import java.sql.{Connection, ResultSet, DriverManager}
+
+object Smth {
+
+  def call1(name: String) = {
+    // ruleid: tainted-sql-string
+    val sql = "SELECT * FROM table WHERE name = " + name + ";"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    rs
+  }
+
+  def call2(name: String) = {
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    // ruleid: tainted-sql-string
+    val rs = stmt.execute(s"SELECT * FROM table WHERE name = $name;")
+    rs
+  }
+
+  def call3(name: String) = {
+    // ruleid: tainted-sql-string
+    val sql = f"SELECT * FROM table WHERE name = $name%s;"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    rs
+  }
+
+  def call4(name: String) = {
+    // ruleid: tainted-sql-string
+    val sql = s"SELECT * FROM table WHERE name = ${name};"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    rs
+  }
+
+  def call5(name: String) = {
+    // todoruleid: tainted-sql-string
+    val sql = s"SELECT * FROM table WHERE name = ${name + "smth"};"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    rs
+  }
+
+  def okCall1(name: String) = {
+    val foobar = getFoobarFromEnv()
+    // ok: tainted-sql-string
+    val sql = "SELECT * FROM table WHERE name = " + foobar + ";"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    rs
+  }
+
+  def okCall2(name: String) = {
+    val foobar = "Foobar"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    // ok: tainted-sql-string
+    val rs = stmt.execute(s"SELECT * FROM table WHERE name = $foobar;")
+    rs
+  }
+
+  def okCall3(name: String) = {
+    // ok: tainted-sql-string
+    println("SELECT * FROM table WHERE name = " + name + ";")
+    doSmth(name)
+  }
+
+
+}

--- a/scala/lang/security/audit/tainted-sql-string.yaml
+++ b/scala/lang/security/audit/tainted-sql-string.yaml
@@ -59,7 +59,9 @@ rules:
               metavariable: $SQLSTR
               regex: (?i)(select|delete|insert|create|update|alter|drop)\b
         - patterns:
-          - pattern: s"..."
+          - pattern-either:
+            - pattern: s"..."
+            - pattern: f"..."
           - pattern-regex: |
               .*\b(?i)(select|delete|insert|create|update|alter|drop)\b.*
       - pattern-not-inside: println(...)

--- a/scala/lang/security/audit/tainted-sql-string.yaml
+++ b/scala/lang/security/audit/tainted-sql-string.yaml
@@ -1,0 +1,65 @@
+rules:
+  - id: tainted-sql-string
+    languages: [scala]
+    severity: ERROR
+    mode: taint
+    message: >-
+      User data flows into this manually-constructed SQL string. User data
+      can be safely inserted into SQL strings using prepared statements or an
+      object-relational mapper (ORM). Manually-constructed SQL strings is a
+      possible indicator of SQL injection, which could let an attacker steal or
+      manipulate data from the database. Instead, use prepared statements
+      (`connection.PreparedStatement`) or a safe library.
+    metadata:
+      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      owasp:
+        - A03:2021
+        - A01:2017
+      references:
+        - https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html
+      category: security
+      technology:
+      - scala
+    pattern-sources:
+    - patterns:
+      - pattern: $PARAM
+      - pattern-either:
+        - pattern-inside: |
+            def $CTRL(..., $PARAM: $TYPE, ...) = {
+              ...
+            }
+        - pattern-inside: |
+            def $CTRL(..., $PARAM: $TYPE, ...) = $A {
+              ...
+            }
+        - pattern-inside: |
+            def $CTRL(..., $PARAM: $TYPE, ...) = $A(...) {
+              ...
+            }
+    pattern-sinks:
+    - patterns:
+      - pattern-either:
+        - patterns:
+          - pattern-either:
+            - pattern: |
+                "$SQLSTR" + ...
+            - pattern: |
+                "$SQLSTR".format(...)
+            - patterns:
+              - pattern-inside: |
+                  $SB = new StringBuilder("$SQLSTR");
+                  ...
+              - pattern: $SB.append(...)
+            - patterns:
+              - pattern-inside: |
+                  $VAR = "$SQLSTR"
+                  ...
+              - pattern: $VAR += ...
+          - metavariable-regex:
+              metavariable: $SQLSTR
+              regex: (?i)(select|delete|insert|create|update|alter|drop)\b
+        - patterns:
+          - pattern: s"..."
+          - pattern-regex: |
+              .*\b(?i)(select|delete|insert|create|update|alter|drop)\b.*
+      - pattern-not-inside: println(...)

--- a/scala/play/security/tainted-sql-from-http-request.scala
+++ b/scala/play/security/tainted-sql-from-http-request.scala
@@ -1,0 +1,61 @@
+package controllers
+
+import play.api.mvc._
+import javax.inject._
+import java.sql.{Connection, ResultSet, DriverManager}
+
+@Singleton
+class HomeController @Inject()(val controllerComponents: ControllerComponents) extends BaseController{
+
+  def oneAction() = Action { implicit request: Request[AnyContent] =>
+    val bodyVals = request.body.asFormUrlEncoded
+    val name = bodyVals.get("username").head
+    // ruleid: tainted-sql-from-http-request
+    val sql = "SELECT * FROM table WHERE name = " + name + ";"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    Ok(rs.first())
+  }
+
+  def twoAction() = Action { implicit request: Request[AnyContent] =>
+    val bodyVals = request.body.asFormUrlEncoded
+    val name = bodyVals.get("username").head
+    // ruleid: tainted-sql-from-http-request
+    val sql = "SELECT * FROM table WHERE name = " + name + ";"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    Ok(rs.first())
+  }
+
+  def threeAction() = Action { implicit request: Request[AnyContent] =>
+    val bodyVals = request.body.asFormUrlEncoded
+    val name = bodyVals.get("username").head
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    // ruleid: tainted-sql-from-http-request
+    val rs = stmt.execute(s"SELECT * FROM table WHERE name = $name;")
+    Ok(rs.first())
+  }
+
+  def okAction1() = Action { implicit request: Request[AnyContent] =>
+    val name = "hardcoded_value"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    // ok: tainted-sql-from-http-request
+    val rs = stmt.execute(s"SELECT * FROM table WHERE name = $name;")
+    Ok(rs.first())
+  }
+
+  def okAction2(name: String) = Action { implicit request: Request[AnyContent] =>
+    val name = "value"
+    // ok: tainted-sql-from-http-request
+    val sql = "SELECT * FROM table WHERE name = " + name + ";"
+    val conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password")
+    val stmt = conn.createStatement()
+    val rs = stmt.execute(sql)
+    Ok(rs.first())
+  }
+
+}

--- a/scala/play/security/tainted-sql-from-http-request.yaml
+++ b/scala/play/security/tainted-sql-from-http-request.yaml
@@ -1,0 +1,95 @@
+rules:
+  - id: tainted-sql-from-http-request
+    languages: [scala]
+    severity: ERROR
+    mode: taint
+    message: >-
+      User data flows into this manually-constructed SQL string. User data
+      can be safely inserted into SQL strings using prepared statements or an
+      object-relational mapper (ORM). Manually-constructed SQL strings is a
+      possible indicator of SQL injection, which could let an attacker steal or
+      manipulate data from the database. Instead, use prepared statements
+      (`connection.PreparedStatement`) or a safe library.
+    metadata:
+      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      owasp:
+        - A03:2021
+        - A01:2017
+      references:
+        - https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html
+      category: security
+      technology:
+      - scala
+      - play
+    pattern-sources:
+    - patterns:
+      - pattern-either:
+        - patterns:
+          - pattern: $REQ
+          - pattern-either:
+            - pattern-inside: |
+                Action {
+                  $REQ: Request[$T] => 
+                    ...
+                }
+            - pattern-inside: |
+                Action(...) {
+                  $REQ: Request[$T] => 
+                    ...
+                }
+            - pattern-inside: |
+                Action.async {
+                  $REQ: Request[$T] => 
+                    ...
+                }
+            - pattern-inside: |
+                Action.async(...) {
+                  $REQ: Request[$T] => 
+                    ...
+                }
+        - patterns:
+          - pattern: $PARAM
+          - pattern-either:
+            - pattern-inside: |
+                def $CTRL(..., $PARAM: $TYPE, ...) = Action {
+                  ...
+                }
+            - pattern-inside: |
+                def $CTRL(..., $PARAM: $TYPE, ...) = Action(...) {
+                  ...
+                }
+            - pattern-inside: |
+                def $CTRL(..., $PARAM: $TYPE, ...) = Action.async {
+                  ...
+                }
+            - pattern-inside: |
+                def $CTRL(..., $PARAM: $TYPE, ...) = Action.async(...) {
+                  ...
+                }
+    pattern-sinks:
+    - patterns:
+      - pattern-either:
+        - patterns:
+          - pattern-either:
+            - pattern: |
+                "$SQLSTR" + ...
+            - pattern: |
+                "$SQLSTR".format(...)
+            - patterns:
+              - pattern-inside: |
+                  $SB = new StringBuilder("$SQLSTR");
+                  ...
+              - pattern: $SB.append(...)
+            - patterns:
+              - pattern-inside: |
+                  $VAR = "$SQLSTR"
+                  ...
+              - pattern: $VAR += ...
+          - metavariable-regex:
+              metavariable: $SQLSTR
+              regex: (?i)(select|delete|insert|create|update|alter|drop)\b
+        - patterns:
+          - pattern: s"..."
+          - pattern-regex: |
+              .*\b(?i)(select|delete|insert|create|update|alter|drop)\b.*
+      - pattern-not-inside: println(...)


### PR DESCRIPTION
Scala versions of: 

https://github.com/returntocorp/semgrep-rules/blob/d84ca1d208965041464983d3c2ea1e3329cad1d9/java/spring/security/injection/tainted-sql-string.yaml

https://github.com/returntocorp/semgrep-rules/blob/d84ca1d208965041464983d3c2ea1e3329cad1d9/java/lang/security/audit/sqli/tainted-sql-from-http-request.yaml