### PR TITLE
Add rule for structured logging in C#

### DIFF
--- a/csharp/lang/best-practice/structured-logging.cs
+++ b/csharp/lang/best-practice/structured-logging.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Logging;
+using Serilog;
+using NLog;
+
+class Program
+{
+    public static void SerilogSample()
+    {
+        using var serilog = new LoggerConfiguration().WriteTo.Console().CreateLogger();
+
+        var position = new { Latitude = 25, Longitude = 134 };
+        var elapsedMs = 34;
+
+        // ok: structured-logging
+        serilog.Information("Processed {@Position} in {Elapsed:000} ms.", position, elapsedMs);
+
+        // ruleid: structured-logging
+        serilog.Information($"Processed {position} in {elapsedMs:000} ms.");
+    }
+
+    public static void MicrosoftSample()
+    {
+        var loggerFactory = LoggerFactory.Create(builder => {
+                builder.AddConsole();
+            }
+        );
+
+        var logger = loggerFactory.CreateLogger<Program>();
+
+        var position = new { Latitude = 25, Longitude = 134 };
+        var elapsedMs = 34;
+
+        // ok: structured-logging
+        logger.LogInformation("Processed {@Position} in {Elapsed:000} ms.", position, elapsedMs);
+
+        // ruleid: structured-logging
+        logger.LogInformation($"Processed {position} in {elapsedMs:000} ms.");
+    }
+
+    public static void NLogSample()
+    {
+        var logger = NLog.LogManager.Setup().LoadConfiguration(builder => {
+            builder.ForLogger().WriteToConsole();
+        }).GetCurrentClassLogger();
+
+        var position = new { Latitude = 25, Longitude = 134 };
+        var elapsedMs = 34;
+
+        // ok: structured-logging
+        logger.Info("Processed {@Position} in {Elapsed:000} ms.", position, elapsedMs);
+
+        // ruleid: structured-logging
+        logger.Info($"Processed {position} in {elapsedMs:000} ms.");
+
+        // try with different name
+        var _LOG = logger;
+
+        // ruleid: structured-logging
+        _LOG.Info($"Processed {position} in {elapsedMs:000} ms.");
+    }
+
+    public static void NotLogging()
+    {
+        // System.Web.TraceContext.Warn does not support structured logging
+        var traceContext = new FakeTraceContext();
+
+        // ok: structured-logging
+        traceContext.Warn($"hello world");
+    }
+
+    public static void Main()
+    {
+        SerilogSample();
+        MicrosoftSample();
+        NLogSample();
+        NotLogging();
+    }
+}
+
+class FakeTraceContext
+{
+    public void Warn(string foo) { }
+}

--- a/csharp/lang/best-practice/structured-logging.yaml
+++ b/csharp/lang/best-practice/structured-logging.yaml
@@ -24,7 +24,7 @@ rules:
     - metavariable-regex:
         metavariable: $LOG
         regex: .*(log|LOG|Log)
-  message: |
+  message: >-
       String interpolation in log message obscures the distinction between
       variables and the log message. Use structured logging instead, where the
       variables are passed as additional arguments and the interpolation is performed

--- a/csharp/lang/best-practice/structured-logging.yaml
+++ b/csharp/lang/best-practice/structured-logging.yaml
@@ -17,9 +17,7 @@ rules:
       - pattern: $LOG.LogTrace($"...")
       - pattern: $LOG.LogWarning($"...")
       # NLog
-      - pattern: $LOG.Debug($"...")
-      - pattern: $LOG.Error($"...")
-      - pattern: $LOG.Fatal($"...")
+      # Debug, Error, Fatal are already present above in Serilog
       - pattern: $LOG.Info($"...")
       - pattern: $LOG.Trace($"...")
       - pattern: $LOG.Warn($"...")

--- a/csharp/lang/best-practice/structured-logging.yaml
+++ b/csharp/lang/best-practice/structured-logging.yaml
@@ -1,0 +1,50 @@
+rules:
+- id: structured-logging
+  patterns:
+    - pattern-either:
+      # Serilog
+      - pattern: $LOG.Debug($"...")
+      - pattern: $LOG.Error($"...")
+      - pattern: $LOG.Fatal($"...")
+      - pattern: $LOG.Information($"...")
+      - pattern: $LOG.Verbose($"...")
+      - pattern: $LOG.Warning($"...")
+      # Microsoft.Extensions.Logging
+      - pattern: $LOG.LogCritical($"...")
+      - pattern: $LOG.LogDebug($"...")
+      - pattern: $LOG.LogError($"...")
+      - pattern: $LOG.LogInformation($"...")
+      - pattern: $LOG.LogTrace($"...")
+      - pattern: $LOG.LogWarning($"...")
+      # NLog
+      - pattern: $LOG.Debug($"...")
+      - pattern: $LOG.Error($"...")
+      - pattern: $LOG.Fatal($"...")
+      - pattern: $LOG.Info($"...")
+      - pattern: $LOG.Trace($"...")
+      - pattern: $LOG.Warn($"...")
+    - metavariable-regex:
+        metavariable: $LOG
+        regex: .*(log|LOG|Log)
+  message: |
+      String interpolation in log message obscures the distinction between
+      variables and the log message. Use structured logging instead, where the
+      variables are passed as additional arguments and the interpolation is performed
+      by the logging library. This reduces the possibility of log injection and makes
+      it easier to search through logs.
+  languages: [csharp]
+  severity: INFO
+  metadata:
+    cwe:
+      - "CWE-117: Improper Output Neutralization for Logs"
+    technology:
+      - .net
+      - serilog
+      - nlog
+    confidence: MEDIUM
+    references:
+      - https://github.com/NLog/NLog/wiki/How-to-use-structured-logging
+      - https://softwareengineering.stackexchange.com/questions/312197/benefits-of-structured-logging-vs-basic-logging
+    category:
+      - security
+      - best-practice

--- a/csharp/lang/best-practice/structured-logging.yaml
+++ b/csharp/lang/best-practice/structured-logging.yaml
@@ -35,6 +35,8 @@ rules:
   metadata:
     cwe:
       - "CWE-117: Improper Output Neutralization for Logs"
+    owasp:
+      - "A09:2021 - Security Logging and Monitoring Failures"
     technology:
       - .net
       - serilog


### PR DESCRIPTION
String interpolation should be done by the logging library instead of by
$"...", so that querying variables is possible, and log injection is prevented.

Add rules for various logging libraries. Some methods are double (e.g.
$LOG.Debug), since they appear in multiple libraries. <s>I have kept this
intentionally to make it clear which methods belong in which libraries.</s>

Also check that the method is called on something that is named "log" or
something like that. Logger objects could be named differently, but this
reduces the chance of false positives when calling `Trace` or something on an
object that is not a logger.