### PR TITLE
get rid of dupes in Ruby rule

### DIFF
--- a/ruby/lang/security/weak-hashes-sha1.yaml
+++ b/ruby/lang/security/weak-hashes-sha1.yaml
@@ -15,8 +15,6 @@ rules:
       - ruby
     severity: WARNING
     pattern-either:
-      - pattern: Digest::SHA1.$FUNC $X
       - pattern: Digest::SHA1.$FUNC
-      - pattern: OpenSSL::Digest::SHA1.$FUNC $X
       - pattern: OpenSSL::Digest::SHA1.$FUNC
       - pattern: OpenSSL::HMAC.$FUNC("sha1",...)


### PR DESCRIPTION
This rule led to duplicate findings, remove two lines to get rid of dupes.