### PR TITLE
Fix dockerfile avoid-latest-version rule

### DIFF
--- a/generic/dockerfile/best-practice/avoid-latest-version.dockerfile
+++ b/generic/dockerfile/best-practice/avoid-latest-version.dockerfile
@@ -2,10 +2,22 @@
 FROM debian:latest
 
 # ruleid: avoid-latest-version
+FROM myregistry.local/testing/test-image:latest
+
+# ruleid: avoid-latest-version
 FROM debian:latest as blah
+
+# ruleid: avoid-latest-version
+FROM myregistry.local/testing/test-image:latest as blah
 
 # ok: avoid-latest-version
 FROM debian:jessie
 
 # ok: avoid-latest-version
-FORM debian:jessie as blah2
+FROM myregistry.local/testing/test-image:42ee222
+
+# ok: avoid-latest-version
+FROM debian:jessie as blah2
+
+# ok: avoid-latest-version
+FROM myregistry.local/testing/test-image:2a4af68 as blah2

--- a/generic/dockerfile/best-practice/avoid-latest-version.yaml
+++ b/generic/dockerfile/best-practice/avoid-latest-version.yaml
@@ -17,4 +17,4 @@ rules:
       include:
         - "*dockerfile*"
         - "*Dockerfile*"
-    pattern: FROM $IMAGE:latest
+    pattern: FROM ...:latest


### PR DESCRIPTION
The existing rule was not able to match when the container image was a URL of a container repository instead of a plain string. It seems that the $IMAGE placeholder didn't match with strings with dots and slashes.

I replaced the $IMAGE placeholder in the rule with the ellipsis operator "...", and based in the test cases, now it works as expected.

Additionally, I noted that in the test cases there was a wrong test case: it was using FORM instead of FROM unintentionally. That made the test in the semgrep registry to fail with this error:

{"code":3,"level":"warn","message":"[WARN] Semgrep Core — Syntax error\nAn error occurred while invoking the Semgrep engine. Please help us fix this by creating an issue at https://github.com/returntocorp/semgrep\n\nAt line targetDockerfile:11: `FORM debian:jessie as blah2` was unexpected\n","path":"targetDockerfile","type":"Syntax error"}
The pattern documentation has full details on pattern syntax.

By replacing the wrong FORM by FROM, I'm expecting to fix this issue too.