### PR TITLE
change 2 rules to taint

### DIFF
--- a/python/django/security/audit/avoid-insecure-deserialization.py
+++ b/python/django/security/audit/avoid-insecure-deserialization.py
@@ -2,37 +2,37 @@ from django.http import HttpResponse
 import datetime
 
 def current_datetime(request):
-    # ok:avoid-insecure-deserialization
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ok:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(b64decode(html)))
 
 # pickle tests
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = b64decode(request.cookies.get('uuid'))
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(user_obj))
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(user_obj))
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(b64decode(user_obj)))
 
 def current_datetime(request):
@@ -42,41 +42,41 @@ def current_datetime(request):
 # Other libraries
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = b64decode(request.cookies.get('uuid'))
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(_pickle.loads(user_obj))
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(cPickle.loads(user_obj))
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(dill.loads(b64decode(user_obj)))
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
+    # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(shelve.loads(user_obj))
 
 def current_datetime(request):
-    # ruleid:avoid-insecure-deserialization
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
 
-    return "Hey there! {}!".format(yaml.loads(b64decode(user_obj)))
+    # ruleid:avoid-insecure-deserialization
+    return "Hey there! {}!".format(yaml.load(b64decode(user_obj)))

--- a/python/django/security/audit/avoid-insecure-deserialization.yaml
+++ b/python/django/security/audit/avoid-insecure-deserialization.yaml
@@ -14,38 +14,43 @@ rules:
     languages:
       - python
     severity: ERROR
-    patterns:
-      - pattern-inside: |
-          def $X(..., request, ...):
-            ...
-      - pattern-either:
-          - pattern: |
-              $VAR = <... request.$Y.get(...) ...>
+    mode: taint
+    pattern-sources:
+    - pattern-either:
+      - patterns:
+        - pattern-inside: |
+            def $INSIDE(..., $PARAM, ...):
               ...
-              pickle.$FUNC(<... $VAR ...>)
-          - pattern: pickle.$FUNC(<... request.$Y.get(...) ...>)
+        - pattern: |
+            $PARAM
+      - pattern: 
+          request.$REQFUNC(...)
+      - pattern:
+          request.$REQFUNC.get(...)
+      - pattern: 
+          request.$REQFUNC[...]
+    pattern-sinks:
+    - pattern-either:
+      - patterns:
+        - pattern-either:
           - pattern: |
-              $VAR = <... request.$Y.get(...) ...>
-              ...
-              _pickle.$FUNC(<... $VAR ...>)
-          - pattern: _pickle.$FUNC(<... request.$Y.get(...) ...>)
+              pickle.$PICKLEFUNC(...)
           - pattern: |
-              $VAR = <... request.$Y.get(...) ...>
-              ...
-              cPickle.$FUNC(<... $VAR ...>)
-          - pattern: cPickle.$FUNC(<... request.$Y.get(...) ...>)
+              _pickle.$PICKLEFUNC(...)
           - pattern: |
-              $VAR = <... request.$Y.get(...) ...>
-              ...
-              dill.$FUNC(<... $VAR ...>)
-          - pattern: dill.$FUNC(<... request.$Y.get(...) ...>)
+              cPickle.$PICKLEFUNC(...)
           - pattern: |
-              $VAR = <... request.$Y.get(...) ...>
-              ...
-              shelve.$FUNC(<... $VAR ...>)
-          - pattern: shelve.$FUNC(<... request.$Y.get(...) ...>)
-          - pattern: |
-              $VAR = <... request.$Y.get(...) ...>
-              ...
-              yaml.$FUNC(<... $VAR ...>)
-          - pattern: yaml.$FUNC(<... request.$Y.get(...) ...>)
+              shelve.$PICKLEFUNC(...)
+        - metavariable-regex:
+            metavariable: $PICKLEFUNC
+            regex: dumps|dump|load|loads
+      - patterns:
+        - pattern: dill.$DILLFUNC(...)
+        - metavariable-regex:
+            metavariable: $DILLFUNC
+            regex: dump|dump_session|dumps|load|load_session|loads 
+      - patterns:
+        - pattern: yaml.$YAMLFUNC(...)
+        - metavariable-regex:
+            metavariable: $YAMLFUNC
+            regex: dump|dump_all|load|load_all

--- a/python/flask/security/audit/directly-returned-format-string.yaml
+++ b/python/flask/security/audit/directly-returned-format-string.yaml
@@ -14,33 +14,48 @@ rules:
     languages:
       - python
     severity: WARNING
-    patterns:
-      - pattern-inside: |
-          @$APP.route(...)
-          def $FUNC(...):
-            ...
+    mode: taint
+    pattern-sources:
+    - pattern-either:
+      - patterns:
+        - pattern-inside: |
+            @$APP.route(...)
+            def $FUNC(..., $PARAM, ...):
+              ...
+        - pattern: $PARAM
+      - pattern: |
+          request.$FUNC.get(...)
+      - pattern: | 
+          request.$FUNC(...)
+      - pattern:
+          request.$FUNC[...]
+    pattern-sinks:
+    - patterns:
       - pattern-not-inside: return "..."
-      - pattern-either:
-          - pattern: return "...".format(...)
-          - pattern: return "..." % ...
-          - pattern: return "..." + ...
-          - pattern: return ... + "..."
-          - pattern: return f"...{...}..."
-          - patterns:
-              - pattern: return $X
-              - pattern-either:
-                  - pattern-inside: |
-                      $X = "...".format(...)
-                      ...
-                  - pattern-inside: |
-                      $X = "..." % ...
-                      ...
-                  - pattern-inside: |
-                      $X = "..." + ...
-                      ...
-                  - pattern-inside: |
-                      $X = ... + "..."
-                      ...
-                  - pattern-inside: |
-                      $X = f"...{...}..."
-                      ...
+      - pattern-either: 
+        - pattern: return "...".format(...)
+        - pattern: return "..." % ...
+        - pattern: return "..." + ...
+        - pattern: return ... + "..."
+        - pattern: return f"...{...}..."
+        - patterns:
+          - pattern: return $X
+          - pattern-either:
+              - pattern-inside: |
+                  $X = "...".format(...)
+                  ...
+              - pattern-inside: |
+                  $X = "..." % ...
+                  ...
+              - pattern-inside: |
+                  $X = "..." + ...
+                  ...
+              - pattern-inside: |
+                  $X = ... + "..."
+                  ...
+              - pattern-inside: |
+                  $X = f"...{...}..."
+                  ...
+          - pattern-not-inside: |
+              $X = "..."
+              ...


### PR DESCRIPTION
* Makes `avoid-insecure-deserialization.yaml` have less FP by making it taint and adding filtering for specific functions
* Improve `Python.flask.security.audit.directly-returned-format-string.directly-returned-format-string`  by making it taint/adding pattern-nots

_To test:_
Run `semgrep --test .` on the directory the files are in. 

Edit: @minusworld should I test this on real world examples? I am getting rate limited again 😭 