### PR TITLE
fix for fp of python string interpolation

### DIFF
--- a/generic/secrets/security/detected-username-and-password-in-uri.txt
+++ b/generic/secrets/security/detected-username-and-password-in-uri.txt
@@ -36,3 +36,12 @@ HTTPS (ex : `https://user:password@192.168.0.1:3128/`)
 
 # ruleid: detected-username-and-password-in-uri
 curl -kvsX PUT \"https://user:pass@something.host.test:8088/search/\" -H \"Content-Type: application/xml\"
+
+# ok: detected-username-and-password-in-uri
+f"https://user:{_github_pat(github_secret_name)}@github.com/"
+
+# ok: detected-username-and-password-in-uri
+f"https://{get_user_name}:{_github_pat(github_secret_name)}@github.com/"
+
+# ruleid: detected-username-and-password-in-uri
+f"https://{get_user_name}:pwd@github.com/"

--- a/generic/secrets/security/detected-username-and-password-in-uri.yaml
+++ b/generic/secrets/security/detected-username-and-password-in-uri.yaml
@@ -1,6 +1,7 @@
 rules:
 - id: detected-username-and-password-in-uri
-  pattern-regex: ([\w+]{1,24})(://)([^$<]{1})([^\s";]{1,}):([^$<]{1})([^\s";]{1,})@[-a-zA-Z0-9@:%._\+~#=]{1,256}[a-zA-Z0-9()]{1,24}([^\s]+)
+  patterns:
+  - pattern-regex: ([\w+]{1,24})(://)([^$<]{1})([^\s";]{1,}):([^$<\{]{1})([^\s";]{1,})@[-a-zA-Z0-9@:%._\+~#=]{1,256}[a-zA-Z0-9()]{1,24}([^\s]+)
   languages:
   - regex
   message: Username and password in URI detected


### PR DESCRIPTION
* fixes FP of python string interpolation (makes sure that { in regex is read as a character that leads to interpolation). 

TODO: eventually translate this rule into something other than regex because the regex is hard to read. (and add metavariable-entropy to it)