### PR TITLE
Corrected fix for autoescape-disabled

### DIFF
--- a/python/jinja2/security/audit/autoescape-disabled-false.py
+++ b/python/jinja2/security/audit/autoescape-disabled-false.py
@@ -5,42 +5,37 @@ from jinja2 import Environment, select_autoescape
 templateLoader = jinja2.FileSystemLoader( searchpath="/" )
 something = ''
 
-# ok:autoescape-disabled
+# ok:incorrect-autoescape-disabled
 Environment(loader=templateLoader, load=templateLoader, autoescape=True)
 
-# ok:autoescape-disabled
+# ok:incorrect-autoescape-disabled
 templateEnv = jinja2.Environment(autoescape=True,
         loader=templateLoader )
 
-# ruleid:autoescape-disabled
+# ruleid:incorrect-autoescape-disabled
 Environment(loader=templateLoader, load=templateLoader, autoescape=something)
 
 
-# ruleid:autoescape-disabled
+# ruleid:incorrect-autoescape-disabled
 templateEnv = jinja2.Environment(autoescape=False, loader=templateLoader )
 
 
-# ruleid:autoescape-disabled
 Environment(loader=templateLoader,
             load=templateLoader,
+# ruleid:incorrect-autoescape-disabled
             autoescape=False)
 
 
-# ruleid:autoescape-disabled
-Environment(loader=templateLoader,
-            load=templateLoader)
-
-# ok:autoescape-disabled
+# ok:incorrect-autoescape-disabled
 Environment(loader=templateLoader, autoescape=select_autoescape())
 
-# ok:autoescape-disabled
 Environment(loader=templateLoader,
+# ok:incorrect-autoescape-disabled
             autoescape=select_autoescape(['html', 'htm', 'xml']))
-
 
 def fake_func():
     return 'foobar'
 
-
-# ruleid:autoescape-disabled
+# ruleid:incorrect-autoescape-disabled
 Environment(loader=templateLoader, autoescape=fake_func())
+

--- a/python/jinja2/security/audit/autoescape-disabled-false.yaml
+++ b/python/jinja2/security/audit/autoescape-disabled-false.yaml
@@ -1,14 +1,14 @@
 rules:
-  - id: autoescape-disabled
+  - id: incorrect-autoescape-disabled
     patterns:
-      - pattern-not: jinja2.Environment(..., autoescape=True, ...)
-      - pattern-not: jinja2.Environment(..., autoescape=jinja2.select_autoescape(...), ...)
-      - pattern: jinja2.Environment(...)
-    fix-regex:
-      regex: (.*)\)
-      replacement: \1, autoescape=True)
+      - pattern: jinja2.Environment(... , autoescape=$VAL, ...)
+      - pattern-not: jinja2.Environment(... , autoescape=True, ...)
+      - pattern-not: jinja2.Environment(... , autoescape=jinja2.select_autoescape(...), ...)
+      - focus-metavariable: $VAL
+    fix: |
+      True
     message: >-
-      Detected a Jinja2 environment without autoescaping. Jinja2 does not autoescape by default.
+      Detected a Jinja2 environment with autoescaping disabled.
       This is dangerous if you are rendering to a browser because this allows for cross-site
       scripting (XSS) attacks. If you are in a web context, enable autoescaping by setting
       'autoescape=True.' You may also consider using 'jinja2.select_autoescape()' to only enable

--- a/python/jinja2/security/audit/missing-autoescape-disabled.py
+++ b/python/jinja2/security/audit/missing-autoescape-disabled.py
@@ -1,0 +1,46 @@
+# cf. https://github.com/PyCQA/bandit/blob/02bad2e42311f420aef52dcd9806d66516ef594d/examples/jinja2_templating.py
+
+import jinja2
+from jinja2 import Environment, select_autoescape
+templateLoader = jinja2.FileSystemLoader( searchpath="/" )
+something = ''
+
+#ok:missing-autoescape-disabled
+Environment(loader=templateLoader, load=templateLoader, autoescape=True)
+
+# ok:missing-autoescape-disabled
+templateEnv = jinja2.Environment(autoescape=True,
+        loader=templateLoader )
+
+# ok:missing-autoescape-disabled
+Environment(loader=templateLoader, load=templateLoader, autoescape=something)
+
+
+# ok:missing-autoescape-disabled
+templateEnv = jinja2.Environment(autoescape=False, loader=templateLoader )
+
+
+# ok:missing-autoescape-disabled
+Environment(loader=templateLoader,
+            load=templateLoader,
+            autoescape=False)
+
+
+# ruleid:missing-autoescape-disabled
+Environment(loader=templateLoader,
+            load=templateLoader)
+
+# ok:missing-autoescape-disabled
+Environment(loader=templateLoader, autoescape=select_autoescape())
+
+# ok:missing-autoescape-disabled
+Environment(loader=templateLoader,
+            autoescape=select_autoescape(['html', 'htm', 'xml']))
+
+
+def fake_func():
+    return 'foobar'
+
+
+# ok:missing-autoescape-disabled
+Environment(loader=templateLoader, autoescape=fake_func())

--- a/python/jinja2/security/audit/missing-autoescape-disabled.yaml
+++ b/python/jinja2/security/audit/missing-autoescape-disabled.yaml
@@ -1,0 +1,25 @@
+rules:
+  - id: missing-autoescape-disabled
+    patterns:
+      - pattern-not: jinja2.Environment(..., autoescape=$VAL, ...)
+      - pattern: jinja2.Environment(...)
+    fix-regex:
+      regex: (.*)\)
+      replacement: \1, autoescape=True)
+    message: >-
+      Detected a Jinja2 environment without autoescaping. Jinja2 does not autoescape by default.
+      This is dangerous if you are rendering to a browser because this allows for cross-site
+      scripting (XSS) attacks. If you are in a web context, enable autoescaping by setting
+      'autoescape=True.' You may also consider using 'jinja2.select_autoescape()' to only enable
+      automatic escaping for certain file extensions.
+    metadata:
+      source-rule-url: https://bandit.readthedocs.io/en/latest/plugins/b701_jinja2_autoescape_false.html
+      cwe: "CWE-116: Improper Encoding or Escaping of Output"
+      owasp: "A6: Security Misconfiguration"
+      references:
+        - https://jinja.palletsprojects.com/en/2.11.x/api/#basics
+      category: security
+      technology:
+        - jinja2
+    languages: [python]
+    severity: WARNING


### PR DESCRIPTION
This fix behaviour was incorrect.

The fix is adding `autoescape-disabled=True` to the arguments.

But the pattern was also catching cases where `autoescape-disabled` was configured with an incorrect value. In these cases the fix would add it to the arguments a second time instead of correcting the value.