### PR TITLE
java.lang.securit.audit: Fix conflicting taint specification

### DIFF
--- a/java/lang/security/audit/tainted-session-from-http-request.yaml
+++ b/java/lang/security/audit/tainted-session-from-http-request.yaml
@@ -14,8 +14,11 @@ rules:
     pattern-sources:
     - patterns:
       - pattern-either:
-        - pattern: |
-            (HttpServletRequest $REQ).$FUNC(...)
+        - patterns:
+          - pattern: |
+              (HttpServletRequest $REQ).$FUNC(...)
+          - pattern-not: |
+              (HttpServletRequest $REQ).getSession()
         - patterns: # this pattern is a hack to get the rule to      recognize `map` as tainted source when `cookie. getValue(user_input)` is used.
            - pattern-inside: |
                (javax.servlet.http.Cookie[] $COOKIES) = (HttpServletRequest $REQ).getCookies(...);


### PR DESCRIPTION
Follows PR returntocorp/semgrep#4901

Given

    pattern-sources:
    - pattern: (HttpServletRequest $REQ).$FUNC(...)

and

    pattern-sinks:
    - pattern: (HttpServletRequest $REQ).getSession().$FUNC(...)

we have that `request.getSession()` in

    request.getSession().setAttribute(param, "10340");

is both a source and a sink! This is fixed by stating that
`request.getSession()` cannot be a source.

We don't see this FP now because $FUNC is used in both the source and
the sink, forcing unification (both $FUNC must be equal!). (And yes,
this means the rule was also missing true bugs.) But once the PR
returntocorp/semgrep#4901 is merged, unification of source-sink
metavariables will not be the default. This will make this rule stop
missing TPs, but without this change it will also start producing FPs.