### PR TITLE
editing http-req to filter out 127.0.0.1

### DIFF
--- a/problem-based-packs/insecure-transport/go-stdlib/http-request.go
+++ b/problem-based-packs/insecure-transport/go-stdlib/http-request.go
@@ -1,5 +1,4 @@
-func bad1() {
-    // ruleid: http-request
+
     resp, err := http.Get("http://example.com/")
     // ruleid: http-request
     resp, err := http.Post("http://example.com/", val, val)
@@ -27,13 +26,23 @@ func ok1() {
     resp, err := http.Head("https://example.com/")
     // ok: http-request
     resp, err := http.PostForm("https://example.com/", form)
+    // ok: http-request
+    resp, err := http.PostForm("http://127.0.0.1/", form)
+    // ok: http-request
+    resp, err := http.Head("http://127.0.0.1/path/to/x")
 }
 
 func ok2() {
-    // ok: http-request
     client := &http.Client{
 	    CheckRedirect: redirectPolicyFunc,
     }
 
+    // ok: http-request
     resp, err := client.Get("https://example.com")
+
+    // ok: http-request
+    resp, err := client.Post("https://127.0.0.1/path/to/x", form)
+
+    // ok: http-request
+    resp, err := client.Get("https://127.0.0.1")
 }

--- a/problem-based-packs/insecure-transport/go-stdlib/http-request.go
+++ b/problem-based-packs/insecure-transport/go-stdlib/http-request.go
@@ -1,4 +1,5 @@
-
+func bad1() {
+    // ruleid: http-request
     resp, err := http.Get("http://example.com/")
     // ruleid: http-request
     resp, err := http.Post("http://example.com/", val, val)
@@ -9,11 +10,11 @@
 }
 
 func bad2() {
-    // ruleid: http-request
     client := &http.Client{
 	    CheckRedirect: redirectPolicyFunc,
     }
 
+    // ruleid: http-request
     resp, err := client.Get("http://example.com")
 }
 

--- a/problem-based-packs/insecure-transport/go-stdlib/http-request.yaml
+++ b/problem-based-packs/insecure-transport/go-stdlib/http-request.yaml
@@ -4,10 +4,16 @@ rules:
       - pattern-either:
           - pattern: |
               http.$FUNC("=~/[hH][tT][tT][pP]://.*/", ...)
-          - pattern: |
-              $CLIENT := &http.Client{...}
-              ...
-              client.$FUNC("=~/[hH][tT][tT][pP]://.*/", ...)
+          - patterns:
+            - pattern-inside: |
+                $CLIENT := &http.Client{...}
+                ...
+            - pattern: |
+                client.$FUNC("=~/[hH][tT][tT][pP]://.*/", ...)
+      - pattern-not:
+          http.$FUNC("=~/[hH][tT][tT][pP]://127.0.0.1.*/", ...)
+      - pattern-not:
+          client.$FUNC("=~/[hH][tT][tT][pP]://127.0.0.1.*/", ...)
       - metavariable-regex:
           metavariable: $FUNC
           regex: (Get|Post|Head|PostForm)


### PR DESCRIPTION
filters out http requests of the form 'http://127.0.0.1', as most webapps served locally are accessed without SSL/TLS

_To test:_
`semgrep --test .` in the directory and check that all tests pass.