### PR TITLE
Edit more rules

### DIFF
--- a/generic/dockerfile/best-practice/missing-zypper-clean.yaml
+++ b/generic/dockerfile/best-practice/missing-zypper-clean.yaml
@@ -1,9 +1,9 @@
 rules:
   - id: missing-zypper-clean
     severity: WARNING
-    languages: [generic]
+    languages: [dockerfile]
     patterns:
-      - pattern: zypper $COMMAND
+      - pattern: RUN ... zypper $COMMAND ...
       - pattern-not-inside: RUN ... && zypper clean
       - pattern-not-inside: RUN ... && \ zypper clean
     message: >-
@@ -15,7 +15,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/java/lang/security/audit/crypto/no-null-cipher.java
+++ b/java/lang/security/audit/crypto/no-null-cipher.java
@@ -7,16 +7,16 @@ class Cls {
     }
 
     public byte[] test1(String plainText) {
-        // ruleid: no-null-cipher
         Cipher doNothingCihper = new NullCipher();
         //The ciphertext produced will be identical to the plaintext.
+        // ruleid: no-null-cipher
         byte[] cipherText = doNothingCihper.doFinal(plainText);
         return cipherText;
     }
 
     public void test2(String plainText) {
-        // ok: no-null-cipher
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        // ok: no-null-cipher
         byte[] cipherText = cipher.doFinal(plainText);
         return cipherText;
     }

--- a/java/lang/security/audit/crypto/no-null-cipher.yaml
+++ b/java/lang/security/audit/crypto/no-null-cipher.yaml
@@ -1,6 +1,12 @@
 rules:
   - id: no-null-cipher
-    pattern: new NullCipher(...);
+    patterns:
+    - pattern-inside: |
+        $CI = new NullCipher(...);
+        ...
+    - pattern-either: 
+      - pattern: $CI.doFinal(...)
+      - pattern: $CI.update(...)
     metadata:
       cwe: "CWE-327: Use of a Broken or Risky Cryptographic Algorithm"
       owasp: "A3: Sensitive Data Exposure"

--- a/python/boto3/security/hardcoded-token.py
+++ b/python/boto3/security/hardcoded-token.py
@@ -34,6 +34,27 @@ s3 = boto3.resource(
     endpoint_url="https://sfo2.digitaloceanspaces.com",
 )
 
+ok_secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# ok:hardcoded-token
+s3 = boto3.resource(
+    "s3",
+    aws_access_key_id=ok_key,
+    aws_secret_access_key=ok_secret,
+    region_name="sfo2",
+    endpoint_url="https://sfo2.digitaloceanspaces.com",
+)
+
+ok_token = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# ok:hardcoded-token
+s3 = boto3.resource(
+    "s3",
+    aws_access_key_id=ok_key,
+    aws_secret_access_key=ok_secret,
+    aws_session_token=ok_token,
+    region_name="sfo2",
+    endpoint_url="https://sfo2.digitaloceanspaces.com",
+)
+
 # ok:hardcoded-token
 s3 = client("s3", aws_access_key_id="this-is-not-a-key")
 

--- a/python/boto3/security/hardcoded-token.yaml
+++ b/python/boto3/security/hardcoded-token.yaml
@@ -18,6 +18,27 @@ rules:
     languages: [python]
     severity: WARNING
     pattern-either:
-      - pattern: $W(..., aws_secret_access_key="=~/^[A-Za-z0-9/+=]+$/", ...)
-      - pattern: $W(..., aws_access_key_id="=~/^AKI/", ...)
-      - pattern: $W(..., aws_session_token="...", ...)
+    - patterns:
+      - pattern: |
+          $W(..., aws_secret_access_key="$ACCESSKEY", ...)
+      - metavariable-regex:
+          metavariable: $ACCESSKEY
+          regex: ^[A-Za-z0-9/+=]+$
+      - metavariable-analysis:
+          metavariable: $ACCESSKEY
+          analyzer: entropy
+    - patterns:
+      - pattern: |
+          $W(..., aws_access_key_id="$KEYID", ...)
+      - metavariable-regex:
+          metavariable: $KEYID
+          regex: ^AKI
+      - metavariable-analysis:
+          metavariable: $KEYID
+          analyzer: entropy
+    - patterns:
+      - pattern: |
+          $W(..., aws_session_token="$TOKEN", ...)
+      - metavariable-analysis:
+          metavariable: $TOKEN
+          analyzer: entropy


### PR DESCRIPTION
This is the last of the batch! Edited a few more rules to reduce FP and negative developer sentiment:
* `generic/dockerfile/best-practice/missing-zypper-clean.yaml` -- converted this to dockerfile rule, and placed the pattern inside `RUN` to hopefully eliminate more FP
* `java/lang/security/audit/crypto/no-null-cipher.yaml` -- add specific functions the Cipher must call in order for it to lead to more potentially vulnerable situations
* `python/boto3/security/hardcoded-token.yaml` -- added metavariable-analysis to this

_Test Plan:_
Run `semgrep --test .` on the directories the rules are in.