### PR TITLE
add localhost to pattern-not

### DIFF
--- a/problem-based-packs/insecure-transport/go-stdlib/http-request.go
+++ b/problem-based-packs/insecure-transport/go-stdlib/http-request.go
@@ -31,6 +31,8 @@ func ok1() {
     resp, err := http.PostForm("http://127.0.0.1/", form)
     // ok: http-request
     resp, err := http.Head("http://127.0.0.1/path/to/x")
+    // ok: http-request
+    resp, err := http.Head("http://localhost/path/to/x")
 }
 
 func ok2() {
@@ -46,4 +48,7 @@ func ok2() {
 
     // ok: http-request
     resp, err := client.Get("https://127.0.0.1")
+
+    // ok: http-request
+    resp, err := client.Get("https://localhost/asdf/path")
 }

--- a/problem-based-packs/insecure-transport/go-stdlib/http-request.yaml
+++ b/problem-based-packs/insecure-transport/go-stdlib/http-request.yaml
@@ -14,6 +14,10 @@ rules:
           http.$FUNC("=~/[hH][tT][tT][pP]://127.0.0.1.*/", ...)
       - pattern-not:
           client.$FUNC("=~/[hH][tT][tT][pP]://127.0.0.1.*/", ...)
+      - pattern-not:
+          http.$FUNC("=~/[hH][tT][tT][pP]://localhost.*/", ...)
+      - pattern-not:
+          client.$FUNC("=~/[hH][tT][tT][pP]://localhost.*/", ...)
       - metavariable-regex:
           metavariable: $FUNC
           regex: (Get|Post|Head|PostForm)


### PR DESCRIPTION
* adds localhost filtering to http-request rule

_To Test:_
Run `semgrep --test .`