### PR TITLE
use-frozen-lockfile: Fix autofixes eating whitespace

### DIFF
--- a/generic/ci/security/use-frozen-lockfile.yaml
+++ b/generic/ci/security/use-frozen-lockfile.yaml
@@ -22,7 +22,7 @@ rules:
     patterns:
       - pattern-regex: npm install\b
       - pattern-not-regex: npm install [\w]+
-    fix: "npm ci "
+    fix: npm ci
     message: >-
       To ensure reproducable and deterministic builds, use `npm ci` rather than `npm install` in scripts. This will use the lockfile rather than updating it.
     languages:

--- a/generic/ci/security/use-frozen-lockfile.yaml
+++ b/generic/ci/security/use-frozen-lockfile.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: use-frozen-lockfile-yarn
     patterns:
-      - pattern-regex: yarn install\s
+      - pattern-regex: yarn install\b
       - pattern-not-regex: yarn install --frozen-lockfile
       - pattern-not-regex: yarn install [\w]+
     fix: yarn install --frozen-lockfile
@@ -20,9 +20,9 @@ rules:
         - yarn
   - id: use-frozen-lockfile-npm
     patterns:
-      - pattern-regex: npm install\s
+      - pattern-regex: npm install\b
       - pattern-not-regex: npm install [\w]+
-    fix: npm ci
+    fix: "npm ci "
     message: >-
       To ensure reproducable and deterministic builds, use `npm ci` rather than `npm install` in scripts. This will use the lockfile rather than updating it.
     languages:
@@ -38,7 +38,7 @@ rules:
         - npm
   - id: use-frozen-lockfile-pipenv
     patterns:
-      - pattern-regex: pipenv install\s
+      - pattern-regex: pipenv install\b
       - pattern-not-regex: pipenv install --ignore-pipfile
       - pattern-not-regex: pipenv install [\w]+
     fix: pipenv install --ignore-pipfile


### PR DESCRIPTION
The \s at the end of these patterns would match a space/newline.
The autofix would then replace that whitespace as well.