### PR TITLE
Improvements to ajv-allerrors-true [JavaScript] rule

### DIFF
--- a/javascript/ajv/security/audit/ajv-allerrors-true.js
+++ b/javascript/ajv/security/audit/ajv-allerrors-true.js
@@ -14,8 +14,28 @@ function test2() {
     ajv.addSchema(schema, 'input');
 }
 
+
+function test3() {
+    // ruleid: ajv-allerrors-true
+    var ajv = new Ajv({  smth: 'else', allErrors: true });
+    ajv.addSchema(schema, 'input');
+}
+
+function test4() {
+    // ruleid: ajv-allerrors-true
+    var ajv = new Ajv({  smth: 'else', smth: 'else', allErrors: true, smth: 'else' });
+    ajv.addSchema(schema, 'input');
+}
+
+
 function okTest1() {
     // ok: ajv-allerrors-true
     let ajv = new Ajv({ allErrors: process.env.DEBUG });
+    ajv.addSchema(schema, 'input');
+}
+
+function okTest2() {
+    // ok: ajv-allerrors-true
+    var ajv = new Ajv({  smth: 'else', allErrors: false });
     ajv.addSchema(schema, 'input');
 }

--- a/javascript/ajv/security/audit/ajv-allerrors-true.yaml
+++ b/javascript/ajv/security/audit/ajv-allerrors-true.yaml
@@ -2,12 +2,12 @@ rules:
   - id: ajv-allerrors-true
     pattern-either:
       - pattern: |
-          new Ajv({allErrors: true},...)
+          new Ajv({...,allErrors: true,...},...)
       - patterns:
           - pattern: |
               new Ajv($SETTINGS,...)
           - pattern-inside: |
-              $SETTINGS = {allErrors: true}
+              $SETTINGS = {...,allErrors: true,...}
               ...
     metadata:
       cwe: "CWE-400: Uncontrolled Resource Consumption"
@@ -17,6 +17,6 @@ rules:
       references:
         - https://ajv.js.org/options.html#allerrors
     message: >-
-      By setting `allerrors: true` in `ajv` library, all error objects will be allocated without limit. This allows the attacker to produce a huge number of errors which can lead to denial of service. Do not use `allerrors: true` in production.
+      By setting `allErrors: true` in `Ajv` library, all error objects will be allocated without limit. This allows the attacker to produce a huge number of errors which can lead to denial of service. Do not use `allErrors: true` in production.
     languages: [js, ts]
     severity: WARNING


### PR DESCRIPTION
Improving the AJV rule based on potential false negatives it would have caused. This rule checks to make sure it is within an object, vs the first argument of said object. 

Cleaned up some of the language too since it now correctly matches the argument name not lowercase property. 
