### PR TITLE
Added [ruby] RSA checks for weak key length and hardcoded passphrase

### DIFF
--- a/ruby/lang/security/hardcoded-secret-rsa-passphrase.rb
+++ b/ruby/lang/security/hardcoded-secret-rsa-passphrase.rb
@@ -1,0 +1,62 @@
+module Test
+
+    require 'openssl'
+
+    class Test
+        @pass = 'pass phrase goes here1'
+
+        def assign(key = nil, iv = nil)
+			@pass1 = 'my secure pass phrase goes here'
+			#ruleid: hardcoded-secret-rsa-passphrase
+			OpenSSL::PKey::RSA.new(1024).to_pem(cipher, "secret")
+        end
+
+
+		def bad
+			key_pem = File.read @fileWithKeyName
+			#ruleid: hardcoded-secret-rsa-passphrase
+			key = OpenSSL::PKey::RSA.new key_pem, @pass
+		end
+
+		def bad1
+			key_pem = File.read @fileWithKeyName
+            #ruleid: hardcoded-secret-rsa-passphrase
+			key = OpenSSL::PKey::RSA.new key_pem, @pass1
+		end
+
+        def bad2
+			key_pem = File.read @fileWithKeyName
+            #ruleid: hardcoded-secret-rsa-passphrase
+			key = OpenSSL::PKey::RSA.new key_pem, 'secret'
+		end
+
+		def bad3 
+			ca_key = OpenSSL::PKey::RSA.new 2048
+			pass_phrase = 'my secure pass phrase goes here'
+			cipher = OpenSSL::Cipher.new 'AES-256-CBC'
+			#ruleid: hardcoded-secret-rsa-passphrase
+			ca_key.export(cipher, pass_phrase)
+			open 'tmp/ca_key.pem', 'w', 0644 do |io|
+			  #ruleid: hardcoded-secret-rsa-passphrase
+			  io.write ca_key.export(cipher, pass_phrase)
+			  #ruleid: hardcoded-secret-rsa-passphrase
+			  io.write ca_key.export(cipher, @pass)
+			  #ruleid: hardcoded-secret-rsa-passphrase
+			  io.write ca_key.export(cipher, @pass1)
+			end
+		end 
+
+        def ok
+			key_pem = File.read @fileWithKeyName
+            #ok: hardcoded-secret-rsa-passphrase
+			key = OpenSSL::PKey::RSA.new key_pem, ENV['SECRET']
+		end
+
+		def bad_intrafunction
+		pass2 = 'omgsosekrit'
+		key_pem = File.read @fileWithKeyName
+        #ruleid: hardcoded-secret-rsa-passphrase
+		key = OpenSSL::PKey::RSA.new key_pem, pass2
+    end
+
+end

--- a/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
+++ b/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
@@ -1,12 +1,14 @@
 rules:
   - id: hardcoded-secret-rsa-passphrase
-    message: |
+    message: >-
         Found the use of an hardcoded passphrase for RSA. The passphrase can be easily discovered, and therefore should not be stored in source-code. 
         It is recommended to remove the passphrase from source-code, and use system environment variables or a restricted configuration file.
     languages:
       - ruby
     severity: WARNING
     metadata:
+      technology:
+        - ruby
       category: security
       references: |
         - https://cwe.mitre.org/data/definitions/522.html

--- a/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
+++ b/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
@@ -1,0 +1,91 @@
+rules:
+  - id: hardcoded-secret-rsa-passphrase
+    message: |
+        Found the use of an hardcoded passphrase for RSA. The passphrase can be easily discovered, and therefore should not be stored in source-code. 
+        It is recommended to remove the passphrase from source-code, and use system environment variables or a restricted configuration file.
+    languages:
+      - ruby
+    severity: WARNING
+    metadata:
+      category: security
+      references: |
+        - https://cwe.mitre.org/data/definitions/522.html
+      cwe:
+        - "CWE-798: Use of Hard-coded Credentials"
+      owasp:
+        - A03:2017 - Sensitive Data Exposure
+        - A02:2021 - Cryptographic Failures
+    patterns:
+      - pattern-either:
+          - pattern: OpenSSL::PKey::RSA.new(..., '...')
+          - pattern: OpenSSL::PKey::RSA.new(...).to_pem(..., '...')
+          - pattern: OpenSSL::PKey::RSA.new(...).export(..., '...')
+          - patterns:
+              - pattern-inside: |
+                  $OPENSSL = OpenSSL::PKey::RSA.new(...)
+              - pattern: |
+                  $OPENSSL.export(...,'...')
+          - patterns:
+              - pattern-either:
+                  - patterns:
+                      - pattern-inside: |
+                          $ASSIGN = '...'
+                          ...
+                          def $METHOD(...)
+                          ...
+                          end
+                      - pattern: OpenSSL::PKey::RSA.new(..., $ASSIGN)
+                  - patterns:
+                      - pattern-inside: |
+                          def $METHOD1(...)
+                          ...
+                          $ASSIGN = '...'
+                          ...
+                          end
+                          ...
+                          def $METHOD2(...)
+                          ...
+                          end
+                      - pattern: OpenSSL::PKey::RSA.new(..., $ASSIGN)
+                  - patterns:
+                      - pattern-inside: |
+                          $ASSIGN = '...'
+                          ...
+                          def $METHOD(...)
+                            $OPENSSL = OpenSSL::PKey::RSA.new(...)
+                          ...
+                          end
+                          ...
+                      - pattern-either:
+                          - pattern: $OPENSSL.export(...,$ASSIGN)
+                          - pattern: $OPENSSL.to_pem(...,$ASSIGN)
+                  - patterns:
+                      - pattern-inside: |
+                          def $METHOD1(...)
+                          ...
+                          $OPENSSL = OpenSSL::PKey::RSA.new(...)
+                          ...
+                          $ASSIGN = '...'
+                          ...
+                          end
+                          ...
+                      - pattern-either:
+                          - pattern: $OPENSSL.export(...,$ASSIGN)
+                          - pattern: $OPENSSL.to_pem(...,$ASSIGN)
+                  - patterns:
+                      - pattern-inside: |
+                          def $METHOD1(...)
+                          ...
+                          $ASSIGN = '...'
+                          ...
+                          end
+                          ...
+                          def $METHOD2(...)
+                          ...
+                          $OPENSSL = OpenSSL::PKey::RSA.new(...)
+                          ...
+                          end
+                          ...
+                      - pattern-either:
+                          - pattern: $OPENSSL.export(...,$ASSIGN)
+                          - pattern: $OPENSSL.to_pem(...,$ASSIGN)

--- a/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
+++ b/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
@@ -10,7 +10,7 @@ rules:
       technology:
         - ruby
       category: security
-      references: |
+      references: 
         - https://cwe.mitre.org/data/definitions/522.html
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"

--- a/ruby/lang/security/insufficient-rsa-key-size.rb
+++ b/ruby/lang/security/insufficient-rsa-key-size.rb
@@ -1,0 +1,51 @@
+
+
+module Test
+
+    require 'openssl'
+    @value = 512
+    # ok: insufficient-rsa-key-size
+    OpenSSL::PKey::RSA.new 2048
+
+    # ruleid: insufficient-rsa-key-size
+    key = OpenSSL::PKey::RSA.new(512, 3)
+
+    # ruleid: insufficient-rsa-key-size
+    OpenSSL::PKey::RSA.new 512
+
+    y = 512
+    # ruleid: insufficient-rsa-key-size
+    key = OpenSSL::PKey::RSA.new(y)
+
+
+    class Test
+        @key = 512
+        @pass1 = 2048
+
+        def assign(key = nil, iv = nil)
+			@key2 = 512
+			# ruleid: insufficient-rsa-key-size
+			OpenSSL::PKey::RSA.new(@key2)
+        end
+
+
+		def bad
+			# ruleid: insufficient-rsa-key-size
+			key = OpenSSL::PKey::RSA.new(@key)
+		end
+
+        def bad1
+            # ruleid: insufficient-rsa-key-size
+			key = OpenSSL::PKey::RSA.new(@key2)
+		end
+
+
+        def ok
+			key_pem = File.read @fileWithKeyName
+            # ok: insufficient-rsa-key-size
+			key = OpenSSL::PKey::RSA.new(@pass1)
+            # ok: insufficient-rsa-key-size
+			key = OpenSSL::PKey::RSA.new(2048)
+		end
+
+end

--- a/ruby/lang/security/insufficient-rsa-key-size.yaml
+++ b/ruby/lang/security/insufficient-rsa-key-size.yaml
@@ -1,0 +1,68 @@
+rules:
+- id: insufficient-rsa-key-size
+  message: |
+      The RSA key size $SIZE is insufficent by NIST standards. It is recommended to use a key length of 2048 or higher.
+  languages: [ruby]
+  severity: WARNING
+  metadata:
+    category: security
+    references: |
+      - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
+    cwe:
+      - "CWE-326: Inadequate Encryption Strength"
+    owasp:
+      - "A02:2021 - Cryptographic Failures"
+      - "A03:2017 - Sensitive Data Exposure"
+  patterns:
+  - pattern-either:
+      - pattern: OpenSSL::PKey::RSA.generate($SIZE,...)
+      - pattern: OpenSSL::PKey::RSA.new($SIZE, ...)
+      - patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern-inside: |
+                      $ASSIGN = $SIZE
+                      ...
+                      def $METHOD(...)
+                      ...
+                      end
+                      ...
+                  - pattern: OpenSSL::PKey::RSA.new($ASSIGN, ...)
+              - patterns:
+                  - pattern-inside: |
+                      def $METHOD1(...)
+                      ...
+                      $ASSIGN = $SIZE
+                      ...
+                      end
+                      ...
+                      def $METHOD2(...)
+                      ...
+                      end
+                      ...
+                  - pattern: OpenSSL::PKey::RSA.new($ASSIGN, ...)  
+              - patterns:
+                  - pattern-inside: |
+                      $ASSIGN = $SIZE
+                      ...
+                      def $METHOD(...)
+                      ...
+                      end
+                      ...
+                  - pattern: OpenSSL::PKey::RSA.generate($ASSIGN, ...)
+              - patterns:
+                  - pattern-inside: |
+                      def $METHOD1(...)
+                      ...
+                      $ASSIGN = $SIZE
+                      ...
+                      end
+                      ...
+                      def $METHOD2(...)
+                      ...
+                      end
+                      ...
+                  - pattern: OpenSSL::PKey::RSA.generate($ASSIGN, ...)  
+  - metavariable-comparison:
+      metavariable: $SIZE
+      comparison: $SIZE < 2048

--- a/ruby/lang/security/insufficient-rsa-key-size.yaml
+++ b/ruby/lang/security/insufficient-rsa-key-size.yaml
@@ -8,7 +8,7 @@ rules:
     technology:
         - ruby
     category: security
-    references: |
+    references: 
       - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf
     cwe:
       - "CWE-326: Inadequate Encryption Strength"

--- a/ruby/lang/security/insufficient-rsa-key-size.yaml
+++ b/ruby/lang/security/insufficient-rsa-key-size.yaml
@@ -1,10 +1,12 @@
 rules:
 - id: insufficient-rsa-key-size
-  message: |
+  message: >-
       The RSA key size $SIZE is insufficent by NIST standards. It is recommended to use a key length of 2048 or higher.
   languages: [ruby]
   severity: WARNING
   metadata:
+    technology:
+        - ruby
     category: security
     references: |
       - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57Pt3r1.pdf


### PR DESCRIPTION
Adding checks for ruby:
1. Hard coded passphrase when using RSA
2. Use of RSA with keylength < 2048