### PR TITLE
Rule for template strings with interpolation and HTML

### DIFF
--- a/javascript/lang/security/html-in-template-string.js
+++ b/javascript/lang/security/html-in-template-string.js
@@ -1,0 +1,25 @@
+
+// ok: html-in-template-string
+const planet = `world`;
+const greeting = "hello";
+
+// ok: html-in-template-string
+let a = `hello ${planet}`;
+
+// ruleid: html-in-template-string
+let b = `<h1>hello ${planet}</h1>`;
+
+// ruleid: html-in-template-string
+let start = `<h1>hello ${planet}`;
+
+// ruleid: html-in-template-string
+let end = `${planet}</h1><b>foo</b>`;
+
+// ruleid: html-in-template-string
+let two = `<h1>${greeting} beautiful ${planet}</h1>`;
+
+function createHtml() {
+    // from issue #1385
+    // ruleid: html-in-template-string
+    return `<div style=${style.color}>${content}</div>`
+}

--- a/javascript/lang/security/html-in-template-string.yaml
+++ b/javascript/lang/security/html-in-template-string.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: html-in-template-string
+    message: >-
+      This template literal looks like HTML and has interpolated variables.
+      These variables are not HTML-encoded by default. If the variables contain
+      HTML tags, these may be interpreted by the browser, resulting in cross-site
+      scripting (XSS).
+    metadata:
+      cwe: "CWE-116: Improper Encoding or Escaping of Output"
+      owasp: "A7: Cross-Site Scripting (XSS)"
+      category: security
+      technology:
+        - javascript
+    languages:
+      - javascript
+      - typescript
+    severity: WARNING
+    patterns:
+      - pattern-either:
+        - pattern: |
+            `$HTML${$VAR}...`
+        - pattern: |
+            `...${$VAR}$HTML`
+      - metavariable-regex:
+          metavariable: $HTML
+          regex: ".*</?[a-zA-Z]"


### PR DESCRIPTION
E.g.
```
return `<div style=${style.color}>${content}</div>`
```

Closes issue #1385