### PR TITLE
Filter floats from Ruby divide-by-zero rule

### DIFF
--- a/ruby/lang/security/divide-by-zero.rb
+++ b/ruby/lang/security/divide-by-zero.rb
@@ -1,13 +1,19 @@
  def divide_by_zero
-    # ruleid: divide-by-zero
-    3/0
-    # ruleid: divide-by-zero
-    oops = 4/0
-    variable = 3
-    # ruleid: divide-by-zero
-    oops = variable / 0
-    # ruleid: divide-by-zero
-    zero = 0
-    # ruleid: divide-by-zero
-    bad = variable/zero
+   # ruleid: divide-by-zero
+   3/0
+   # ruleid: divide-by-zero
+   oops = 4/0
+   variable = 3
+   # ruleid: divide-by-zero
+   oops = variable / 0
+
+   zero = 0
+   # ruleid: divide-by-zero
+   bad = variable/zero
+
+   # ok: divide-by-zero
+   ok = 1.0 / 0
+   # ok: divide-by-zero
+   ok2 = 2.0 / zero
+   
  end

--- a/ruby/lang/security/divide-by-zero.yaml
+++ b/ruby/lang/security/divide-by-zero.yaml
@@ -1,22 +1,25 @@
 rules:
   - id: divide-by-zero
     message: >-
-      Checks for divide by zero. Best practice involves not dividing a variable by zero,
-      as this leads to a Ruby
-      ZeroDivisionError.
+      Detected a possible ZeroDivisionError.
     metadata:
       references:
         - https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_divide_by_zero.rb
       category: security
       technology:
         - ruby
+      confidence: MEDIUM
     languages:
       - ruby
     severity: WARNING
-    pattern-either:
-      - pattern: |
-          $X / 0
-      - pattern: |
-          $ZERO = 0
-          ...
-          $X / $ZERO
+    mode: taint
+    pattern-sources:
+    - patterns:
+      - pattern: $VAR
+      - metavariable-regex:
+          metavariable: $VAR
+          regex: ^\d*(?!\.)$
+    pattern-sinks:
+    - patterns:
+      - pattern-inside: $NUMER / 0
+      - pattern: $NUMER


### PR DESCRIPTION
Use metavariable-regex plus taint mode to limit Ruby's divide-by-zero rule to integers. In Ruby, floats divided by zero are idiomatic for 'Infinity'. This should filter out that case.