### PR TITLE
Update to use semgrep command in docker image. Entrypoint was deprecated

### DIFF
--- a/.github/workflows/semgrep-rules-test-develop.yml
+++ b/.github/workflows/semgrep-rules-test-develop.yml
@@ -22,7 +22,7 @@ jobs:
       run: rm -rf semgrep-rules/fingerprints
     - name: validate rules
       run: |
-        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --validate --config /src
+        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop semgrep --validate --config /src
     - name: test with semgrep develop branch
       run: |
-        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop --test --test-ignore-todo /src
+        docker run --rm -v ${GITHUB_WORKSPACE}/semgrep-rules:/src returntocorp/semgrep:develop semgrep --test --test-ignore-todo /src


### PR DESCRIPTION
from https://github.com/returntocorp/semgrep-rules/runs/5978850918?check_suite_focus=true

```
======= DEPRECATION WARNING =======
The returntocorp/semgrep Docker image's custom entrypoint will be removed by June 2022.
Please update your command to explicitly call semgrep.
Change from:  docker run returntocorp/semgrep --validate --config /src
Change to:    docker run returntocorp/semgrep semgrep --validate --config /src
```