### PR TITLE
Generic to dockerfile updates

### DIFF
--- a/dockerfile/best-practice/avoid-apk-upgrade.yaml
+++ b/dockerfile/best-practice/avoid-apk-upgrade.yaml
@@ -14,8 +14,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern: RUN ... apk upgrade ...

--- a/dockerfile/best-practice/avoid-apt-get-upgrade.yaml
+++ b/dockerfile/best-practice/avoid-apt-get-upgrade.yaml
@@ -12,10 +12,6 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern-either:
       - pattern: RUN ... apt-get upgrade ...
       - pattern: RUN ... apt-get dist-upgrade ...

--- a/dockerfile/best-practice/avoid-dnf-update.yaml
+++ b/dockerfile/best-practice/avoid-dnf-update.yaml
@@ -13,8 +13,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern: dnf update

--- a/dockerfile/best-practice/avoid-latest-version.yaml
+++ b/dockerfile/best-practice/avoid-latest-version.yaml
@@ -13,8 +13,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern: FROM $FROM:latest

--- a/dockerfile/best-practice/avoid-platform-with-from.yaml
+++ b/dockerfile/best-practice/avoid-platform-with-from.yaml
@@ -17,8 +17,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
 #   fix: FROM $IMAGE

--- a/dockerfile/best-practice/avoid-yum-update.yaml
+++ b/dockerfile/best-practice/avoid-yum-update.yaml
@@ -13,8 +13,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern: yum update

--- a/dockerfile/best-practice/avoid-zypper-update.yaml
+++ b/dockerfile/best-practice/avoid-zypper-update.yaml
@@ -13,8 +13,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern: zypper update ...

--- a/dockerfile/best-practice/maintainer-is-deprecated.yaml
+++ b/dockerfile/best-practice/maintainer-is-deprecated.yaml
@@ -12,8 +12,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     fix: "# MAINTAINER $NAME"

--- a/dockerfile/best-practice/missing-apk-no-cache.yaml
+++ b/dockerfile/best-practice/missing-apk-no-cache.yaml
@@ -19,8 +19,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
 #   fix: RUN apk $COMMAND --no-cache $SOMETHING

--- a/dockerfile/best-practice/missing-dnf-assume-yes-switch.yaml
+++ b/dockerfile/best-practice/missing-dnf-assume-yes-switch.yaml
@@ -19,7 +19,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/missing-dnf-clean-all.yaml
+++ b/dockerfile/best-practice/missing-dnf-clean-all.yaml
@@ -15,7 +15,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/missing-image-version.yaml
+++ b/dockerfile/best-practice/missing-image-version.yaml
@@ -18,8 +18,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
-

--- a/dockerfile/best-practice/missing-no-install-recommends.yaml
+++ b/dockerfile/best-practice/missing-no-install-recommends.yaml
@@ -18,7 +18,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/missing-yum-assume-yes-switch.yaml
+++ b/dockerfile/best-practice/missing-yum-assume-yes-switch.yaml
@@ -19,7 +19,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/nonsensical-command.yaml
+++ b/dockerfile/best-practice/nonsensical-command.yaml
@@ -17,7 +17,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/prefer-apt-get.yaml
+++ b/dockerfile/best-practice/prefer-apt-get.yaml
@@ -14,7 +14,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/prefer-copy-over-add.yaml
+++ b/dockerfile/best-practice/prefer-copy-over-add.yaml
@@ -13,8 +13,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern: ADD $FROM $TO

--- a/dockerfile/best-practice/prefer-json-notation.yaml
+++ b/dockerfile/best-practice/prefer-json-notation.yaml
@@ -13,10 +13,6 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern-either:
       - patterns:
           - pattern: CMD $WORD ...

--- a/dockerfile/best-practice/remove-package-cache.yaml
+++ b/dockerfile/best-practice/remove-package-cache.yaml
@@ -16,7 +16,3 @@ rules:
       technology:
         - dockerfile
       license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/remove-package-lists.yaml
+++ b/dockerfile/best-practice/remove-package-lists.yaml
@@ -18,7 +18,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/best-practice/use-either-wget-or-curl.yaml
+++ b/dockerfile/best-practice/use-either-wget-or-curl.yaml
@@ -11,10 +11,6 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern-either:
       - pattern: |
           RUN wget ...

--- a/dockerfile/best-practice/use-shell-instruction.yaml
+++ b/dockerfile/best-practice/use-shell-instruction.yaml
@@ -13,8 +13,4 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     fix: SHELL ["$SHELL", "-c"]

--- a/dockerfile/best-practice/use-workdir.yaml
+++ b/dockerfile/best-practice/use-workdir.yaml
@@ -13,7 +13,3 @@ rules:
       category: best-practice
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/correctness/invalid-port.dockerfile
+++ b/dockerfile/correctness/invalid-port.dockerfile
@@ -11,5 +11,5 @@ EXPOSE 65536
 # ok: invalid-port
 EXPOSE 0
 
-# ruleid: invalid-port
-EXPOSE -1
+# this is invalid dockerfile code and can not be parsed with dockerfile parser
+# EXPOSE -1

--- a/dockerfile/correctness/invalid-port.yaml
+++ b/dockerfile/correctness/invalid-port.yaml
@@ -1,9 +1,9 @@
 rules:
   - id: invalid-port
-    message: >-
-      Detected an invalid port number. Valid ports are 0 through 65535.
+    message: Detected an invalid port number. Valid ports are 0 through 65535.
     severity: ERROR
-    languages: [generic]
+    languages:
+      - dockerfile
     metadata:
       source-rule-url: https://github.com/hadolint/hadolint/wiki/DL3011
       references:
@@ -11,14 +11,9 @@ rules:
       category: correctness
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"
     pattern-either:
       - patterns:
           - pattern: EXPOSE $PORT
           - metavariable-comparison:
               metavariable: $PORT
-              comparison: $PORT > 65535
-      - pattern: EXPOSE -$PORT
+              comparison: int($PORT) > 65535

--- a/dockerfile/correctness/missing-assume-yes-switch.yaml
+++ b/dockerfile/correctness/missing-assume-yes-switch.yaml
@@ -21,7 +21,3 @@ rules:
       category: correctness
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/correctness/multiple-entrypoint-instructions.yaml
+++ b/dockerfile/correctness/multiple-entrypoint-instructions.yaml
@@ -16,7 +16,3 @@ rules:
       category: correctness
       technology:
         - dockerfile
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/security/last-user-is-root.yaml
+++ b/dockerfile/security/last-user-is-root.yaml
@@ -21,7 +21,3 @@ rules:
       technology:
         - dockerfile
       confidence: MEDIUM
-    paths:
-      include:
-        - "*dockerfile*"
-        - "*Dockerfile*"

--- a/dockerfile/security/missing-user.yaml
+++ b/dockerfile/security/missing-user.yaml
@@ -13,10 +13,6 @@ rules:
       is a USER other than 'root'.
     severity: ERROR
     languages: [dockerfile]
-    paths:
-      include:
-        - "*Dockerfile*"
-        - "*dockerfile*"
     metadata:
       category: security
       technology:


### PR DESCRIPTION
This PR does two things

- remove `paths` key from rules that is no longer necessary when using dockerfile parser.
- Port additional rule `invalid-port`. Also removed a test case for this rule as that test case is invalid dockerfile code and can not be parsed with the dockerfile parser. Output before commenting out this test case:

```
semgrep-core -dump_ast correctness/invalid-port.dockerfile -lang dockerfile

Pr(
  [ExprStmt(
     Call(N(Id(("FROM", ()), {id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
       [Arg(
          Call(
            N(
              Id(("!dockerfile_concat!", ()),
                {id_hidden=true; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
            [Arg(L(String(("b", ())))); Arg(L(String(("usybox", ()))))]))]), ());
   ExprStmt(
     Call(N(Id(("EXPOSE", ()), {id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
       [Arg(L(String(("65535", ()))))]), ());
   ExprStmt(
     Call(N(Id(("EXPOSE", ()), {id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
       [Arg(L(String(("65536", ()))))]), ());
   ExprStmt(
     Call(N(Id(("EXPOSE", ()), {id_hidden=false; id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
       [Arg(L(String(("0", ()))))]), ())])
WARNING: fail to fully parse correctness/invalid-port.dockerfile
```
