### PR TITLE
Add fs-directory-listing rule (Go)

### DIFF
--- a/go/lang/security/audit/net/fs-directory-listing.go
+++ b/go/lang/security/audit/net/fs-directory-listing.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func dirListing1() {
+	fs := http.FileServer(http.Dir(""))
+	//ruleid: fs-directory-listing
+	log.Fatal(http.ListenAndServe(":9000", fs))
+}
+
+func dirListing2() {
+	fs := http.FileServer(http.Dir(""))
+	certFile := "/path/tp/my/cert"
+	keyFile := "/path/to/my/key"
+	//ruleid: fs-directory-listing
+	log.Fatal(http.ListenAndServeTLS(":9000", certFile, keyFile, fs))
+}
+
+func dirListing3() {
+	fs := http.FileServer(http.Dir(""))
+	//ruleid: fs-directory-listing
+	http.Handle("/myroute", fs)
+}
+
+func dirListing4() {
+	//ruleid: fs-directory-listing
+	http.Handle("/myroute", http.FileServer(http.Dir("")))
+}
+
+func noDirListing1() {
+	h1 := func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("<h1>Hello!</h1>"))
+	}
+	//ok: fs-directory-listing
+	http.HandleFunc("/myroute", h1)
+}
+
+func noDirListing2() {
+	h1 := func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("<h1>Home page</h1>"))
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", h1)
+	//ok: fs-directory-listing
+	log.Fatal(http.ListenAndServe(":9000", mux))
+}

--- a/go/lang/security/audit/net/fs-directory-listing.yaml
+++ b/go/lang/security/audit/net/fs-directory-listing.yaml
@@ -1,6 +1,6 @@
 rules:
   - id: fs-directory-listing
-    message: >
+    message: >-
       Detected usage of 'http.FileServer' as handler: this allows directory listing
       and an attacker could navigate through directories looking for sensitive
       files. Be sure to disable directory listing or restrict access to specific

--- a/go/lang/security/audit/net/fs-directory-listing.yaml
+++ b/go/lang/security/audit/net/fs-directory-listing.yaml
@@ -38,3 +38,5 @@ rules:
         - https://github.com/OWASP/Go-SCP
         - https://cwe.mitre.org/data/definitions/548.html
       confidence: MEDIUM
+      technology:
+        - go

--- a/go/lang/security/audit/net/fs-directory-listing.yaml
+++ b/go/lang/security/audit/net/fs-directory-listing.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: fs-directory-listing
+    message: >
+      Detected usage of 'http.FileServer' as handler: this allows directory listing
+      and an attacker could navigate through directories looking for sensitive
+      files. Be sure to disable directory listing or restrict access to specific
+      directories/files.
+    severity: WARNING
+    languages:
+      - go
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern-inside: |
+                  $FS := http.FileServer(...)
+                  ...
+              - pattern-either:
+                  - pattern: |
+                      http.ListenAndServe(..., $FS)
+                  - pattern: |
+                      http.ListenAndServeTLS(..., $FS)
+                  - pattern: |
+                      http.Handle(..., $FS)
+                  - pattern: |
+                      http.HandleFunc(..., $FS)
+          - patterns:
+              - pattern: |
+                  http.$FN(..., http.FileServer(...))
+              - metavariable-regex:
+                  metavariable: $FN
+                  regex: (ListenAndServe|ListenAndServeTLS|Handle|HandleFunc)
+    metadata:
+      category: security
+      cwe: "CWE-548: Exposure of Information Through Directory Listing"
+      owasp:
+        - A05:2021 - Security Misconfiguration
+      references:
+        - https://github.com/OWASP/Go-SCP
+        - https://cwe.mitre.org/data/definitions/548.html
+      confidence: MEDIUM


### PR DESCRIPTION
Simple rule to check if 'http.FileServer' is used which can lead to directory listing vulnerability.