### PR TITLE
edit rule to make sure there's not too many FPs

### DIFF
--- a/java/lang/security/audit/formatted-sql-string.java
+++ b/java/lang/security/audit/formatted-sql-string.java
@@ -67,6 +67,7 @@ public class SqlExample2 {
 
     public List<AccountDTO> findAccountsById(String id) {
         String jql = "from Account where id = '" + id + "'";
+        EntityManager em = emfactory.createEntityManager();
         // ruleid:formatted-sql-string
         TypedQuery<Account> q = em.createQuery(jql, Account.class);
         return q.getResultList()
@@ -92,6 +93,7 @@ public class SQLExample3 {
 
     public List<AccountDTO> findAccountsById(String id) {
         String jql = String.format("from Account where id = '%s'", id);
+        EntityManager em = emfactory.createEntityManager();
         // ruleid: formatted-sql-string
         TypedQuery<Account> q = em.createQuery(jql, Account.class);
         return q.getResultList()
@@ -117,3 +119,16 @@ public class tableConcatStatements {
         stmt.execute(String.format("CREATE TABLE %s", tableName));
     }
 }
+
+// This whole operation has nothing to do with SQL
+public class FalsePositiveCase {
+    private ApiClient apiClient; // imagine an ApiClient class that contains a method named execute
+
+    public void test(String parameter) throws ApiException {
+        com.squareup.okhttp.Call call = constructHttpCall(parameter); // Create OKHttp call using parameter from outside
+        apiClient.execute(call);
+        apiClient.execute(call);
+        apiClient.run(call); // proof that 'execute' name is causing the false-positive
+    }
+}
+

--- a/java/lang/security/audit/formatted-sql-string.java
+++ b/java/lang/security/audit/formatted-sql-string.java
@@ -126,7 +126,9 @@ public class FalsePositiveCase {
 
     public void test(String parameter) throws ApiException {
         com.squareup.okhttp.Call call = constructHttpCall(parameter); // Create OKHttp call using parameter from outside
+                                                                 // ok: formatted-sql-string
         apiClient.execute(call);
+        // ok: formatted-sql-string
         apiClient.execute(call);
         apiClient.run(call); // proof that 'execute' name is causing the false-positive
     }

--- a/java/lang/security/audit/formatted-sql-string.java
+++ b/java/lang/security/audit/formatted-sql-string.java
@@ -126,7 +126,7 @@ public class FalsePositiveCase {
 
     public void test(String parameter) throws ApiException {
         com.squareup.okhttp.Call call = constructHttpCall(parameter); // Create OKHttp call using parameter from outside
-                                                                 // ok: formatted-sql-string
+        // ok: formatted-sql-string
         apiClient.execute(call);
         // ok: formatted-sql-string
         apiClient.execute(call);

--- a/java/lang/security/audit/formatted-sql-string.yaml
+++ b/java/lang/security/audit/formatted-sql-string.yaml
@@ -37,9 +37,12 @@ rules:
             - pattern: String.format(..., (String $INPUT), ...)
     pattern-sinks: 
     - patterns:
-      - pattern-not: $W.$SQLFUNC(<... "=~/.*TABLE *$/" ...>)
-      - pattern-not: $W.$SQLFUNC(<... "=~/.*TABLE %s$/" ...>)
-      - pattern: $W.$SQLFUNC(...)
+      - pattern-not: $S.$SQLFUNC(<... "=~/.*TABLE *$/" ...>)
+      - pattern-not: $S.$SQLFUNC(<... "=~/.*TABLE %s$/" ...>)
+      - pattern-either:
+        - pattern: (Statement $S).$SQLFUNC(...)
+        - pattern: (Connection $C).createStatement(...).$SQLFUNC(...)
+        - pattern: (EntityManager $EM).$SQLFUNC(...)
       - metavariable-regex:
           metavariable: $SQLFUNC
           regex: execute|executeQuery|createQuery|query


### PR DESCRIPTION
should solve https://github.com/returntocorp/semgrep-rules/issues/2024. 

* this will reduce FPs with the usage of typed metavariables. However, there will be cases we don't catch as a result (because we're specifying the types). 

_To test:_
run `semgrep --test .` in the directory.