### PR TITLE
Improvements to node-expat checker & angularjs methods

### DIFF
--- a/javascript/angular/security/detect-angular-element-methods.js
+++ b/javascript/angular/security/detect-angular-element-methods.js
@@ -1,18 +1,11 @@
 var app = angular.module('MyApp', []);
-app.controller('myCtrl', function($scope) {
+app.controller('myCtrl', function($scope,$sanitize) {
+    $scope.value = grabInput()
+    $rootScope.value = grabInput()
     // ruleid: detect-angular-element-methods
-    var now = angular.element($scope.input).html();
+    angular.element('div').html($scope.value)
+    // ok: detect-angular-element-methods
+    angular.element('div').html('hi')
     // ruleid: detect-angular-element-methods
-    var now = angular.element($scope.input).append("foo");
-    // ruleid: detect-angular-element-methods
-    var now = angular.element($scope.input).prepend("foo");
-    // ruleid: detect-angular-element-methods
-    var now = angular.element($scope.input).wrap();
-
-    var el = angular.element($scope.input);
-    // ruleid: detect-angular-element-methods
-    var now = el.html();
-
-    return now;
-
+    angular.element('div').html($rootScope.value)
 });

--- a/javascript/angular/security/detect-angular-element-methods.yaml
+++ b/javascript/angular/security/detect-angular-element-methods.yaml
@@ -2,30 +2,44 @@ rules:
   - id: detect-angular-element-methods
     mode: taint
     message: >-
-      Use of angular.element can lead to XSS if after,append,html,prepend,replaceWith,wrap are used with user-input.
+      Use of angular.element can lead to XSS if user-input is treated as part of the HTML element within `$SINK`. 
+      It is recommended to contextually output encode user-input, before inserting into `$SINK`. 
+      If the HTML needs to be preseved it is recommended to sanitize the input using $sce.getTrustedHTML or $sanitize.
     languages:
       - javascript
       - typescript
     metadata:
+      confidence: LOW
       references:
         - https://docs.angularjs.org/api/ng/function/angular.element
         - https://owasp.org/www-chapter-london/assets/slides/OWASPLondon20170727_AngularJS.pdf
       category: security
       technology:
-        - angular
-    severity: WARNING
+        - angularjs
+    severity: INFO
     pattern-sources:
-      - pattern: angular.element(...)
+      - patterns:
+          - pattern-either:
+              - pattern: $scope
+              - pattern: $rootScope
+              - pattern: $injector.get('$rootScope')
+              - pattern: $injector.get('$scope')
     pattern-sinks:
-      - pattern: |
-          $SINK.html(...);
-      - pattern: |
-          $SINK.append(...);
-      - pattern: |
-          $SINK.prepend(...);
-      - pattern: |
-          $SINK.replaceWith(...);
-      - pattern: |
-          $SINK.wrap(...);
-      - pattern: |
-          $SINK.after(...);
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  angular.element(...). ... .$SINK($QUERY)
+              - pattern-inside: |
+                  $ANGULAR = angular.element(...)
+                  ...
+                  $ANGULAR. ... .$SINK($QUERY)
+          - metavariable-regex:
+              metavariable: $SINK
+              regex: ^(after|append|html|prepend|replaceWith|wrap)$
+          - pattern: $QUERY
+    pattern-sanitizers:
+      - patterns:
+          - pattern-either:
+              - pattern: $sce.getTrustedHtml(...)
+              - pattern: $sanitize(...)
+              - pattern: DOMPurify.sanitize(...)

--- a/javascript/angular/security/detect-angular-element-taint.js
+++ b/javascript/angular/security/detect-angular-element-taint.js
@@ -1,0 +1,12 @@
+var app = angular.module('MyApp', []);
+app.controller('myCtrl', function($scope,$sanitize) {
+    let a = unescape(window.location.href)
+    // ruleid: detect-angular-element-taint
+    angular.element('div').html(a)
+    let b = $sanitize(unescape(window.location.href))
+    // ok: detect-angular-element-taint
+    angular.element('div').html(b)
+    // ruleid: detect-angular-element-taint
+    angular.element('div').html((new URLSearchParams(window.location.search)).get('returnUrl'))
+
+});

--- a/javascript/angular/security/detect-angular-element-taint.yaml
+++ b/javascript/angular/security/detect-angular-element-taint.yaml
@@ -1,0 +1,70 @@
+rules:
+  - id: detect-angular-element-taint
+    mode: taint
+    message: >-
+      Use of angular.element can lead to XSS if user-input is treated as part of the HTML element within `$SINK`. 
+      It is recommended to contextually output encode user-input, before inserting into `$SINK`. 
+      If the HTML needs to be preseved it is recommended to sanitize the input using $sce.getTrustedHTML or $sanitize.
+    languages:
+      - javascript
+      - typescript
+    metadata:
+      confidence: HIGH
+      references:
+        - https://docs.angularjs.org/api/ng/function/angular.element
+        - https://owasp.org/www-chapter-london/assets/slides/OWASPLondon20170727_AngularJS.pdf
+      category: security
+      technology:
+        - angularjs
+    severity: WARNING
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern: window.location.search
+              - pattern: window.document.location.search
+              - pattern: document.location.search
+              - pattern: location.search
+              - pattern: $location.search(...)
+      - patterns:
+          - pattern-either:
+              - pattern: $DECODE(<... location.hash ...>)
+              - pattern: $DECODE(<... window.location.hash ...>)
+              - pattern: $DECODE(<... document.location.hash ...>)
+              - pattern: $DECODE(<... location.href ...>)
+              - pattern: $DECODE(<... window.location.href ...>)
+              - pattern: $DECODE(<... document.location.href ...>)
+              - pattern: $DECODE(<... document.URL ...>)
+              - pattern: $DECODE(<... window.document.URL ...>)
+              - pattern: $DECODE(<... document.location.href ...>)
+              - pattern: $DECODE(<... document.location.href ...>)
+              - pattern: $DECODE(<... $location.absUrl() ...>)
+              - pattern: $DECODE(<... $location.url() ...>)
+              - pattern: $DECODE(<... $location.hash() ...>)
+          - metavariable-regex:
+              metavariable: $DECODE
+              regex: ^(unescape|decodeURI|decodeURIComponent)$
+      - patterns:
+          - pattern-inside: $http.$METHOD(...).$CONTINUE(function $FUNC($RES) {...})
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(get|delete|head|jsonp|post|put|patch)
+          - pattern: $RES.data
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  angular.element(...). ... .$SINK($QUERY)
+              - pattern-inside: |
+                  $ANGULAR = angular.element(...)
+                  ...
+                  $ANGULAR. ... .$SINK($QUERY)
+          - metavariable-regex:
+              metavariable: $SINK
+              regex: ^(after|append|html|prepend|replaceWith|wrap)$
+          - pattern: $QUERY
+    pattern-sanitizers:
+      - patterns:
+          - pattern-either:
+              - pattern: $sce.getTrustedHtml(...)
+              - pattern: $sanitize(...)
+              - pattern: DOMPurify.sanitize(...)

--- a/javascript/express/security/express-expat-xxe.yaml
+++ b/javascript/express/security/express-expat-xxe.yaml
@@ -2,10 +2,12 @@ rules:
   - id: express-expat-xxe
     mode: taint
     message: >-
-      Make sure that unverified user data can not reach the XML Parser,
-      as it can result in XML External or Internal Entity (XXE) Processing vulnerabilities
+      Make sure that unverified user data can not reach the XML Parser, as it
+      can result in XML External or Internal Entity (XXE) Processing
+      vulnerabilities
     metadata:
-      owasp: "A4: XML External Entities (XXE)"
+      owasp: 
+        - "A4: XML External Entities (XXE)"
       cwe: "CWE-611: Improper Restriction of XML External Entity Reference"
       asvs:
         section: V5 Validation, Sanitization and Encoding
@@ -16,26 +18,52 @@ rules:
       technology:
         - express
     severity: ERROR
-    languages: [javascript, typescript]
+    languages:
+      - javascript
+      - typescript
     pattern-sources:
       - patterns:
           - pattern-either:
               - pattern-inside: function ... ($REQ, $RES) {...}
               - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
-              - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
-              - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
-              - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
-              - pattern-inside: $APP.head(..., function $FUNC($REQ, $RES) {...})
-              - pattern-inside: $APP.delete(..., function $FUNC($REQ, $RES) {...})
-              - pattern-inside: $APP.options(..., function $FUNC($REQ, $RES) {...})
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
+                      - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})
+                  - metavariable-regex:
+                      metavariable: $METHOD
+                      regex: ^(get|post|put|head|delete|options)$
           - pattern-either:
-              - pattern: $REQ.$QUERY
-              - pattern: $REQ.$BODY.$PARAM
+              - pattern: $REQ.query
+              - pattern: $REQ.body
+              - pattern: $REQ.params
+              - pattern: $REQ.cookies
+              - pattern: $REQ.headers
+      - patterns:
+          - pattern-either:
+              - pattern-inside: >
+                  ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
+                  {...}
+              - pattern-inside: |
+                  ({ $REQ }: Request,$RES: Response) => {...}
+          - pattern-either:
+              - pattern: params
+              - pattern: query
+              - pattern: cookies
+              - pattern: headers
+              - pattern: body
     pattern-sinks:
       - patterns:
-          - pattern-inside: |
-              require('node-expat');
-              ...
+          - pattern-either:
+              - pattern-inside: |
+                  $XML = require('node-expat')
+                  ...
+              - pattern-inside: |
+                  import $XML from 'node-expat'
+                  ...
+              - pattern-inside: |
+                  import * as $XML from 'node-expat'
+                  ...
           - pattern-either:
               - pattern-inside: |
                   $PARSER = new $EXPAT.Parser(...);
@@ -44,5 +72,6 @@ rules:
                   $PARSER = new Parser(...);
                   ...
           - pattern-either:
-              - pattern: $PARSER.parse(...)
-              - pattern: $PARSER.write(...)
+              - pattern-inside: $PARSER.parse($QUERY)
+              - pattern: $PARSER.write($QUERY)
+          - pattern: $QUERY

--- a/javascript/express/security/express-expat-xxe.yaml
+++ b/javascript/express/security/express-expat-xxe.yaml
@@ -66,10 +66,7 @@ rules:
                   ...
           - pattern-either:
               - pattern-inside: |
-                  $PARSER = new $EXPAT.Parser(...);
-                  ...
-              - pattern-inside: |
-                  $PARSER = new Parser(...);
+                  $PARSER = new $XML.Parser(...);
                   ...
           - pattern-either:
               - pattern-inside: $PARSER.parse($QUERY)

--- a/javascript/express/security/express-expat-xxe.yaml
+++ b/javascript/express/security/express-expat-xxe.yaml
@@ -7,7 +7,8 @@ rules:
       vulnerabilities
     metadata:
       owasp: 
-        - "A4: XML External Entities (XXE)"
+        - A4:2017 - XML External Entities (XXE)
+        - A03:2021 - Injection
       cwe: "CWE-611: Improper Restriction of XML External Entity Reference"
       asvs:
         section: V5 Validation, Sanitization and Encoding

--- a/javascript/express/security/express-expat-xxe.yaml
+++ b/javascript/express/security/express-expat-xxe.yaml
@@ -7,7 +7,7 @@ rules:
       vulnerabilities
     metadata:
       owasp: 
-        - A4:2017 - XML External Entities (XXE)
+        - A04:2017 - XML External Entities (XXE)
         - A03:2021 - Injection
       cwe: "CWE-611: Improper Restriction of XML External Entity Reference"
       asvs:


### PR DESCRIPTION
This rule needed some improvements to taint mode:

- Fixes sources to contain more accurate values from input and object deconstruction
- Updates metadata to be more inline 