### PR TITLE
add `tainted-deserialization` rule for Ruby

### DIFF
--- a/ruby/aws-lambda/security/tainted-deserialization.rb
+++ b/ruby/aws-lambda/security/tainted-deserialization.rb
@@ -1,0 +1,26 @@
+def handler(event:, context:)
+	foobar = event['smth']
+
+    # ruleid: tainted-deserialization
+    obj1 = Marshal.load(foobar)
+
+    data = event['body']['object']
+    # ruleid: tainted-deserialization
+    obj2 = YAML.load(data)
+
+    # ruleid: tainted-deserialization
+    obj3 = CSV.load("o:" + event['data'])
+end
+
+def ok_handler(event:, context:)
+
+    # ok: tainted-deserialization
+    obj1 = Marshal.load(Marshal.dump(Foobar.new))
+
+    data = "hardcoded_value"
+    # ok: tainted-deserialization
+    obj2 = YAML.load(data)
+
+    # ok: tainted-deserialization
+    obj3 = CSV.load(get_safe_data())
+end

--- a/ruby/aws-lambda/security/tainted-deserialization.yaml
+++ b/ruby/aws-lambda/security/tainted-deserialization.yaml
@@ -1,6 +1,7 @@
 rules:
 - id: tainted-deserialization
   mode: taint
+  languages: [ruby]
   message: >-
     Deserialization of a string tainted by `event` object found. Objects in Ruby can be serialized into strings,
     then later loaded from strings. However, uses of `load` can cause remote code execution.

--- a/ruby/aws-lambda/security/tainted-deserialization.yaml
+++ b/ruby/aws-lambda/security/tainted-deserialization.yaml
@@ -1,0 +1,35 @@
+rules:
+- id: tainted-deserialization
+  mode: taint
+  message: >-
+    Deserialization of a string tainted by `event` object found. Objects in Ruby can be serialized into strings,
+    then later loaded from strings. However, uses of `load` can cause remote code execution.
+    Loading user input with MARSHAL or CSV can potentially be dangerous. Use JSON in a secure fashion instead.
+  metadata:
+    references:
+      - https://groups.google.com/g/rubyonrails-security/c/61bkgvnSGTQ/m/nehwjA8tQ8EJ
+      - https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_deserialize.rb
+    category: security
+    technology:
+      - ruby
+      - aws-lambda
+  pattern-sinks:
+  - patterns:
+    - pattern: $SINK
+    - pattern-either:
+      - pattern-inside: |
+          YAML.load($SINK,...)
+      - pattern-inside: |
+          CSV.load($SINK,...)
+      - pattern-inside: |
+          Marshal.load($SINK,...)
+      - pattern-inside: |
+          Marshal.restore($SINK,...)
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context)
+          ...
+        end
+  severity: WARNING

--- a/ruby/aws-lambda/security/tainted-deserialization.yaml
+++ b/ruby/aws-lambda/security/tainted-deserialization.yaml
@@ -14,6 +14,8 @@ rules:
       - https://groups.google.com/g/rubyonrails-security/c/61bkgvnSGTQ/m/nehwjA8tQ8EJ
       - https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_deserialize.rb
     category: security
+    owasp: "A08:2017 - Deserialization"
+    cwe: "CWE-502: Deserialization of Untrusted Data"
     technology:
       - ruby
       - aws-lambda

--- a/ruby/aws-lambda/security/tainted-deserialization.yaml
+++ b/ruby/aws-lambda/security/tainted-deserialization.yaml
@@ -5,9 +5,12 @@ rules:
   message: >-
     Deserialization of a string tainted by `event` object found. Objects in Ruby can be serialized into strings,
     then later loaded from strings. However, uses of `load` can cause remote code execution.
-    Loading user input with MARSHAL or CSV can potentially be dangerous. Use JSON in a secure fashion instead.
+    Loading user input with MARSHAL, YAML or CSV can potentially be dangerous.
+    If you need to deserialize untrusted data, you should use JSON as it is only capable of returning 'primitive' types
+    such as strings, arrays, hashes, numbers and nil.
   metadata:
     references:
+      - https://ruby-doc.org/core-3.1.2/doc/security_rdoc.html
       - https://groups.google.com/g/rubyonrails-security/c/61bkgvnSGTQ/m/nehwjA8tQ8EJ
       - https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_deserialize.rb
     category: security


### PR DESCRIPTION
simple rule to catch tainted deserialization calls in AWS Lambda functions