### PR TITLE
Removed false positive for django-ckeditor RichTextFields

### DIFF
--- a/python/django/correctness/nontext-field-must-set-null-true.py
+++ b/python/django/correctness/nontext-field-must-set-null-true.py
@@ -1,4 +1,5 @@
 from django.db import models
+from ckeditor.fields import RichTextField
 from phonenumber_field.modelfields import PhoneNumberField
 
 
@@ -25,6 +26,8 @@ class FakeModel(models.Model):
     fieldUUID = models.UUIDField(blank=True)
     # ok: nontext-field-must-set-null-true
     fieldManyToMany = models.ManyToManyField("self", blank=True)
+    # ok: nontext-field-must-set-null-true
+    fieldCKEditorRichtext = RichTextField(blank=True)
     # ruleid: nontext-field-must-set-null-true
     fieldInt = models.IntegerField(
         blank=True,

--- a/python/django/correctness/nontext-field-must-set-null-true.yaml
+++ b/python/django/correctness/nontext-field-must-set-null-true.yaml
@@ -15,6 +15,7 @@ rules:
       - pattern-not: $F = django.db.models.ManyToManyField(...)
       - pattern-not: $F = django.db.models.NullBooleanField(...)
       - pattern-not: $F = phonenumber_field.modelfields.PhoneNumberField(...)
+      - pattern-not: $F = ckeditor.fields.RichTextField(...)
       - pattern-not: $F = $X(..., null=True, blank=True, ...)
       - pattern: $F = $X(..., blank=True, ...)
     message: null=True should be set if blank=True is set on non-text fields.


### PR DESCRIPTION
[django-ckeditor](https://github.com/django-ckeditor/django-ckeditor) RichtextField is a text field and should be allowed to be blank without being nullable.