### PR TITLE
Fixing OWASP DocumentBuilderFactory rule

### DIFF
--- a/contrib/owasp/java/xxe/documentbuilderfactory.java
+++ b/contrib/owasp/java/xxe/documentbuilderfactory.java
@@ -41,188 +41,6 @@ public class XXE {
     private static Logger logger = LoggerFactory.getLogger(XXE.class);
     private static String EXCEPT = "xxe except";
 
-    @PostMapping("/xmlReader/vuln")
-    public String xmlReaderVuln(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            XMLReader xmlReader = XMLReaderFactory.createXMLReader();
-            xmlReader.parse(new InputSource(new StringReader(body)));  // parse xml
-            return "xmlReader xxe vuln code";
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-    }
-
-
-    @RequestMapping(value = "/xmlReader/sec", method = RequestMethod.POST)
-    public String xmlReaderSec(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-
-            XMLReader xmlReader = XMLReaderFactory.createXMLReader();
-            xmlReader.parse(new InputSource(new StringReader(body)));  // parse xml
-
-            // fix code start
-            xmlReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            xmlReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            xmlReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            //fix code end
-
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-
-        return "xmlReader xxe security code";
-    }
-
-
-    @RequestMapping(value = "/SAXBuilder/vuln", method = RequestMethod.POST)
-    public String SAXBuilderVuln(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            SAXBuilder builder = new SAXBuilder();
-            // org.jdom2.Document document
-            builder.build(new InputSource(new StringReader(body)));  // cause xxe
-            return "SAXBuilder xxe vuln code";
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-    }
-
-
-    @RequestMapping(value = "/SAXBuilder/sec", method = RequestMethod.POST)
-    public String SAXBuilderSec(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-
-            SAXBuilder builder = new SAXBuilder();
-            builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            // org.jdom2.Document document
-            builder.build(new InputSource(new StringReader(body)));
-
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-
-        return "SAXBuilder xxe security code";
-    }
-
-    @RequestMapping(value = "/SAXReader/vuln", method = RequestMethod.POST)
-    public String SAXReaderVuln(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            SAXReader reader = new SAXReader();
-            // org.dom4j.Document document
-            reader.read(new InputSource(new StringReader(body))); // cause xxe
-
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-
-        return "SAXReader xxe vuln code";
-    }
-
-    @RequestMapping(value = "/SAXReader/sec", method = RequestMethod.POST)
-    public String SAXReaderSec(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-
-            SAXReader reader = new SAXReader();
-            reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            // org.dom4j.Document document
-            reader.read(new InputSource(new StringReader(body)));
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-        return "SAXReader xxe security code";
-    }
-
-    @RequestMapping(value = "/SAXParser/vuln", method = RequestMethod.POST)
-    public String SAXParserVuln(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            SAXParser parser = spf.newSAXParser();
-            parser.parse(new InputSource(new StringReader(body)), new DefaultHandler());  // parse xml
-
-            return "SAXParser xxe vuln code";
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-    }
-
-
-    @RequestMapping(value = "/SAXParser/sec", method = RequestMethod.POST)
-    public String SAXParserSec(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            SAXParser parser = spf.newSAXParser();
-            parser.parse(new InputSource(new StringReader(body)), new DefaultHandler());  // parse xml
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-        return "SAXParser xxe security code";
-    }
-
-
-    @RequestMapping(value = "/Digester/vuln", method = RequestMethod.POST)
-    public String DigesterVuln(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            Digester digester = new Digester();
-            digester.parse(new StringReader(body));  // parse xml
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-        return "Digester xxe vuln code";
-    }
-
-    @RequestMapping(value = "/Digester/sec", method = RequestMethod.POST)
-    public String DigesterSec(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-
-            Digester digester = new Digester();
-            digester.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            digester.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            digester.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            digester.parse(new StringReader(body));  // parse xml
-
-            return "Digester xxe security code";
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-    }
-
-
     // 有回显
     @RequestMapping(value = "/DocumentBuilder/vuln01", method = RequestMethod.POST)
     public String DocumentBuilderVuln01(HttpServletRequest request) {
@@ -297,11 +115,9 @@ public class XXE {
         try {
             String body = WebUtils.getRequestBody(request);
             logger.info(body);
-            // ruleid:owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
+            // ok:owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             DocumentBuilder db = dbf.newDocumentBuilder();
             StringReader sr = new StringReader(body);
             InputSource is = new InputSource(sr);
@@ -313,7 +129,6 @@ public class XXE {
         }
         return "DocumentBuilder xxe security code";
     }
-
 
     @RequestMapping(value = "/DocumentBuilder/xinclude/vuln", method = RequestMethod.POST)
     public String DocumentBuilderXincludeVuln(HttpServletRequest request) {
@@ -347,6 +162,7 @@ public class XXE {
         try {
             String body = WebUtils.getRequestBody(request);
             logger.info(body);
+            // ok:owasp.java.xxe.javax.xml.parsers.DocumentBuilderFactory
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
             dbf.setXIncludeAware(true);   // 支持XInclude
@@ -370,65 +186,6 @@ public class XXE {
         }
         return "DocumentBuilder xinclude xxe vuln code";
     }
-
-
-    @PostMapping("/XMLReader/vuln")
-    public String XMLReaderVuln(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            SAXParser saxParser = spf.newSAXParser();
-            XMLReader xmlReader = saxParser.getXMLReader();
-            xmlReader.parse(new InputSource(new StringReader(body)));
-
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-
-        return "XMLReader xxe vuln code";
-    }
-
-
-    @PostMapping("/XMLReader/sec")
-    public String XMLReaderSec(HttpServletRequest request) {
-        try {
-            String body = WebUtils.getRequestBody(request);
-            logger.info(body);
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            SAXParser saxParser = spf.newSAXParser();
-            XMLReader xmlReader = saxParser.getXMLReader();
-            xmlReader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            xmlReader.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            xmlReader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            xmlReader.parse(new InputSource(new StringReader(body)));
-
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-        return "XMLReader xxe security code";
-    }
-
-
-    /**
-     * 修复该漏洞只需升级dom4j到2.1.1及以上，该版本及以上禁用了ENTITY；
-     * 不带ENTITY的PoC不能利用，所以禁用ENTITY即可完成修复。
-     */
-    @PostMapping("/DocumentHelper/vuln")
-    public String DocumentHelper(HttpServletRequest req) {
-        try {
-            String body = WebUtils.getRequestBody(req);
-            DocumentHelper.parseText(body); // parse xml
-        } catch (Exception e) {
-            logger.error(e.toString());
-            return EXCEPT;
-        }
-
-        return "DocumentHelper xxe vuln code";
-    }
-
 
     private static void response(NodeList rootNodeList){
         for (int i = 0; i < rootNodeList.getLength(); i++) {

--- a/contrib/owasp/java/xxe/documentbuilderfactory.yaml
+++ b/contrib/owasp/java/xxe/documentbuilderfactory.yaml
@@ -22,22 +22,13 @@ rules:
       - pattern-not-inside: |
           $RETURNTYPE $METHOD(...) {
             ...
-            $DBF.setXIncludeAware(true);
-            $DBF.setNamespaceAware(true);
-            ...
             $DBF.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            $DBF.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            $DBF.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             ...
           }
       - pattern-not-inside: |
           DocumentBuilderFactory $DBF =  ... ;
           ...
-          $DBF.setXIncludeAware(true);
-          $DBF.setNamespaceAware(true);
-          ...
           $DBF.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-          $DBF.setFeature("http://xml.org/sax/features/external-general-entities", false);
-          $DBF.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+          ...
     languages:
       - java


### PR DESCRIPTION
There is a problem with the existing OWASP DocumentBuilderFactory rule:

- As per https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#jaxp-documentbuilderfactory-saxparserfactory-and-dom4j if doctypes are disabled, no further features are required.
