### PR TITLE
Release from develop

### DIFF
--- a/java/spring/security/injection/tainted-file-path.java
+++ b/java/spring/security/injection/tainted-file-path.java
@@ -1,0 +1,48 @@
+package org.sasanlabs.service.vulnerability.fileupload;
+
+import static org.sasanlabs.service.vulnerability.fileupload.UnrestrictedFileUpload.CONTENT_DISPOSITION_STATIC_FILE_LOCATION;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+import org.sasanlabs.internal.utility.FrameworkConstants;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Preflight is the request which is executed to download the uploaded file. This controller is made
+ * specifically for content disposition based response. we could have created the similar endpoint
+ * in {@code UnrestrictedFileUpload} but as framework appends the "Vulnerability name" hence created
+ * a new endpoint.
+ *
+ * @author KSASAN preetkaran20@gmail.com
+ */
+@RestController
+public class PreflightController {
+    private UnrestrictedFileUpload unrestrictedFileUpload;
+
+    public PreflightController(UnrestrictedFileUpload unrestrictedFileUpload) {
+        this.unrestrictedFileUpload = unrestrictedFileUpload;
+    }
+
+    @RequestMapping(
+            CONTENT_DISPOSITION_STATIC_FILE_LOCATION + FrameworkConstants.SLASH + "{fileName}")
+    public ResponseEntity<byte[]> fetchFile(@PathVariable("fileName") String fileName)
+            throws IOException {
+        InputStream inputStream =
+                // ruleid: tainted-file-path
+                new FileInputStream(
+                        unrestrictedFileUpload.getContentDispositionRoot().toFile()
+                                + FrameworkConstants.SLASH
+                                + fileName);
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(HttpHeaders.CONTENT_DISPOSITION, "attachment");
+        return new ResponseEntity<byte[]>(
+                IOUtils.toByteArray(inputStream), httpHeaders, HttpStatus.OK);
+    }
+}

--- a/java/spring/security/injection/tainted-file-path.yaml
+++ b/java/spring/security/injection/tainted-file-path.yaml
@@ -1,0 +1,50 @@
+rules:
+  - id: tainted-file-path
+    languages:
+      - java
+    severity: ERROR
+    message: Detected user input controlling a file path. An attacker could control
+      the location of this file, to include going backwards in the directory
+      with '../'. To address this, ensure that user-controlled variables in file
+      paths are sanitized. You may also consider using a utility method such as
+      org.apache.commons.io.FilenameUtils.getName(...) to only retrieve the file
+      name from the path.
+    metadata:
+      cwe: "CWE-23: Relative Path Traversal"
+      owasp:
+        - A01:2021 - Broken Access Control
+        - A05:2017 - Broken Access Control
+      references:
+        - https://owasp.org/www-community/attacks/Path_Traversal
+      category: security
+      technology:
+        - java
+        - spring
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ($LOOKUP) String
+                  $SOURCE,...) {
+                    ...
+                  }
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ String
+                  $SOURCE,...) {
+                    ...
+                  }
+          - metavariable-regex:
+              metavariable: $REQ
+              regex: (RequestBody|PathVariable|RequestParam)
+          - pattern: $SOURCE
+    pattern-sinks:
+      - pattern-either:
+          - pattern-either:
+              - pattern: new FileInputStream(...)
+              - pattern: new java.io.FileInputStream(...)
+              - pattern: new FileReader(...)
+              - pattern: new java.io.FileReader(...)
+              - pattern: new File(...)
+              - pattern: new java.io.File(...)
+              - pattern: $SOMETHING.getResourceAsStream(...)

--- a/java/spring/security/injection/tainted-html-string.java
+++ b/java/spring/security/injection/tainted-html-string.java
@@ -1,0 +1,212 @@
+package org.sasanlabs.service.vulnerability.xss.reflected;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.text.StringEscapeUtils;
+import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
+import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.sasanlabs.vulnerability.utils.Constants;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.util.HtmlUtils;
+
+/**
+ * This class contains XSS vulnerabilities which are present in Image Tag attribute.
+ *
+ * @author KSASAN preetkaran20@gmail.com
+ * @author jpralle janpralle@gmail.com
+ * @author t0bel1x t0bel1x.git@gmail.com
+ * @author pdelmonego philipp.delmonego@live.de
+ */
+@VulnerableAppRestController(descriptionLabel = "XSS_VULNERABILITY", value = "XSSInImgTagAttribute")
+public class XSSInImgTagAttribute {
+
+    private static final String OWASP_IMAGE = "images/owasp.png";
+    private static final String ZAP_IMAGE = "images/ZAP.png";
+    private static final String PARAMETER_NAME = "src";
+    public static final String IMAGE_RESOURCE_PATH = "/VulnerableApp/images/";
+    public static final String FILE_EXTENSION = ".png";
+
+    private final Set<String> allowedValues = new HashSet<>();
+
+    public XSSInImgTagAttribute() {
+        allowedValues.add(OWASP_IMAGE);
+        allowedValues.add(ZAP_IMAGE);
+    }
+
+    // Just adding User defined input(Untrusted Data) into Src tag is not secure.
+    // Can be broken by various ways
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.REFLECTED_XSS,
+            description = "XSS_DIRECT_INPUT_SRC_ATTRIBUTE_IMG_TAG")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/XSS")
+    public ResponseEntity<String> getVulnerablePayloadLevel1(
+            @RequestParam(PARAMETER_NAME) String imageLocation) {
+
+        String vulnerablePayloadWithPlaceHolder = "<img src=%s width=\"400\" height=\"300\"/>";
+
+        return new ResponseEntity<>(
+                // ruleid: tainted-html-string
+                String.format(vulnerablePayloadWithPlaceHolder, imageLocation), HttpStatus.OK);
+    }
+
+    // Adding Untrusted Data into Src tag between quotes is beneficial but not
+    // without escaping the input
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.REFLECTED_XSS,
+            description = "XSS_QUOTES_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/XSS")
+    public ResponseEntity<String> getVulnerablePayloadLevel2(
+            @RequestParam(PARAMETER_NAME) String imageLocation) {
+
+        String vulnerablePayloadWithPlaceHolder = "<img src=\"%s\" width=\"400\" height=\"300\"/>";
+
+        // ruleid: tainted-html-string
+        String payload = String.format(vulnerablePayloadWithPlaceHolder, imageLocation);
+
+        return new ResponseEntity<>(payload, HttpStatus.OK);
+    }
+
+    // Good way for HTML escapes so hacker cannot close the tags but can use event
+    // handlers like onerror etc. eg:- ''onerror='alert(1);'
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.REFLECTED_XSS,
+            description = "XSS_HTML_ESCAPE_ON_DIRECT_INPUT_SRC_ATTRIBUTE_IMG_TAG")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/XSS")
+    public ResponseEntity<String> getVulnerablePayloadLevel3(
+            @RequestParam(PARAMETER_NAME) String imageLocation) {
+
+        String vulnerablePayloadWithPlaceHolder = "<img src=%s width=\"400\" height=\"300\"/>";
+
+        String payload =
+                // ruleid: tainted-html-string
+                String.format(
+                        vulnerablePayloadWithPlaceHolder,
+                        StringEscapeUtils.escapeHtml4(imageLocation));
+
+        return new ResponseEntity<>(payload, HttpStatus.OK);
+    }
+
+    // Good way for HTML escapes so hacker cannot close the tags and also cannot pass brackets but
+    // can use event
+    // handlers like onerror etc. eg:- onerror=alert`1` (backtick operator)
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.REFLECTED_XSS,
+            description =
+                    "XSS_HTML_ESCAPE_ON_DIRECT_INPUT_AND_REMOVAL_OF_VALUES_WITH_PARENTHESIS_SRC_ATTRIBUTE_IMG_TAG")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/XSS")
+    public ResponseEntity<String> getVulnerablePayloadLevel4(
+            @RequestParam(PARAMETER_NAME) String imageLocation) {
+
+        String vulnerablePayloadWithPlaceHolder = "<img src=%s width=\"400\" height=\"300\"/>";
+        StringBuilder payload = new StringBuilder();
+
+        if (!imageLocation.contains("(") || !imageLocation.contains(")")) {
+            payload.append(
+                    // ruleid: tainted-html-string
+                    String.format(
+                            vulnerablePayloadWithPlaceHolder,
+                            StringEscapeUtils.escapeHtml4(imageLocation)));
+        }
+
+        return new ResponseEntity<>(payload.toString(), HttpStatus.OK);
+    }
+
+    // Assume here that there is a validator vulnerable to Null Byte which validates the file name
+    // only till null byte
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.REFLECTED_XSS,
+            description =
+                    "XSS_HTML_ESCAPE_PLUS_FILTERING_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG_BUT_NULL_BYTE_VULNERABLE")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_5, htmlTemplate = "LEVEL_1/XSS")
+    public ResponseEntity<String> getVulnerablePayloadLevel5(
+            @RequestParam(PARAMETER_NAME) String imageLocation) {
+
+        String vulnerablePayloadWithPlaceHolder = "<img src=%s width=\"400\" height=\"300\"/>";
+        StringBuilder payload = new StringBuilder();
+
+        String validatedFileName = imageLocation;
+
+        // Behavior of Null Byte Vulnerable Validator for filename
+        if (imageLocation.contains(Constants.NULL_BYTE_CHARACTER)) {
+            validatedFileName =
+                    imageLocation.substring(
+                            0, imageLocation.indexOf(Constants.NULL_BYTE_CHARACTER));
+        }
+
+        if (allowedValues.contains(validatedFileName)) {
+            payload.append(
+                    // ruleid: tainted-html-string
+                    String.format(
+                            vulnerablePayloadWithPlaceHolder,
+                            StringEscapeUtils.escapeHtml4(imageLocation)));
+        }
+
+        return new ResponseEntity<>(payload.toString(), HttpStatus.OK);
+    }
+
+    // Good way and can protect against attacks but it is better to have check on
+    // the input values provided if possible.
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.REFLECTED_XSS,
+            description = "XSS_QUOTES_AND_WITH_HTML_ESCAPE_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_6,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/XSS")
+    public ResponseEntity<String> getVulnerablePayloadLevel6(
+            @RequestParam(PARAMETER_NAME) String imageLocation) {
+
+        String vulnerablePayloadWithPlaceHolder = "<img src=\"%s\" width=\"400\" height=\"300\"/>";
+
+        if (allowedValues.contains(imageLocation)) {
+            String payload =
+                    // ruleid: tainted-html-string
+                    String.format(
+                            vulnerablePayloadWithPlaceHolder,
+                            StringEscapeUtils.escapeHtml4(imageLocation));
+
+            return new ResponseEntity<>(payload, HttpStatus.OK);
+        }
+
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+
+    // Escape all special characters to their corresponding HTML hex format
+    // and validate input.
+    // Would be even better if Content Security Policy (CSP) is set.
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.REFLECTED_XSS,
+            description =
+                    "XSS_QUOTES_AND_WITH_HTML_ESCAPE_PLUS_FILTERING_ON_INPUT_SRC_ATTRIBUTE_IMG_TAG")
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_7,
+            variant = Variant.SECURE,
+            htmlTemplate = "LEVEL_1/XSS")
+    public ResponseEntity<String> getVulnerablePayloadLevelSecure(
+            @RequestParam(PARAMETER_NAME) String imageLocation) {
+        String vulnerablePayloadWithPlaceHolder = "<img src=\"%s\" width=\"400\" height=\"300\"/>";
+
+        if ((imageLocation.startsWith(IMAGE_RESOURCE_PATH)
+                        && imageLocation.endsWith(FILE_EXTENSION))
+                || allowedValues.contains(imageLocation)) {
+
+            String payload =
+                    // ruleid: tainted-html-string
+                    String.format(
+                            vulnerablePayloadWithPlaceHolder,
+                            HtmlUtils.htmlEscapeHex(imageLocation));
+
+            return new ResponseEntity<>(payload, HttpStatus.OK);
+
+        } else {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+}
+        

--- a/java/spring/security/injection/tainted-html-string.yaml
+++ b/java/spring/security/injection/tainted-html-string.yaml
@@ -1,0 +1,68 @@
+rules:
+  - id: tainted-html-string
+    languages:
+      - java
+    severity: ERROR
+    message: >-
+      Detected user input flowing into a manually constructed HTML string.
+      You may be accidentally bypassing secure methods of rendering HTML by
+      manually constructing HTML and this could create a cross-site scripting
+      vulnerability, which could let attackers steal sensitive user data. To be
+      sure this is safe, check that the HTML is rendered safely. You can use
+      the OWASP ESAPI encoder if you must render user data.
+    metadata:
+      cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting"
+      owasp:
+        - A03:2021 – Injection
+        - A07:2017 - Cross-Site Scripting (XSS)
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
+      category: security
+      technology:
+        - java
+        - spring
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ($LOOKUP) String
+                  $SOURCE,...) {
+                    ...
+                  }
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ String
+                  $SOURCE,...) {
+                    ...
+                  }
+          - metavariable-regex:
+              metavariable: $REQ
+              regex: (RequestBody|PathVariable|RequestParam)
+          - pattern: $SOURCE
+    pattern-sinks:
+      - patterns:
+          - patterns:
+              - pattern-either:
+                  - pattern: |
+                      "$HTMLSTR" + ...
+                  - pattern: |
+                      "$HTMLSTR".concat(...)
+                  - patterns:
+                      - pattern-inside: |
+                          StringBuilder $SB = new StringBuilder("$HTMLSTR");
+                          ...
+                      - pattern: $SB.append(...)
+                  - patterns:
+                      - pattern-inside: |
+                          $VAR = "$HTMLSTR";
+                          ...
+                      - pattern: $VAR += ...
+                  - pattern: String.format("$HTMLSTR", ...)
+                  - patterns:
+                    - pattern-inside: |
+                        String $VAR = "$HTMLSTR";
+                        ...
+                    - pattern: String.format($VAR, ...)
+              - metavariable-regex:
+                  metavariable: $HTMLSTR
+                  regex: ^<\w+

--- a/java/spring/security/injection/tainted-sql-string.java
+++ b/java/spring/security/injection/tainted-sql-string.java
@@ -1,5 +1,7 @@
 package com.r2c.tests;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.*;
@@ -14,6 +16,8 @@ import java.sql.Statement;
 @RestController
 @EnableAutoConfiguration
 public class TestController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestController.class);
 
     @RequestMapping(value = "/test1", method = RequestMethod.POST, produces = "plain/text")
     ResultSet test1(@RequestBody String name) {
@@ -83,6 +87,10 @@ public class TestController {
         String sql = "SELECT * FROM table WHERE name = 'everyone';";
         // ok: tainted-sql-string
         System.out.println(String.format("Got request from %s", name));
+        // ok: tainted-sql-string
+        System.out.println("select noise for tests using tainted name:" + name);
+        // ok: tainted-sql-string
+        Logger.debug("Create noise for tests using tainted name:" + name);
         Connection conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password");
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.execute(sql);

--- a/java/spring/security/injection/tainted-sql-string.yaml
+++ b/java/spring/security/injection/tainted-sql-string.yaml
@@ -1,57 +1,74 @@
 rules:
   - id: tainted-sql-string
-    languages: [java]
+    languages:
+      - java
     severity: ERROR
-    message: >-
-      User data flows into this manually-constructed SQL string. User data
+    message: User data flows into this manually-constructed SQL string. User data
       can be safely inserted into SQL strings using prepared statements or an
       object-relational mapper (ORM). Manually-constructed SQL strings is a
       possible indicator of SQL injection, which could let an attacker steal or
       manipulate data from the database. Instead, use prepared statements
       (`connection.PreparedStatement`) or a safe library.
     metadata:
-      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      cwe: "CWE-89: Improper Neutralization of Special Elements used in an SQL Command
+        ('SQL Injection')"
       owasp:
-        - A03:2021
-        - A01:2017
+        - A03:2021 - Injection
+        - A01:2017 - Injection
       references:
         - https://docs.oracle.com/javase/7/docs/api/java/sql/PreparedStatement.html
       category: security
       technology:
         - spring
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     mode: taint
     pattern-sources:
       - patterns:
           - pattern-either:
-              - pattern: |
-                  @RequestMapping(...) $RETURNTYPE $METHODNAME(..., @$ANNOTATION
-                  $TYPE $PARAMETER, ...) {
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ($LOOKUP) String
+                  $SOURCE,...) {
                     ...
                   }
-              - pattern: |
-                  @RequestMapping(...) $RETURNTYPE $METHODNAME(...,
-                  @$ANNOTATION(...) $TYPE $PARAMETER, ...) {
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ String
+                  $SOURCE,...) {
                     ...
                   }
+          - metavariable-regex:
+              metavariable: $REQ
+              regex: (RequestBody|PathVariable|RequestParam)
+          - pattern: $SOURCE
     pattern-sinks:
-      - patterns:
-          - patterns:
-              - pattern-either:
-                  - pattern: |
-                      "$SQLSTR" + ...
-                  - pattern: |
-                      "$SQLSTR".concat(...)
-                  - patterns:
-                      - pattern-inside: |
-                          StringBuilder $SB = new StringBuilder("$SQLSTR");
-                          ...
-                      - pattern: $SB.append(...)
-                  - patterns:
-                      - pattern-inside: |
-                          $VAR = "$SQLSTR";
-                          ...
-                      - pattern: $VAR += ...
-                  - pattern: String.format("$SQLSTR", ...)
-              - metavariable-regex:
-                  metavariable: $SQLSTR
-                  regex: (?i)(select|delete|insert|create|update|alter|drop)\b
+    - patterns:
+        - pattern-either:
+            - pattern: |
+                "$SQLSTR" + ...
+            - pattern: |
+                "$SQLSTR".concat(...)
+            - patterns:
+                - pattern-inside: |
+                    StringBuilder $SB = new StringBuilder("$SQLSTR");
+                    ...
+                - pattern: $SB.append(...)
+            - patterns:
+                - pattern-inside: |
+                    $VAR = "$SQLSTR";
+                    ...
+                - pattern: $VAR += ...
+            - pattern: String.format("$SQLSTR", ...)
+            - patterns:
+              - pattern-inside: |
+                  String $VAR = "$SQLSTR";
+                  ...
+              - pattern: String.format($VAR, ...)
+        - pattern-not-inside: System.out.println(...)
+        - pattern-not-inside: $LOG.info(...)
+        - pattern-not-inside: $LOG.warn(...)
+        - pattern-not-inside: $LOG.warning(...)
+        - pattern-not-inside: $LOG.debug(...)
+        - pattern-not-inside: $LOG.debugging(...)
+        - pattern-not-inside: $LOG.error(...)
+        - metavariable-regex:
+            metavariable: $SQLSTR
+            regex: (?i)(select|delete|insert|create|update|alter|drop)\b

--- a/java/spring/security/injection/tainted-system-command.java
+++ b/java/spring/security/injection/tainted-system-command.java
@@ -1,0 +1,219 @@
+package org.sasanlabs.service.vulnerability.commandInjection;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.Variant;
+import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
+import org.sasanlabs.service.exception.ServiceApplicationException;
+import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+/**
+ * This class contains vulnerabilities related to Command Injection. <a
+ * href="https://owasp.org/www-community/attacks/Command_Injection">For More information</a>
+ *
+ * @author KSASAN preetkaran20@gmail.com
+ */
+@VulnerableAppRestController(
+        descriptionLabel = "COMMAND_INJECTION_VULNERABILITY",
+        value = "CommandInjection")
+public class CommandInjection {
+
+    private static final String IP_ADDRESS = "ipaddress";
+    private static final Pattern SEMICOLON_SPACE_LOGICAL_AND_PATTERN = Pattern.compile("[;& ]");
+    private static final Pattern IP_ADDRESS_PATTERN =
+            Pattern.compile("\\b((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\\.|$)){4}\\b");
+
+    StringBuilder getResponseFromPingCommand(String ipAddress, boolean isValid) throws IOException {
+        boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+        StringBuilder stringBuilder = new StringBuilder();
+        if (isValid) {
+            Process process;
+            if (!isWindows) {
+                process =
+                        new ProcessBuilder(new String[] {"sh", "-c", "ping -c 2 " + ipAddress})
+                                .redirectErrorStream(true)
+                                .start();
+            } else {
+                process =
+                        new ProcessBuilder(new String[] {"cmd", "/c", "ping -n 2 " + ipAddress})
+                                .redirectErrorStream(true)
+                                .start();
+            }
+            try (BufferedReader bufferedReader =
+                    new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                bufferedReader.lines().forEach(val -> stringBuilder.append(val).append("\n"));
+            }
+        }
+        return stringBuilder;
+    }
+
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
+            description = "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/CI_Level1")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel1(
+            @RequestParam(IP_ADDRESS) String ipAddress) throws IOException {
+        Supplier<Boolean> validator = () -> StringUtils.isNotBlank(ipAddress);
+        boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+        StringBuilder stringBuilder = new StringBuilder();
+        if (isValid) {
+            Process process;
+            if (!isWindows) {
+                process =
+                        // ruleid: tainted-system-command
+                        new ProcessBuilder(new String[] {"sh", "-c", "ping -c 2 " + ipAddress})
+                                .redirectErrorStream(true)
+                                .start();
+            } else {
+                process =
+                        // ruleid: tainted-system-command
+                        new ProcessBuilder(new String[] {"cmd", "/c", "ping -n 2 " + ipAddress})
+                                .redirectErrorStream(true)
+                                .start();
+            }
+            try (BufferedReader bufferedReader =
+                    new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                bufferedReader.lines().forEach(val -> stringBuilder.append(val).append("\n"));
+            }
+        }
+        return new ResponseEntity<GenericVulnerabilityResponseBean<String>>(
+                new GenericVulnerabilityResponseBean<String>(
+                        stringBuilder.toString(),
+                        true),
+                HttpStatus.OK);
+    }
+
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
+            description =
+                    "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_NOT_PRESENT")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_2, htmlTemplate = "LEVEL_1/CI_Level1")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel2(
+            @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)
+            throws ServiceApplicationException, IOException {
+
+        Supplier<Boolean> validator =
+                () ->
+                        StringUtils.isNotBlank(ipAddress)
+                                && !SEMICOLON_SPACE_LOGICAL_AND_PATTERN
+                                        .matcher(requestEntity.getUrl().toString())
+                                        .find();
+        return new ResponseEntity<GenericVulnerabilityResponseBean<String>>(
+                new GenericVulnerabilityResponseBean<String>(
+                        // todoruleid: tainted-system-command
+                        // Indirection, needs interproc taint
+                        this.getResponseFromPingCommand(ipAddress, validator.get()).toString(),
+                        true),
+                HttpStatus.OK);
+    }
+
+    // Case Insensitive
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
+            description =
+                    "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_NOT_PRESENT")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_3, htmlTemplate = "LEVEL_1/CI_Level1")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel3(
+            @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)
+            throws ServiceApplicationException, IOException {
+
+        Supplier<Boolean> validator =
+                () ->
+                        StringUtils.isNotBlank(ipAddress)
+                                && !SEMICOLON_SPACE_LOGICAL_AND_PATTERN
+                                        .matcher(requestEntity.getUrl().toString())
+                                        .find()
+                                && !requestEntity.getUrl().toString().contains("%26")
+                                && !requestEntity.getUrl().toString().contains("%3B");
+        return new ResponseEntity<GenericVulnerabilityResponseBean<String>>(
+                new GenericVulnerabilityResponseBean<String>(
+                        this.getResponseFromPingCommand(ipAddress, validator.get()).toString(),
+                        true),
+                HttpStatus.OK);
+    }
+
+    // e.g Attack
+    // http://localhost:9090/vulnerable/CommandInjectionVulnerability/LEVEL_3?ipaddress=192.168.0.1%20%7c%20cat%20/etc/passwd
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
+            description =
+                    "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_CASE_INSENSITIVE_NOT_PRESENT")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_4, htmlTemplate = "LEVEL_1/CI_Level1")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel4(
+            @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)
+            throws ServiceApplicationException, IOException {
+
+        Supplier<Boolean> validator =
+                () ->
+                        StringUtils.isNotBlank(ipAddress)
+                                && !SEMICOLON_SPACE_LOGICAL_AND_PATTERN
+                                        .matcher(requestEntity.getUrl().toString())
+                                        .find()
+                                && !requestEntity.getUrl().toString().toUpperCase().contains("%26")
+                                && !requestEntity.getUrl().toString().toUpperCase().contains("%3B");
+        return new ResponseEntity<GenericVulnerabilityResponseBean<String>>(
+                new GenericVulnerabilityResponseBean<String>(
+                        this.getResponseFromPingCommand(ipAddress, validator.get()).toString(),
+                        true),
+                HttpStatus.OK);
+    }
+    // Payload: 127.0.0.1%0Als
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.COMMAND_INJECTION,
+            description =
+                    "COMMAND_INJECTION_URL_PARAM_DIRECTLY_EXECUTED_IF_SEMICOLON_SPACE_LOGICAL_AND_%26_%3B_%7C_CASE_INSENSITIVE_NOT_PRESENT")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_5, htmlTemplate = "LEVEL_1/CI_Level1")
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel5(
+            @RequestParam(IP_ADDRESS) String ipAddress, RequestEntity<String> requestEntity)
+            throws IOException {
+        Supplier<Boolean> validator =
+                () ->
+                        StringUtils.isNotBlank(ipAddress)
+                                && !SEMICOLON_SPACE_LOGICAL_AND_PATTERN
+                                        .matcher(requestEntity.getUrl().toString())
+                                        .find()
+                                && !requestEntity.getUrl().toString().toUpperCase().contains("%26")
+                                && !requestEntity.getUrl().toString().toUpperCase().contains("%3B")
+                                        & !requestEntity
+                                                .getUrl()
+                                                .toString()
+                                                .toUpperCase()
+                                                .contains("%7C");
+        return new ResponseEntity<GenericVulnerabilityResponseBean<String>>(
+                new GenericVulnerabilityResponseBean<String>(
+                        this.getResponseFromPingCommand(ipAddress, validator.get()).toString(),
+                        true),
+                HttpStatus.OK);
+    }
+
+    @VulnerableAppRequestMapping(
+            value = LevelConstants.LEVEL_6,
+            htmlTemplate = "LEVEL_1/CI_Level1",
+            variant = Variant.SECURE)
+    public ResponseEntity<GenericVulnerabilityResponseBean<String>> getVulnerablePayloadLevel6(
+            @RequestParam(IP_ADDRESS) String ipAddress) throws IOException {
+        Supplier<Boolean> validator =
+                () ->
+                        StringUtils.isNotBlank(ipAddress)
+                                && (IP_ADDRESS_PATTERN.matcher(ipAddress).matches()
+                                        || ipAddress.contentEquals("localhost"));
+
+        return new ResponseEntity<GenericVulnerabilityResponseBean<String>>(
+                new GenericVulnerabilityResponseBean<String>(
+                        this.getResponseFromPingCommand(ipAddress, validator.get()).toString(),
+                        true),
+                HttpStatus.OK);
+    }
+}

--- a/java/spring/security/injection/tainted-system-command.yaml
+++ b/java/spring/security/injection/tainted-system-command.yaml
@@ -1,0 +1,56 @@
+rules:
+  - id: tainted-system-command
+    languages:
+      - java
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ($LOOKUP) String
+                  $SOURCE,...) {
+                    ...
+                  }
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ String
+                  $SOURCE,...) {
+                    ...
+                  }
+          - metavariable-regex:
+              metavariable: $REQ
+              regex: (RequestBody|PathVariable|RequestParam)
+          - pattern: $SOURCE
+    pattern-sinks:
+    - pattern-either:
+      - pattern: (Runtime $RUNTIME).exec(...)
+      - pattern: (Runtime $RUNTIME).loadLibrary(...)
+      - pattern: Runtime.getRuntime(...).exec(...)
+      - pattern: Runtime.getRuntime(...).loadLibrary(...)
+      - pattern: new ProcessBuilder($ONEARG)
+      - patterns:
+        - pattern: new ProcessBuilder(...)
+        - pattern-not: new ProcessBuilder("...", ...)
+    message: >-
+      Detected user input entering a method which executes a system command.
+      This could result in a command injection vulnerability, which allows an
+      attacker to inject an arbitrary system command onto the server. The attacker
+      could download malware onto or steal data from the server. Instead, use
+      ProcessBuilder, separating the command into individual arguments, like this:
+      `new ProcessBuilder("ls", "-al", targetDirectory)`. Further, make sure you
+      hardcode or allowlist the actual command so that attackers can't run arbitrary commands.
+    metadata:
+      cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command
+        ('OS Command Injection')"
+      owasp:
+        - A03:2021 - Injection
+        - A01:2017 - Injection
+      category: security
+      technology:
+        - java
+        - spring
+      confidence: HIGH
+      references:
+      - https://www.stackhawk.com/blog/command-injection-java/
+      - https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
+      

--- a/java/spring/security/injection/tainted-url-host.java
+++ b/java/spring/security/injection/tainted-url-host.java
@@ -1,0 +1,86 @@
+package org.sasanlabs.service.vulnerability.ssrf;
+
+import com.nimbusds.jose.util.StandardCharset;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.sasanlabs.internal.utility.LevelConstants;
+import org.sasanlabs.internal.utility.annotations.AttackVector;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRequestMapping;
+import org.sasanlabs.internal.utility.annotations.VulnerableAppRestController;
+import org.sasanlabs.service.vulnerability.bean.GenericVulnerabilityResponseBean;
+import org.sasanlabs.vulnerability.types.VulnerabilityType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@VulnerableAppRestController(descriptionLabel = "SSRF_VULNERABILITY", value = "SSRFVulnerability")
+public class SSRFVulnerability {
+
+    private static final String IMAGE_URL = "imageurl";
+    private static final transient Logger LOGGER = LogManager.getLogger(SSRFVulnerability.class);
+
+    @AttackVector(
+            vulnerabilityExposed = VulnerabilityType.SIMPLE_SSRF,
+            description = "IMAGE_URL_PASSED_TO_REQUEST")
+    @VulnerableAppRequestMapping(value = LevelConstants.LEVEL_1, htmlTemplate = "LEVEL_1/SSRF")
+    public ResponseEntity<GenericVulnerabilityResponseBean<byte[]>> getVulnerablePayloadLevel1(
+            @RequestParam(IMAGE_URL) String urlImage) {
+        try {
+            // ruleid: tainted-url-host
+            URL u = new URL(urlImage);
+            URLConnection urlConnection = u.openConnection();
+            byte[] bytes;
+            try (InputStream in = urlConnection.getInputStream()) {
+                bytes = StreamUtils.copyToByteArray(urlConnection.getInputStream());
+            }
+            return new ResponseEntity<>(
+                    new GenericVulnerabilityResponseBean<>(bytes, true), HttpStatus.OK);
+        } catch (Exception e) {
+            LOGGER.error(
+                    "Following exception occurred while opening the connection to {}", urlImage, e);
+        }
+        return new ResponseEntity<>(
+                new GenericVulnerabilityResponseBean<>(
+                        ("Failed to fetch image from URL " + urlImage)
+                                .getBytes(StandardCharset.UTF_8),
+                        false),
+                HttpStatus.BAD_REQUEST);
+    }
+}
+
+
+@RestController
+@RequestMapping("/user03")
+public class User03Controller {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @GetMapping("/get")
+    public UserDTO get(@RequestParam("id") Integer id) {
+        // ok: tainted-url-host
+        String url = String.format("http://%s/user/get?id=%d", "demo-provider", id);
+        return restTemplate.getForObject(url, UserDTO.class);
+    }
+
+    @PostMapping("/add")
+    public Integer add(UserAddDTO addDTO) {
+        // 请求头
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        // 请求体
+        String body = JSON.toJSONString(addDTO);
+        // 创建 HttpEntity 对象
+        HttpEntity<String> entity = new HttpEntity<>(body, headers);
+        // 执行请求
+        // ok: tainted-url-host
+        String url = String.format("http://%s/user/add", "demo-provider");
+        return restTemplate.postForObject(url, entity, Integer.class);
+    }
+
+}
+

--- a/java/spring/security/injection/tainted-url-host.yaml
+++ b/java/spring/security/injection/tainted-url-host.yaml
@@ -1,0 +1,72 @@
+rules:
+  - id: tainted-url-host
+    languages:
+      - java
+    severity: ERROR
+    message: >-
+      User data flows into the host portion of this manually-constructed URL.
+      This could allow an attacker to send data to their own server,
+      potentially exposing sensitive data such as cookies or authorization
+      information sent with this request. They could also probe internal
+      servers or other resources that the server runnig this code can access.
+      (This is called server-side request forgery, or SSRF.) Do not allow
+      arbitrary hosts. Instead, create an allowlist for approved hosts hardcode
+      the correct host, or ensure that the user data can only affect the path or parameters.
+    metadata:
+      cwe: "CWE-918: SSRF"
+      owasp:
+        - A10:2021 - Server-Side Request Forgery (SSRF)
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+      category: security
+      technology:
+        - java
+        - spring
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ($LOOKUP) String
+                  $SOURCE,...) {
+                    ...
+                  }
+              - pattern-inside: |
+                  $METHODNAME(..., @$REQ String
+                  $SOURCE,...) {
+                    ...
+                  }
+          - metavariable-regex:
+              metavariable: $REQ
+              regex: (RequestBody|PathVariable|RequestParam)
+          - pattern: $SOURCE
+    pattern-sinks:
+    - pattern-either:
+      - pattern: new URL($ONEARG)
+      - patterns:
+        - pattern-either:
+          - pattern: |
+              "$URLSTR" + ...
+          - pattern: |
+              "$URLSTR".concat(...)
+          - patterns:
+            - pattern-inside: |
+                StringBuilder $SB = new StringBuilder("$URLSTR");
+                ...
+            - pattern: $SB.append(...)
+          - patterns:
+            - pattern-inside: |
+                $VAR = "$URLSTR";
+                ...
+            - pattern: $VAR += ...
+          - patterns:
+            - pattern: String.format("$URLSTR", ...)
+            - pattern-not: String.format("$URLSTR", "...", ...)
+          - patterns:
+            - pattern-inside: |
+                String $VAR = "$URLSTR";
+                ...
+            - pattern: String.format($VAR, ...)
+        - metavariable-regex:
+            metavariable: $URLSTR
+            regex: http(s?)://%(v|s|q).*

--- a/ruby/aws-lambda/security/tainted-deserialization.rb
+++ b/ruby/aws-lambda/security/tainted-deserialization.rb
@@ -1,0 +1,26 @@
+def handler(event:, context:)
+	foobar = event['smth']
+
+    # ruleid: tainted-deserialization
+    obj1 = Marshal.load(foobar)
+
+    data = event['body']['object']
+    # ruleid: tainted-deserialization
+    obj2 = YAML.load(data)
+
+    # ruleid: tainted-deserialization
+    obj3 = CSV.load("o:" + event['data'])
+end
+
+def ok_handler(event:, context:)
+
+    # ok: tainted-deserialization
+    obj1 = Marshal.load(Marshal.dump(Foobar.new))
+
+    data = "hardcoded_value"
+    # ok: tainted-deserialization
+    obj2 = YAML.load(data)
+
+    # ok: tainted-deserialization
+    obj3 = CSV.load(get_safe_data())
+end

--- a/ruby/aws-lambda/security/tainted-deserialization.yaml
+++ b/ruby/aws-lambda/security/tainted-deserialization.yaml
@@ -1,0 +1,41 @@
+rules:
+- id: tainted-deserialization
+  mode: taint
+  languages: [ruby]
+  message: >-
+    Deserialization of a string tainted by `event` object found. Objects in Ruby can be serialized into strings,
+    then later loaded from strings. However, uses of `load` can cause remote code execution.
+    Loading user input with MARSHAL, YAML or CSV can potentially be dangerous.
+    If you need to deserialize untrusted data, you should use JSON as it is only capable of returning 'primitive' types
+    such as strings, arrays, hashes, numbers and nil.
+  metadata:
+    references:
+      - https://ruby-doc.org/core-3.1.2/doc/security_rdoc.html
+      - https://groups.google.com/g/rubyonrails-security/c/61bkgvnSGTQ/m/nehwjA8tQ8EJ
+      - https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_deserialize.rb
+    category: security
+    owasp: "A08:2017 - Deserialization"
+    cwe: "CWE-502: Deserialization of Untrusted Data"
+    technology:
+      - ruby
+      - aws-lambda
+  pattern-sinks:
+  - patterns:
+    - pattern: $SINK
+    - pattern-either:
+      - pattern-inside: |
+          YAML.load($SINK,...)
+      - pattern-inside: |
+          CSV.load($SINK,...)
+      - pattern-inside: |
+          Marshal.load($SINK,...)
+      - pattern-inside: |
+          Marshal.restore($SINK,...)
+  pattern-sources:
+  - patterns:
+    - pattern: event
+    - pattern-inside: |
+        def $HANDLER(event, context)
+          ...
+        end
+  severity: WARNING


### PR DESCRIPTION
* Add Spring taint rules, derived from https://github.com/SasanLabs/VulnerableApp

* Remove FPs based on OSS scan

* Add FP test cases

* Finish adding data to tainted-file-path

* add owasp names

* add owasp names

* add cwe name

* update source file-path

* update sources html-string

* update sources tainted-sql

* updated sources system

* update sources host

* Move sanitizers to pattern-not-inside for tainted-sql-string

* Add FQDN for path traversal rule

Co-authored-by: Lewis <LewisArdern@live.co.uk>