### PR TITLE
Fixing false positive for JWT rule

### DIFF
--- a/generic/secrets/security/detected-jwt-token.txt
+++ b/generic/secrets/security/detected-jwt-token.txt
@@ -17,3 +17,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IsWww6H
 # 4) no signature - but still valid
 # ruleid: detected-jwt-token
 eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ
+
+# 5) Not a JWT token, but was matching against an earlier rule
+# ok: detected-jwt-token
+foreignKeyJsonObject.get(

--- a/generic/secrets/security/detected-jwt-token.yaml
+++ b/generic/secrets/security/detected-jwt-token.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: detected-jwt-token
     pattern-regex: |-
-      eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*?
+      eyJ[A-Za-z0-9-_=]{14,}\.[A-Za-z0-9-_=]{13,}\.?[A-Za-z0-9-_.+/=]*?
     languages: [regex]
     message: JWT token detected
     severity: ERROR


### PR DESCRIPTION
The JWT detection rule has a false positive on a java expression that starts with eyJ and has a "." in it. I fixed it by adding minimum characters both to the header (Base-64 URL encoded version of {"alg":""} which is a required header for JWS) and the payload (BASE-64 URL encoded version of {"":""}).