### PR TITLE
Fixing some false positives with api key detection

### DIFF
--- a/generic/secrets/security/detected-generic-api-key.txt
+++ b/generic/secrets/security/detected-generic-api-key.txt
@@ -3,3 +3,15 @@ api_key=1234567890123456789012345678901234567890
 
 # ruleid: detected-generic-api-key
 APIKEY : 123567890123456789012345678901234567890
+
+# ruleid: detected-generic-api-key
+APIKEY - 123567890123456789012345678901234567890
+
+# ruleid: detected-generic-api-key
+APIKEY  123567890123456789012345678901234567890
+
+# ruleid: detected-generic-api-key
+APIKEY="123567890123456789012345678901234567890"
+
+# ok: detected-generic-api-key
+ApiKeyGenerator.generateApiKeySomeLongMethodName();

--- a/generic/secrets/security/detected-generic-api-key.yaml
+++ b/generic/secrets/security/detected-generic-api-key.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: detected-generic-api-key
     pattern-regex: |-
-      [aA][pP][iI]_?[kK][eE][yY].*['|"]?[0-9a-zA-Z]{32,45}['|"]?
+      [aA][pP][iI]_?[kK][eE][yY][=_:\s-]+['|"]?[0-9a-zA-Z]{32,45}['|"]?
     languages: [regex]
     message: Generic API Key detected
     severity: ERROR


### PR DESCRIPTION
The Generic API key detection rule will flag any text which has ApiKey with 32+ following characters, which can lead to false positives. Instead I tweaked the rule to allow for one or more spaces, =, _, -, : after the ApiKey characters.