### PR TITLE
Various new exclusions for frozen lockfile rule

### DIFF
--- a/generic/ci/security/use-frozen-lockfile.generic
+++ b/generic/ci/security/use-frozen-lockfile.generic
@@ -7,11 +7,15 @@ RUN yarn install
 # ruleid: use-frozen-lockfile-yarn
 RUN yarn install
 RUN yarn install --frozen-lockfile
+RUN yarn install --immutable
 RUN yarn install some_package
+RUN yarn install -g some_package
+RUN yarn install --global some_package
 
 RUN echo 'yarn installing foo'
 
 RUN yarn install --frozen-lockfile
+RUN yarn install --immutable
 COPY . /app
 RUN yarn build
 
@@ -21,6 +25,8 @@ RUN yarn install foo
 RUN npm install foo
 # ruleid: use-frozen-lockfile-npm
 RUN npm install
+RUN npm install -g some_package
+RUN npm install --global some_package
 RUN npm ci
 COPY . /app
 RUN yarn build

--- a/generic/ci/security/use-frozen-lockfile.yaml
+++ b/generic/ci/security/use-frozen-lockfile.yaml
@@ -2,7 +2,10 @@ rules:
   - id: use-frozen-lockfile-yarn
     patterns:
       - pattern-regex: yarn install\b
-      - pattern-not-regex: yarn install --frozen-lockfile
+      - pattern-not-regex: yarn install --frozen-lockfile # yarn v1
+      - pattern-not-regex: yarn install --immutable # yarn berry
+      - pattern-not-regex: yarn install -g
+      - pattern-not-regex: yarn install --global
       - pattern-not-regex: yarn install [\w]+
     fix: yarn install --frozen-lockfile
     message: >-
@@ -21,6 +24,8 @@ rules:
   - id: use-frozen-lockfile-npm
     patterns:
       - pattern-regex: npm install\b
+      - pattern-not-regex: npm install -g
+      - pattern-not-regex: npm install --global
       - pattern-not-regex: npm install [\w]+
     fix: npm ci
     message: >-


### PR DESCRIPTION
- Permit `yarn install --immutable`, which is yarn berry's equivalent of yarn v1's `yarn install --frozen-lockfile`.
- Permit global installs with yarn and npm. Typically the user is doing this intentionally, especially when there is no package.json. They're usually just installing a one-off tool.