### PR TITLE
Remove lxml from dlint-equivalent.insecure-xml-use

### DIFF
--- a/contrib/dlint/dlint-equivalent.yaml
+++ b/contrib/dlint/dlint-equivalent.yaml
@@ -91,7 +91,6 @@ rules:
           - pattern-not: xml.sax.saxutils
           - pattern-not: xml.etree.ElementTree.Element
           - pattern-not: xml.etree.ElementTree.SubElement
-      - pattern: lxml.$ANYTHING
       - pattern: xmlrpclib.$ANYTHING
   - id: insecure-yaml-use
     message: The Python 'yaml' module is not secure against maliciously constructed input


### PR DESCRIPTION
As mentioned in #1086, defusedxml.lxml was only ever an example and is deprecated. I've created a PR on the dlint project at https://github.com/dlint-py/dlint/pull/44.