### PR TITLE
Change replacement for defaulthttpclient

### DIFF
--- a/java/lang/security/audit/crypto/ssl/defaulthttpclient-is-deprecated.yaml
+++ b/java/lang/security/audit/crypto/ssl/defaulthttpclient-is-deprecated.yaml
@@ -15,10 +15,10 @@ rules:
     message: >-
       DefaultHttpClient is deprecated. Further, it does not support connections
       using TLS1.2, which makes using DefaultHttpClient a security hazard.
-      Use SystemDefaultHttpClient instead, which supports TLS1.2.
+      Use HttpClientBuilder instead.
     severity: WARNING
     languages: [java]
     pattern: new DefaultHttpClient(...);
     fix-regex:
       regex: DefaultHttpClient
-      replacement: SystemDefaultHttpClient
+      replacement: HttpClientBuilder


### PR DESCRIPTION
The current defaulthttpclient rule recommends switching to a deprecated class https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/client/SystemDefaultHttpClient.html

Instead we should switch to HttpClientBuilder as per https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/impl/client/DefaultHttpClient.html
"Deprecated. (4.3) use [HttpClientBuilder]"