### PR TITLE
Add `FROM scratch` as an exception to dockerfile.best-practice.missing-image-version.missing-image-version

### DIFF
--- a/dockerfile/best-practice/missing-image-version.dockerfile
+++ b/dockerfile/best-practice/missing-image-version.dockerfile
@@ -52,3 +52,6 @@ FROM --platform=linux/amd64 python:3.10.1-alpine3.15@sha256:4be65b406f7402b5c4fd
 
 # ok: missing-image-version
 FROM --platform=linux/amd64 python@sha256:4be65b406f7402b5c4fd5df7173d2fd7ea3fdaa74d9c43b6ebd896197a45c448 AS name
+
+# ok: missing-image-version
+FROM scratch

--- a/dockerfile/best-practice/missing-image-version.yaml
+++ b/dockerfile/best-practice/missing-image-version.yaml
@@ -6,6 +6,7 @@ rules:
       - pattern-not: FROM $IMAGE:$VERSION
       - pattern-not: FROM $IMAGE@$DIGEST
       - pattern-not: FROM $IMAGE:$VERSION@$DIGEST
+      - pattern-not: FROM scratch
     message: >-
       Images should be tagged with an explicit version to produce
       deterministic container images.

--- a/javascript/argon2/security/unsafe-argon2-config.js
+++ b/javascript/argon2/security/unsafe-argon2-config.js
@@ -28,7 +28,7 @@ const prepareSavingBad = (user) => {
 
 
   return argon2
-    // TODO - this requires inter-function taint
+    // ruleid:unsafe-argon2-config
     .hash(user.Password, hashSettings)
     .then((hash) => ({ ...user, Password: hash }))
     .catch((err) => console.error(`Error during hashing: ${err}`));

--- a/ruby/rails/security/audit/avoid-tainted-http-request.rb
+++ b/ruby/rails/security/audit/avoid-tainted-http-request.rb
@@ -22,7 +22,7 @@ def foo
 
   # ruleid: avoid-tainted-http-request
   Net::HTTP.start(uri.host, uri.port) do |http|
-    # todoruleid: avoid-tainted-http-request
+    # ruleid: avoid-tainted-http-request
     req = Net::HTTP::Get.new uri
     resp = http.request request
   end


### PR DESCRIPTION
Addressing: https://github.com/returntocorp/semgrep-rules/issues/2105