### PR TITLE
Rule for using pytest snapshots after patching pathlib

### DIFF
--- a/python/lang/correctness/pytest-assert_match-after-path-patch.py
+++ b/python/lang/correctness/pytest-assert_match-after-path-patch.py
@@ -1,4 +1,5 @@
 import pytest
+from pathlib import Path
 
 @pytest.mark.quick
 def test_foo(snapshot, mocker):

--- a/python/lang/correctness/pytest-assert_match-after-path-patch.py
+++ b/python/lang/correctness/pytest-assert_match-after-path-patch.py
@@ -6,6 +6,13 @@ def test_foo(snapshot, mocker):
     #ruleid: pytest-assert_match-after-path-patch
     snapshot.assert_match(foo(), "results.json")
 
+
+@pytest.mark.quick
+def test_fooooo(snapshot, mocker):
+    mocker.patch("pathlib.Path", None)
+    #ruleid: pytest-assert_match-after-path-patch
+    snapshot.assert_match(foo(), "results.json")
+
 @pytest.mark.quick
 def test_bar(snapshot, mocker):
     #ok: pytest-assert_match-after-path-patch

--- a/python/lang/correctness/pytest-assert_match-after-path-patch.py
+++ b/python/lang/correctness/pytest-assert_match-after-path-patch.py
@@ -1,0 +1,12 @@
+import pytest
+
+@pytest.mark.quick
+def test_foo(snapshot, mocker):
+    mocker.patch.object(Path, "open", mocker.mock_open(read_data=file_content))
+    #ruleid: pytest-assert_match-after-path-patch
+    snapshot.assert_match(foo(), "results.json")
+
+@pytest.mark.quick
+def test_bar(snapshot, mocker):
+    #ok: pytest-assert_match-after-path-patch
+    snapshot.assert_match(foo(), "results.json")

--- a/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
+++ b/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
@@ -4,9 +4,13 @@ rules:
       - pattern-inside: |
           import pytest
           ...
-      - pattern-inside: |
-          mocker.patch.object(Path, $METHOD, $MOCKED_VALUE)
-          ...
+      - pattern-either:
+        - pattern-inside: |
+            mocker.patch("pathlib.Path", $MOCKED_VALUE)
+            ...
+        - pattern-inside: |
+            mocker.patch.object(Path, $METHOD, $MOCKED_VALUE)
+            ...
       - pattern:
           snapshot.assert_match(...)
     message: >-

--- a/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
+++ b/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
@@ -9,7 +9,7 @@ rules:
             mocker.patch("pathlib.Path", $MOCKED_VALUE)
             ...
         - pattern-inside: |
-            mocker.patch.object(Path, $METHOD, $MOCKED_VALUE)
+            mocker.patch.object(pathlib.Path, $METHOD, $MOCKED_VALUE)
             ...
       - pattern:
           snapshot.assert_match(...)

--- a/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
+++ b/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: pytest-assert_match-after-path-patch
+    patterns:
+      - pattern-inside: |
+          import pytest
+          ...
+      - pattern-inside: |
+          mocker.patch.object(Path, $METHOD, $MOCKED_VALUE)
+          ...
+      - pattern:
+          snapshot.assert_match(...)
+    message: >-
+      snapshot.assert_match makes use of pathlib to create files. Patching $METHOD may result in unexpected snapshot behavior
+    languages: [python]
+    severity: WARNING
+    metadata:
+      category: correctness
+      technology:
+        - python

--- a/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
+++ b/python/lang/correctness/pytest-assert_match-after-path-patch.yaml
@@ -21,3 +21,6 @@ rules:
       category: correctness
       technology:
         - python
+      references:
+        - https://github.com/returntocorp/semgrep/pull/5459
+        - https://pypi.org/project/pytest-snapshot/


### PR DESCRIPTION
This adds a rule that will catch the use of `snapshot.assert_match` in a pytest test after patching the `Path` object. Doing this can cause unexpected behavior because `assert_match` using path operations to create snapshot files.