### PR TITLE
Address feedback for prefer-copy-over-add

### DIFF
--- a/dockerfile/best-practice/prefer-copy-over-add.dockerfile
+++ b/dockerfile/best-practice/prefer-copy-over-add.dockerfile
@@ -1,19 +1,31 @@
 FROM busybox
 
 # ruleid: prefer-copy-over-add
+ADD http://foo bar
+
+# ruleid: prefer-copy-over-add
+ADD https://foo bar
+
+# ruleid: prefer-copy-over-add
+ADD foo.tar.gz bar
+
+# ruleid: prefer-copy-over-add
+ADD foo.bz2 bar
+
+# ok: prefer-copy-over-add
 ADD foo bar
 
-# ruleid: prefer-copy-over-add
+# ok: prefer-copy-over-add
 ADD foo* /mydir/
 
-# ruleid: prefer-copy-over-add
+# ok: prefer-copy-over-add
 ADD hom?.txt /mydir/o
 
-# ruleid: prefer-copy-over-add
+# ok: prefer-copy-over-add
 ADD arr[[]0].txt /mydir/o
 
-# ruleid: prefer-copy-over-add
+# ok: prefer-copy-over-add
 ADD --chown=55:mygroup files* /somedir/
 
-# ruleid: prefer-copy-over-add
+# ok: prefer-copy-over-add
 ADD --chown=bin files* /somedir/

--- a/dockerfile/best-practice/prefer-copy-over-add.yaml
+++ b/dockerfile/best-practice/prefer-copy-over-add.yaml
@@ -3,14 +3,21 @@ rules:
     severity: INFO
     languages: [dockerfile]
     message: >-
-      The ADD command will accept and include files from a URL.
-      This potentially exposes the container to a man-in-the-middle attack.
-      Since ADD can have this and other unexpected side effects, the use of
-      the more explicit COPY command is preferred.
+      The ADD command will accept and include files from a URL and automatically extract
+      archives. This potentially exposes the container to a man-in-the-middle attack or
+      other attacks if a malicious actor can tamper with the source archive. Since
+      ADD can have this and other unexpected side effects, the use of the more explicit
+      COPY command is preferred.
     metadata:
       references:
-        - https://snyk.io/blog/10-docker-image-security-best-practices/
+        - https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html
       category: best-practice
       technology:
         - dockerfile
-    pattern: ADD $FROM $TO
+    patterns:
+      - pattern: |
+          ADD $FROM $TO
+      - metavariable-regex:
+          metavariable: $FROM
+          regex: (^[A-Za-z]+:\/\/|.*[.](gz|bz2|zip|tar)$)
+      - focus-metavariable: $FROM


### PR DESCRIPTION
We received feedback related to Dockerfile's `prefer-copy-over-add` rule, which is too noisy.
I updated the rule to focus on the most interesting cases of dangerous ADD usage: URLs and files that Docker will automatically extract.
