### PR TITLE
Update react-missing-noreferrer.yaml

### DIFF
--- a/typescript/react/security/audit/react-missing-noreferrer.jsx
+++ b/typescript/react/security/audit/react-missing-noreferrer.jsx
@@ -1,10 +1,10 @@
 // ruleid: react-missing-noreferrer
 var Test1 = <a target='_blank' href="http://example.com/"></a>
 
-// ruleid: react-missing-noreferrer
+// ok: react-missing-noreferrer
 var Test2 = <a target="_blank" rel='noopener' href="http://example.com"></a>
 
-// ruleid: react-missing-noreferrer
+// ok: react-missing-noreferrer
 var Test3 = <a rel='noopener' target="_blank" href="http://example.com"></a>
 
 // ruleid: react-missing-noreferrer
@@ -37,7 +37,7 @@ function TestComponent2() {
 }
 
 function TestComponent3() {
-// ruleid: react-missing-noreferrer
+// ok: react-missing-noreferrer
   return React.createElement('a', {target: '_blank', href: 'http://example.com/', rel: 'noopener'});
 }
 

--- a/typescript/react/security/audit/react-missing-noreferrer.tsx
+++ b/typescript/react/security/audit/react-missing-noreferrer.tsx
@@ -1,10 +1,10 @@
 // ruleid: react-missing-noreferrer
 var Test1 = <a target='_blank' href="http://example.com/"></a>
 
-// ruleid: react-missing-noreferrer
+// ok: react-missing-noreferrer
 var Test2 = <a target="_blank" rel='noopener' href="http://example.com"></a>
 
-// ruleid: react-missing-noreferrer
+// ok: react-missing-noreferrer
 var Test3 = <a rel='noopener' target="_blank" href="http://example.com"></a>
 
 // ruleid: react-missing-noreferrer
@@ -37,7 +37,7 @@ function TestComponent2() {
 }
 
 function TestComponent3() {
-// ruleid: react-missing-noreferrer
+// ok: react-missing-noreferrer
   return React.createElement('a', {target: '_blank', href: 'http://example.com/', rel: 'noopener'});
 }
 

--- a/typescript/react/security/audit/react-missing-noreferrer.yaml
+++ b/typescript/react/security/audit/react-missing-noreferrer.yaml
@@ -17,7 +17,7 @@ rules:
               <$X href="=~/^\/[^\/]/i" rel=... />
           - pattern-not-inside: |
               <$X to="=~/^\/[^\/]/i" rel=... />
-          - pattern-regex: rel=["']((?!noreferrer).)*?["']
+          - pattern-regex: rel=["']((?!noreferrer)|(?!noopener).)*?["']
       - patterns:
           - pattern: |
               React.createElement($A, {target: '_blank'},...)
@@ -32,7 +32,7 @@ rules:
               React.createElement($A, {href: '=~/^\/[^\/]/i'},...)
           - metavariable-regex:
               metavariable: $REL
-              regex: '["'']((?!noreferrer).)*?[''"]'
+              regex: '["'']((?!noreferrer)|(?!noopener).)*?[''"]'
       - patterns:
           - pattern: |
               $P = {target: '_blank'};
@@ -57,12 +57,12 @@ rules:
               React.createElement($A, $P,...);
           - metavariable-regex:
               metavariable: $REL
-              regex: '["'']((?!noreferrer).)*?[''"]'
+              regex: '["'']((?!noreferrer)|(?!noopener).)*?[''"]'
     message: >-
-      This anchor tag with 'target="_blank"' is missing 'noreferrer'.
+      This anchor tag with 'target="_blank"' is missing 'noreferrer' or 'noopener'.
       A page opened with 'target="_blank"' can access the window object of the origin page.
       This means it can manipulate the 'window.opener' property, which could redirect the origin page to a malicious URL.
-      This is called reverse tabnabbing. To prevent this, include 'rel=noreferrer' on this tag.
+      This is called reverse tabnabbing. To prevent this, include 'rel=noreferrer' or 'rel=noopener' on this tag.
     metadata:
       cwe: "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
       owasp: "A3: Sensitive Data Exposure"

--- a/typescript/react/security/audit/react-missing-noreferrer.yaml
+++ b/typescript/react/security/audit/react-missing-noreferrer.yaml
@@ -55,17 +55,23 @@ rules:
               $P = {href: '=~/^\/[^\/]/i'};
               ...
               React.createElement($A, $P,...);
-          - metavariable-regex:
+          - metavariable-pattern:
               metavariable: $REL
-              regex: '["'']((?!noreferrer)|(?!noopener).)*?[''"]'
+              language: generic
+              patterns:
+              - pattern-either:
+                - pattern: noopener
+                - pattern: noreferrer
     message: >-
       This anchor tag with 'target="_blank"' is missing 'noreferrer' or 'noopener'.
       A page opened with 'target="_blank"' can access the window object of the origin page.
       This means it can manipulate the 'window.opener' property, which could redirect the origin page to a malicious URL.
       This is called reverse tabnabbing. To prevent this, include 'rel=noreferrer' or 'rel=noopener' on this tag.
     metadata:
+      confidence: MEDIUM
       cwe: "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
-      owasp: "A3: Sensitive Data Exposure"
+      owasp: 
+      - A03:2017 - Sensitive Data Exposure
       references:
         - https://web.dev/external-anchors-use-rel-noopener/
         - https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer

--- a/typescript/react/security/audit/react-missing-noreferrer.yaml
+++ b/typescript/react/security/audit/react-missing-noreferrer.yaml
@@ -12,12 +12,17 @@ rules:
               <$X to="=~/^\/[^\/]/i" />
       - patterns:
           - pattern-inside: |
-              <$X target="_blank" rel=... />
+              <$X target="_blank" rel=$REL />
           - pattern-not-inside: |
-              <$X href="=~/^\/[^\/]/i" rel=... />
+              <$X href="=~/^\/[^\/]/i" rel=$REL />
           - pattern-not-inside: |
-              <$X to="=~/^\/[^\/]/i" rel=... />
-          - pattern-regex: rel=["']((?!noreferrer)|(?!noopener).)*?["']
+              <$X to="=~/^\/[^\/]/i" rel=$REL />
+          - metavariable-pattern:
+              metavariable: $REL
+              language: generic
+              patterns:
+              - pattern-not-regex: .*noopener.*
+              - pattern-not-regex: .*noreferrer.*
       - patterns:
           - pattern: |
               React.createElement($A, {target: '_blank'},...)
@@ -30,9 +35,12 @@ rules:
               React.createElement($A, {target: '_blank', rel: $REL},...)
           - pattern-not: |
               React.createElement($A, {href: '=~/^\/[^\/]/i'},...)
-          - metavariable-regex:
+          - metavariable-pattern:
               metavariable: $REL
-              regex: '["'']((?!noreferrer)|(?!noopener).)*?[''"]'
+              language: generic
+              patterns:
+              - pattern-not-regex: .*noopener.*
+              - pattern-not-regex: .*noreferrer.*
       - patterns:
           - pattern: |
               $P = {target: '_blank'};
@@ -59,9 +67,8 @@ rules:
               metavariable: $REL
               language: generic
               patterns:
-              - pattern-either:
-                - pattern: noopener
-                - pattern: noreferrer
+              - pattern-not-regex: .*noopener.*
+              - pattern-not-regex: .*noreferrer.*
     message: >-
       This anchor tag with 'target="_blank"' is missing 'noreferrer' or 'noopener'.
       A page opened with 'target="_blank"' can access the window object of the origin page.


### PR DESCRIPTION
This rule shouldn't complain when `noopener` is in place, but `noreferrer` is in place. The linked reference suggests both are suitable for a mitigation of the `window.opener` risk.