### PR TITLE
Match `new` in grpc rule

### DIFF
--- a/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
+++ b/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
@@ -5,11 +5,14 @@ rules:
       A malicious attacker
       could tamper with the gRPC message, which could compromise the machine.
     metadata:
-      owasp: "A8: Insecure Deserialization"
+      owasp: 
+      - A08:2017 - Insecure Deserialization
       cwe: "CWE-502: Deserialization of Untrusted Data"
       category: security
       technology:
         - grpc
+       references:
+       - https://blog.gopheracademy.com/advent-2017/go-grpc-beyond-basics/#:~:text=disables%20transport%20security
     severity: ERROR
     languages: [javascript, typescript]
     pattern-either:

--- a/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
+++ b/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
@@ -2,17 +2,16 @@ rules:
   - id: grpc-nodejs-insecure-connection
     message: >-
       Found an insecure gRPC connection. This creates a connection without encryption to a gRPC client/server.
-      A malicious attacker
-      could tamper with the gRPC message, which could compromise the machine.
+      A malicious attacker could tamper with the gRPC message, which could compromise the machine.
     metadata:
-      owasp: 
-      - "A08:2017 - Insecure Deserialization"
+      owasp:
+        - "A08:2017 - Insecure Deserialization"
       cwe: "CWE-502: Deserialization of Untrusted Data"
       category: security
       technology:
         - grpc
-       references:
-       - "https://blog.gopheracademy.com/advent-2017/go-grpc-beyond-basics/#:~:text=disables%20transport%20security"
+      references:
+        - "https://blog.gopheracademy.com/advent-2017/go-grpc-beyond-basics/#:~:text=disables%20transport%20security"
     severity: ERROR
     languages: [javascript, typescript]
     pattern-either:

--- a/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
+++ b/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
@@ -6,13 +6,13 @@ rules:
       could tamper with the gRPC message, which could compromise the machine.
     metadata:
       owasp: 
-      - A08:2017 - Insecure Deserialization
+      - "A08:2017 - Insecure Deserialization"
       cwe: "CWE-502: Deserialization of Untrusted Data"
       category: security
       technology:
         - grpc
        references:
-       - https://blog.gopheracademy.com/advent-2017/go-grpc-beyond-basics/#:~:text=disables%20transport%20security
+       - "https://blog.gopheracademy.com/advent-2017/go-grpc-beyond-basics/#:~:text=disables%20transport%20security"
     severity: ERROR
     languages: [javascript, typescript]
     pattern-either:

--- a/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
+++ b/javascript/grpc/security/grpc-nodejs-insecure-connection.yaml
@@ -17,9 +17,19 @@ rules:
           require('grpc');
           ...
           $GRPC($ADDR,...,$CREDENTIALS.createInsecure(),...);
+      - pattern: |
+          require('grpc');
+          ...
+          new $GRPC($ADDR,...,$CREDENTIALS.createInsecure(),...);
       - pattern: |-
           require('grpc');
           ...
           $CREDS = <... $CREDENTIALS.createInsecure() ...>;
           ...
           $GRPC($ADDR,...,$CREDS,...);
+      - pattern: |-
+          require('grpc');
+          ...
+          $CREDS = <... $CREDENTIALS.createInsecure() ...>;
+          ...
+          new $GRPC($ADDR,...,$CREDS,...);


### PR DESCRIPTION
This rule previously matched `new ...` only by accident, because of a
parsing inconsistency between JS/TS and other languages. I am addressing
that inconsistency in https://github.com/returntocorp/semgrep/pull/5510.

This change updates the rule so that it will continue to function as
desired.