### PR TITLE
improve dangerouslysetinnerhtml audit

### DIFF
--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
@@ -7,16 +7,14 @@ function TestComponent1() {
 }
 
 function TestComponent2() {
-    // ok:react-dangerouslysetinnerhtml
+    // ruleid:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo},a:b};
     return React.createElement('div', params);
 }
 
 function TestComponent3() {
     // ruleid:react-dangerouslysetinnerhtml
-    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
-
-  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: foo}} />;
+  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: params}} />;
 }
 
 

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
@@ -7,12 +7,15 @@ function TestComponent1() {
 }
 
 function TestComponent2() {
-    // ruleid:react-dangerouslysetinnerhtml
-  return <li className={"foobar"} dangerouslySetInnerHTML={createMarkup()} />;
+    // ok:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo},a:b};
+    return React.createElement('div', params);
 }
 
 function TestComponent3() {
     // ruleid:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
+
   return <li className={"foobar"} dangerouslySetInnerHTML={{__html: foo}} />;
 }
 

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
@@ -1,6 +1,5 @@
-function createMarkup() {
-  return {__html: 'Первый &middot; Второй'};
-}
+import DOMPurify from "dompurify"
+import sanitize from "xss"
 
 function TestComponent1() {
     // ruleid:react-dangerouslysetinnerhtml
@@ -12,18 +11,30 @@ function TestComponent2() {
   return <li className={"foobar"} dangerouslySetInnerHTML={createMarkup()} />;
 }
 
-function TestComponent3() {
-    // ruleid:react-dangerouslysetinnerhtml
-    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: 'foobar'}};
+
+function OkComponent1() {
+    // ok:react-dangerouslysetinnerhtml
+  return <li className={"foobar"} dangerouslySetInnerHTML={DOMPurify.sanitize(createMarkup())} />;
+}
+
+function OkComponent2() {
+    // ok:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
     return React.createElement('div', params);
 }
 
-function OkComponent1() {
+function OkComponent3() {
+    // ok:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: "hi"},a:b};
+    return React.createElement('div', params);
+}
+
+function OkComponent4() {
     // ok:react-dangerouslysetinnerhtml
   return <li class="foobar" selected={true} />;
 }
 
-function OkComponent2() {
+function OkComponent5() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: "test123", style: {color: 'red'}};
     return React.createElement('div', params);

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
@@ -11,30 +11,42 @@ function TestComponent2() {
   return <li className={"foobar"} dangerouslySetInnerHTML={createMarkup()} />;
 }
 
+function TestComponent3() {
+    // ruleid:react-dangerouslysetinnerhtml
+  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: foo}} />;
+}
+
 
 function OkComponent1() {
+    // ok:react-dangerouslysetinnerhtml
+  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(foo)}} />;
+}
+
+
+
+function OkComponent2() {
     // ok:react-dangerouslysetinnerhtml
   return <li className={"foobar"} dangerouslySetInnerHTML={DOMPurify.sanitize(createMarkup())} />;
 }
 
-function OkComponent2() {
+function OkComponent3() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
     return React.createElement('div', params);
 }
 
-function OkComponent3() {
+function OkComponent4() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: "hi"},a:b};
     return React.createElement('div', params);
 }
 
-function OkComponent4() {
+function OkComponent5() {
     // ok:react-dangerouslysetinnerhtml
   return <li class="foobar" selected={true} />;
 }
 
-function OkComponent5() {
+function OkComponent6() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: "test123", style: {color: 'red'}};
     return React.createElement('div', params);

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -7,16 +7,14 @@ function TestComponent1() {
 }
 
 function TestComponent2() {
-    // ok:react-dangerouslysetinnerhtml
+    // ruleid:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo},a:b};
     return React.createElement('div', params);
 }
 
 function TestComponent3() {
     // ruleid:react-dangerouslysetinnerhtml
-    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
-
-  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: foo}} />;
+  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: params}} />;
 }
 
 

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -7,12 +7,15 @@ function TestComponent1() {
 }
 
 function TestComponent2() {
-    // ruleid:react-dangerouslysetinnerhtml
-  return <li className={"foobar"} dangerouslySetInnerHTML={createMarkup()} />;
+    // ok:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo},a:b};
+    return React.createElement('div', params);
 }
 
 function TestComponent3() {
     // ruleid:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
+
   return <li className={"foobar"} dangerouslySetInnerHTML={{__html: foo}} />;
 }
 

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -1,6 +1,5 @@
-function createMarkup() {
-  return {__html: 'Первый &middot; Второй'};
-}
+import DOMPurify from "dompurify"
+import sanitize from "xss"
 
 function TestComponent1() {
     // ruleid:react-dangerouslysetinnerhtml
@@ -12,18 +11,30 @@ function TestComponent2() {
   return <li className={"foobar"} dangerouslySetInnerHTML={createMarkup()} />;
 }
 
-function TestComponent3() {
-    // ruleid:react-dangerouslysetinnerhtml
-    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: 'foobar'}};
+
+function OkComponent1() {
+    // ok:react-dangerouslysetinnerhtml
+  return <li className={"foobar"} dangerouslySetInnerHTML={DOMPurify.sanitize(createMarkup())} />;
+}
+
+function OkComponent2() {
+    // ok:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
     return React.createElement('div', params);
 }
 
-function OkComponent1() {
+function OkComponent3() {
+    // ok:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: "hi"},a:b};
+    return React.createElement('div', params);
+}
+
+function OkComponent4() {
     // ok:react-dangerouslysetinnerhtml
   return <li class="foobar" selected={true} />;
 }
 
-function OkComponent2() {
+function OkComponent5() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: "test123", style: {color: 'red'}};
     return React.createElement('div', params);

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -11,30 +11,42 @@ function TestComponent2() {
   return <li className={"foobar"} dangerouslySetInnerHTML={createMarkup()} />;
 }
 
+function TestComponent3() {
+    // ruleid:react-dangerouslysetinnerhtml
+  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: foo}} />;
+}
+
 
 function OkComponent1() {
+    // ok:react-dangerouslysetinnerhtml
+  return <li className={"foobar"} dangerouslySetInnerHTML={{__html: DOMPurify.sanitize(foo)}} />;
+}
+
+
+
+function OkComponent2() {
     // ok:react-dangerouslysetinnerhtml
   return <li className={"foobar"} dangerouslySetInnerHTML={DOMPurify.sanitize(createMarkup())} />;
 }
 
-function OkComponent2() {
+function OkComponent3() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: sanitize(foo)},a:b};
     return React.createElement('div', params);
 }
 
-function OkComponent3() {
+function OkComponent4() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: "hi"},a:b};
     return React.createElement('div', params);
 }
 
-function OkComponent4() {
+function OkComponent5() {
     // ok:react-dangerouslysetinnerhtml
   return <li class="foobar" selected={true} />;
 }
 
-function OkComponent5() {
+function OkComponent6() {
     // ok:react-dangerouslysetinnerhtml
     let params = {smth: "test123", style: {color: 'red'}};
     return React.createElement('div', params);

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -50,10 +50,10 @@ rules:
                   ...
           - pattern: $S(...)
     message: >-
-      Detection of trusting HTML from code. This is risky because you can
-      inadvertently expose your users to cross-site scripting (XSS) attacks. This
-      can lead to attackers accessing sensitive information. Consider doing this
-      without dangerouslySetInnerHTML or use a sanitization library such as DOMPurify to santize your HTML.
+      Detection of dangerouslySetInnerHTML from non-constant definition. This can
+      inadvertently expose users to cross-site scripting (XSS) attacks if this comes 
+      from user-provided input. If you have to use dangerouslySetInnerHTML, consider 
+      using a sanitization library such as DOMPurify to santize your HTML.
     metadata:
       cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation
         ('Cross-site Scripting')"

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -42,7 +42,8 @@ rules:
                   import * as $S from "sanitize-html";
                   ...
           - pattern: $S(...)
-    message: Detection of trusting HTML from code. This is risky because you can
+    message: >-
+      Detection of trusting HTML from code. This is risky because you can
       inadvertently expose your users to cross-site scripting (XSS) attacks.
       This can lead to attackers accessing sensitive information. Consider doing
       this without dangerouslySetInnerHTML or use a sanitization library such as

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -9,11 +9,18 @@ rules:
           - focus-metavariable: $X
           - pattern-either:
               - pattern: |
-                  {dangerouslySetInnerHTML: {__html: <... $X ...>}}
+                  {dangerouslySetInnerHTML: <... $X ...>}
               - pattern: |
                   <$Y ... dangerouslySetInnerHTML={<... $X ...>} />
           - pattern-not: |
               <... {__html: "..."} ...>
+          - metavariable-pattern:
+              metavariable: $X
+              patterns:
+                - pattern-not: |
+                    {..., $FLD : $Y, ...}
+                - pattern-not: |
+                    {...,__html: $F,...}
     pattern-sanitizers:
       - patterns:
           - pattern-either:
@@ -44,10 +51,9 @@ rules:
           - pattern: $S(...)
     message: >-
       Detection of trusting HTML from code. This is risky because you can
-      inadvertently expose your users to cross-site scripting (XSS) attacks.
-      This can lead to attackers accessing sensitive information. Consider doing
-      this without dangerouslySetInnerHTML or use a sanitization library such as
-      DOMPurify to santize your HTML.
+      inadvertently expose your users to cross-site scripting (XSS) attacks. This
+      can lead to attackers accessing sensitive information. Consider doing this
+      without dangerouslySetInnerHTML or use a sanitization library such as DOMPurify to santize your HTML.
     metadata:
       cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation
         ('Cross-site Scripting')"

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -18,9 +18,7 @@ rules:
               metavariable: $X
               patterns:
                 - pattern-not: |
-                    {..., $FLD : $Y, ...}
-                - pattern-not: |
-                    {...,__html: $F,...}
+                    {..., $FLD : $Z, ...}
     pattern-sanitizers:
       - patterns:
           - pattern-either:

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -18,7 +18,7 @@ rules:
               metavariable: $X
               patterns:
                 - pattern-not: |
-                    {..., $FLD : $Z, ...}
+                    {...}
     pattern-sanitizers:
       - patterns:
           - pattern-either:

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -1,20 +1,65 @@
 rules:
   - id: react-dangerouslysetinnerhtml
-    pattern-either:
-      - pattern: |
-          <$X dangerouslySetInnerHTML=... />
-      - pattern: |
-          {dangerouslySetInnerHTML: ...}
-    message: >-
-      Detected setting HTML from code. This is risky because it’s easy to inadvertently expose your users to a cross-site scripting (XSS) attack. This can lead to attackers accessing sensitive information. Instead, do this without dangerouslySetInnerHTML or use DOMPurify to santize your HTML.
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: $X
+    pattern-sinks:
+      - patterns:
+          - focus-metavariable: $X
+          - pattern-either:
+              - pattern: |
+                  {dangerouslySetInnerHTML: {__html: <... $X ...>}}
+              - pattern: |
+                  <$Y ... dangerouslySetInnerHTML={<... $X ...>} />
+          - pattern-not: |
+              <... {__html: "..."} ...>
+    pattern-sanitizers:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from "dompurify";
+                  ...
+              - pattern-inside: |
+                  import * as $S from "dompurify";
+                  ...
+              - pattern-inside: |
+                  import $S from "isomorphic-dompurify";
+                  ...
+          - pattern: $S.sanitize(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from 'xss';
+                  ...
+              - pattern-inside: |
+                  import * as $S from 'xss';
+                  ...
+              - pattern-inside: |
+                  import $S from 'sanitize-html';
+                  ...
+              - pattern-inside: |
+                  import * as $S from "sanitize-html";
+                  ...
+          - pattern: $S(...)
+    message: Detection of trusting HTML from code. This is risky because you can
+      inadvertently expose your users to cross-site scripting (XSS) attacks.
+      This can lead to attackers accessing sensitive information. Consider doing
+      this without dangerouslySetInnerHTML or use a sanitization library such as
+      DOMPurify to santize your HTML.
     metadata:
-      cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-      owasp: "A7: Cross-Site Scripting (XSS)"
+      cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation
+        ('Cross-site Scripting')"
+      owasp:
+        - "A07:2017: - Cross-Site Scripting (XSS)"
+        - "A03:2022: - Injection"
       references:
         - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
       category: security
+      confidence: LOW
       technology:
         - react
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     languages:
       - typescript
       - javascript


### PR DESCRIPTION
This introduces a still 'audit style' rule, but uses taint to try to help reduce the large number of false positives people have been seeing. 
1. We still focus on any element with dangerouslySetInnerHTML and { } values 
2. We now check for use of a pattern-sanitizer for the 3 common sanitizers iv'e seen used in react apps
3. We do a basic check for no longer usage of consts, which people will deem a false positive

Until deepsemgrep comes to JS I think this is the close to best audit rule we can create, maybe with some additional checks in the future such as  { } object entering createElement  

https://semgrep.dev/s/oRW1

