### PR TITLE
Deprecate prototype-pollution-function

### DIFF
--- a/javascript/lang/security/audit/prototype-pollution/prototype-pollution-function.js
+++ b/javascript/lang/security/audit/prototype-pollution/prototype-pollution-function.js
@@ -4,7 +4,6 @@ const merge1 = (dst, src) => {
         if (isObject(dst[key])) {
             merge1(dst[key], src[key]);
         } else {
-            // ruleid: prototype-pollution-function
             dst[key] = src[key];
         }
     }
@@ -16,7 +15,6 @@ function merge2(dst, src) {
         if (isObject(dst[key])) {
             merge2(dst[key], src[key]);
         } else {
-            // ruleid: prototype-pollution-function
             dst[key] = src[key];
         }
     }
@@ -28,7 +26,6 @@ function okMerge1(dst, src) {
         if (dst.hasOwnProperty(key) && isObject(dst[key])) {
             okMerge1(dst[key], src[key]);
         } else {
-            // ok: prototype-pollution-function
             dst[key] = src[key];
         }
     }
@@ -41,7 +38,6 @@ function okMerge2(dst, src) {
         if (isObject(dst[key])) {
             okMerge2(dst[key], src[key]);
         } else {
-            // ok: prototype-pollution-function
             dst[key] = src[key];
         }
     }

--- a/javascript/lang/security/audit/prototype-pollution/prototype-pollution-function.yaml
+++ b/javascript/lang/security/audit/prototype-pollution/prototype-pollution-function.yaml
@@ -3,7 +3,6 @@ rules:
     languages:
       - javascript
       - typescript
-    mode: taint
     metadata:
       cwe: "CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes"
       category: security
@@ -14,84 +13,10 @@ rules:
       owasp:
         - A08:2021 - Software and Data Integrity Failures
         - A08:2017 - Insecure Deserialization
+      deprecated: true
     severity: WARNING
     message: >-
-      Possibility of prototype polluting function detected.
-      By adding or modifying attributes of an object prototype, it is possible to create
-      attributes that exist on every object,
-      or replace critical attributes with malicious ones.
-      This can be problematic if the software depends on existence or non-existence
-      of certain attributes, or uses pre-defined
-      attributes of object prototype (such as hasOwnProperty, toString or valueOf).
-      Possible mitigations might be: freezing the object prototype, using an object
-      without prototypes (via Object.create(null)
-      ), blocking modifications of attributes that resolve to object prototype, using
-      Map instead of object.
-    pattern-sources:
-      - pattern-either:
-          - patterns:
-              - pattern: $SOURCE[$B]
-              - pattern-not: $SOURCE["..."]
-              - pattern-not: $SOURCE[`...${...}...`]
-              - pattern-not: |
-                  $SOURCE[($B: float)]
-          - pattern: function $X(..., $SOURCE, ...) { ... }
-    pattern-sinks:
-      - patterns:
-          - pattern: $TARGET[$A] = ...
-          - pattern-not: $TARGET["..."] = ...
-          - pattern-not: |
-              $TARGET[($A: float)] = ...
-          - pattern-not-inside: |
-              if (<... $TARGET.hasOwnProperty($A) ...>) {
-                ...
-              }
-          - pattern-either:
-              - pattern-inside: |
-                  $NAME = function $F(...) {
-                    ...
-                    $NAME(...)
-                    ...
-                  }
-              - pattern-inside: |
-                  function $NAME(...) {
-                    ...
-                    $NAME(...)
-                    ...
-                  }
-              - pattern-inside: |
-                  function $NAME(...) {
-                    ...
-                    $THIS.$NAME(...)
-                    ...
-                  }
-              - pattern-inside: |
-                  function $NAME(...) {
-                    ...
-                    $NAME.call(...)
-                    ...
-                  }
-              - pattern-inside: |
-                  $OBJ = function $NAME(...) {
-                    ...
-                    $NAME(...)
-                    ...
-                  }
-              - pattern-inside: |
-                  $OBJ = function $NAME(...) {
-                    ...
-                    $NAME.call(...)
-                    ...
-                  }
-    pattern-sanitizers:
-      - patterns:
-          - pattern: |
-              if (<...'constructor' ...>) {
-                ...
-              }
-              ...
-          - pattern: |
-              if (<...'__proto__' ...>) {
-                ...
-              }
-              ...
+      This rule is deprecated.
+    patterns:
+    - pattern: a()
+    - pattern: b()


### PR DESCRIPTION
This rule has been shown to have hundreds of irrelevant findings. This PR deprecates the rule so that any usage of it no longer produces any findings. This rule is now considered deprecated and will no longer produce findings.