### PR TITLE
Deprecate bracket-object-injection

### DIFF
--- a/javascript/lang/security/audit/detect-bracket-object-injection.js
+++ b/javascript/lang/security/audit/detect-bracket-object-injection.js
@@ -9,17 +9,11 @@ const validate = function() {
   if (field !== undefined) {
     return ValidationManager.validateField(fieldName, field.value, validations);
   }
-  // ruleid:detect-bracket-object-injection
   const badField = formData[formData["foo"]];
-  // ok:detect-bracket-object-injection
   const goodField = formData[someOtherField];
-  // ok:detect-bracket-object-injection
   const someField = formData["bar"]
-  // ok:detect-bracket-object-injection
   const email = formData.split("@")[0];
-  // ruleid:detect-bracket-object-injection
   const email = formData.split("@")[0 + a];
-  // ruleid:detect-bracket-object-injection
   const email = formData.split("@")[a + 0];
   return {
     name: fieldName,

--- a/javascript/lang/security/audit/detect-bracket-object-injection.yaml
+++ b/javascript/lang/security/audit/detect-bracket-object-injection.yaml
@@ -1,18 +1,11 @@
 rules:
   - id: detect-bracket-object-injection
     patterns:
-      - pattern: |
-          $VAR = $OBJ[$FIELD];
-      - pattern-not: |
-          $VAR = $OBJ[($FIELD : float)];
-      - pattern-not: |
-          $VAR = $OBJ["..."];
-      - pattern-not-inside: |
-          $FIELD = ...;
-          ...
+    - pattern: a()
+    - pattern: b()
     message: >-
-      Detected user input used in bracket notation accessor. This could lead to object injection through $FIELD, which could grant access to every property available in the object and therefore sensitive information. Instead, avoid the use of user input in property name fields or create a whitelist of allowed input.
-    severity: WARNING
+      This rule is deprecated.
+    severity: INFO
     languages:
       - javascript
       - typescript
@@ -20,3 +13,12 @@ rules:
       category: security
       technology:
         - javascript
+      cwe: |
+        CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
+      owasp:
+      - A01:2017 - Injection
+      - A03:2021 - Injection
+      references:
+      - https://github.com/nodesecurity/eslint-plugin-security/issues/21
+      - https://github.com/nodesecurity/eslint-plugin-security#rules
+      deprecated: true


### PR DESCRIPTION
This rule will be deprecated. It is based on eslint-plugin-security's detect-object-injection rule, but fires on extremely common patterns (approx. 800 times per project according to some scans) and is rarely, if ever, a security problem.

This rule will no longer match anything.