### PR TITLE
fix eval_node

### DIFF
--- a/contrib/nodejsscan/eval_node.js
+++ b/contrib/nodejsscan/eval_node.js
@@ -13,7 +13,11 @@ app.get('/', function (req, res) {
     res.send('Response</br>');
 });
 app.listen(8000);
+// ok:eval_nodejs
 eval("outside_express" + req.foo)
+// ok:eval_nodejs
 setTimeout('alert(' + req.body.name, 0);
+// ok:eval_nodejs
 setInterval(req.body.name, 0);
+// ok:eval_nodejs
 new Function('arg1', 'arg2', req.query.name)

--- a/contrib/nodejsscan/eval_node.yaml
+++ b/contrib/nodejsscan/eval_node.yaml
@@ -36,7 +36,7 @@ rules:
       - patterns:
           - pattern-either:
               - pattern: |
-                  new Function(<... $SINK ...>)
+                  new Function(...,<... $SINK ...>)
               - pattern: |
                   new Function(<... $SINK ...>)(...)
               - pattern: |

--- a/contrib/nodejsscan/eval_node.yaml
+++ b/contrib/nodejsscan/eval_node.yaml
@@ -46,7 +46,8 @@ rules:
               - pattern: |
                   setInterval(<... $SINK ...>, ...)
           - focus-metavariable: $SINK
-    message: User controlled data was found to enter a dynamic execution of
+    message: >-
+      User controlled data was found to enter a dynamic execution of
       JavaScript. This can lead to Remote Code Injection. Where possible do not
       dynamically execute user-input in functions such as eval(...).
     languages:

--- a/contrib/nodejsscan/eval_node.yaml
+++ b/contrib/nodejsscan/eval_node.yaml
@@ -1,73 +1,67 @@
 rules:
   - id: eval_nodejs
-    patterns:
-      - pattern-either:
-          - pattern-inside: function ($REQ, $RES, ...) {...}
-          - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
-          - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
-          - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
-      - pattern-either:
-          - pattern: |
-              new Function(..., <... $REQ.$QUERY.$VAR ...>, ...)
-          - pattern: |
-              new Function(..., <... $REQ.$QUERY ...>, ...)
-          - pattern: |
-              eval(..., <... $REQ.$QUERY.$VAR ...>, ...)
-          - pattern: |
-              eval(..., <... $REQ.$QUERY ...>, ...)
-          - pattern: |
-              setTimeout(..., <... $REQ.$QUERY.$VAR ...>, ...)
-          - pattern: |
-              setTimeout(..., <... $REQ.$QUERY ...>, ...)
-          - pattern: |
-              setInterval(..., <... $REQ.$QUERY.$VAR ...>, ...)
-          - pattern: |
-              setInterval(..., <... $REQ.$QUERY ...>, ...)
-          - pattern: |
-              $INP = <... $REQ.$QUERY.$VAR ...>;
-              ...
-              new Function(..., <... $INP ...>, ...);
-          - pattern: |
-              $INP = <... $REQ.$QUERY ...>;
-              ...
-              new Function(..., <... $INP ...>, ...);
-          - pattern: |
-              $INP = <... $REQ.$QUERY.$VAR ...>;
-              ...
-              eval(..., <... $INP ...>, ...);
-          - pattern: |
-              $INP = <... $REQ.$QUERY ...>;
-              ...
-              eval(..., <... $INP ...>, ...);
-          - pattern: |
-              $INP = <... $REQ.$QUERY.$VAR ...>;
-              ...
-              setTimeout(..., <... $INP ...>, ...);
-          - pattern: |
-              $INP = <... $REQ.$QUERY ...>;
-              ...
-              setTimeout(..., <... $INP ...>, ...);
-          - pattern: |
-              $INP = <... $REQ.$QUERY.$VAR ...>;
-              ...
-              setInterval(..., <... $INP ...>, ...);
-          - pattern: |
-              $INP = <... $REQ.$QUERY ...>;
-              ...
-              setInterval(..., <... $INP ...>, ...);
-    message: >-
-      User controlled data in eval() or similar functions may result in Server
-      Side Injection or Remote Code Injection
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: function ... ($REQ, $RES) {...}
+              - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
+                      - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})
+                  - metavariable-regex:
+                      metavariable: $METHOD
+                      regex: ^(get|post|put|head|delete|options)$
+          - pattern-either:
+              - pattern: $REQ.query
+              - pattern: $REQ.body
+              - pattern: $REQ.params
+              - pattern: $REQ.cookies
+              - pattern: $REQ.headers
+      - patterns:
+          - pattern-either:
+              - pattern-inside: >
+                  ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
+                  {...}
+              - pattern-inside: |
+                  ({ $REQ }: Request,$RES: Response) => {...}
+          - pattern-either:
+              - pattern: params
+              - pattern: query
+              - pattern: cookies
+              - pattern: headers
+              - pattern: body
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  new Function(<... $SINK ...>)
+              - pattern: |
+                  new Function(<... $SINK ...>)(...)
+              - pattern: |
+                  eval(<... $SINK ...>)
+              - pattern: |
+                  setTimeout( <... $SINK ...>, ...)
+              - pattern: |
+                  setInterval(<... $SINK ...>, ...)
+          - focus-metavariable: $SINK
+    message: User controlled data was found to enter a dynamic execution of
+      JavaScript. This can lead to Remote Code Injection. Where possible do not
+      dynamically execute user-input in functions such as eval(...).
     languages:
       - javascript
     severity: ERROR
     metadata:
-      owasp: "A1: Injection"
-      cwe: >-
-        CWE-95: Improper Neutralization of Directives in Dynamically Evaluated
-        Code ('Eval Injection')
+      references:
+        - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!
+      owasp:
+        - A03:2021 - Injection
+        - A01:2017 - Injection
+      cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated
+        Code ('Eval Injection')"
       category: security
       technology:
         - node.js
         - express
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]


### PR DESCRIPTION
Rewritten the contrib rule to use taint-mode for the same sinks within express.