### PR TITLE
Open Redirect Taint Update

### DIFF
--- a/javascript/browser/security/open-redirect-from-function.js
+++ b/javascript/browser/security/open-redirect-from-function.js
@@ -1,0 +1,18 @@
+var hi = new URLSearchParams(window.location.search).get('gamer')
+
+var hi1 = new URLSearchParams(window.location.search)
+
+function test1(userInput) {
+    //ruleid:js-open-redirect-from-function
+    location.href = userInput;
+    //ruleid:js-open-redirect-from-function
+    location.href = `${userInput}/hi`
+}
+
+
+function test4(userInput) {
+    // ok:js-open-redirect-from-function
+    location.href = `https://www.hardcoded.place/${userInput}`
+    // ok:js-open-redirect-from-function
+    location.href = "https://www.hardcoded.place/" + userInput;
+}

--- a/javascript/browser/security/open-redirect-from-function.yaml
+++ b/javascript/browser/security/open-redirect-from-function.yaml
@@ -7,6 +7,7 @@ rules:
       (XSS)  with JavaScript URIs. It is recommended to validate
       user-controllable  input before allowing it to control the redirection.
     metadata:
+      confidence: LOW
       cwe: "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
       owasp:
         - A10:2013 - Unvalidated Redirects and Forwards
@@ -26,7 +27,7 @@ rules:
     languages:
       - javascript
       - typescript
-    severity: WARNING
+    severity: INFO
     mode: taint
     pattern-sources:
       - patterns:

--- a/javascript/browser/security/open-redirect-from-function.yaml
+++ b/javascript/browser/security/open-redirect-from-function.yaml
@@ -30,11 +30,9 @@ rules:
     mode: taint
     pattern-sources:
       - patterns:
-          - pattern-either:
-              - patterns:
-                  - pattern: |
-                      function ... (..., $PROP, ...) { ... }
-                  - pattern: $PROP
+            - pattern-inside: |
+                function ... (..., $PROP, ...) { ... }
+            - focus-metavariable: $PROP
     pattern-sinks:
       - patterns:
           - pattern-either:

--- a/javascript/browser/security/open-redirect-from-function.yaml
+++ b/javascript/browser/security/open-redirect-from-function.yaml
@@ -1,0 +1,57 @@
+rules:
+  - id: js-open-redirect-from-function
+    message: >-
+      The application accepts potentially user-controlled input `$PROP` which
+      can control the location of the current window context. This can lead two
+      types of vulnerabilities open-redirection and Cross-Site-Scripting
+      (XSS)  with JavaScript URIs. It is recommended to validate
+      user-controllable  input before allowing it to control the redirection.
+    metadata:
+      cwe: "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
+      owasp:
+        - A10:2013 - Unvalidated Redirects and Forwards
+        - A07:2017 - Cross-Site Scripting
+        - A03:2021 - Injection
+      asvs:
+        section: V5 Validation, Sanitization and Encoding
+        control_id: 5.5.1 Insecue Redirect
+        control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v51-input-validation
+        version: "4"
+      category: security
+      references: 
+        - https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+      technology:
+        - browser
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    languages:
+      - javascript
+      - typescript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern: |
+                      function ... (..., $PROP, ...) { ... }
+                  - pattern: $PROP
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: location.href = $SINK
+              - pattern: window.location.href = $SINK
+              - pattern: this.window.location.href = $SINK
+              - pattern: this.location.href = $SINK
+              - pattern: location.replace($SINK)
+              - pattern: window.location.replace($SINK)
+              - pattern: this.window.location.replace($SINK)
+              - pattern: this.location.replace($SINK)
+          - focus-metavariable: $SINK
+          - metavariable-pattern:
+              metavariable: $SINK
+              patterns:
+                - pattern-not: |
+                    "..." + $VALUE
+                - pattern-not: |
+                    `...${$VALUE}`
+                    

--- a/javascript/browser/security/open-redirect.js
+++ b/javascript/browser/security/open-redirect.js
@@ -1,14 +1,27 @@
+var hi = new URLSearchParams(window.location.search).get('gamer')
+
+var hi1 = new URLSearchParams(window.location.search)
+
+var hi2 = new URL(window.location.href)
+
+var hi3 = new URL(location.href).searchParams.get('gamer');
+
 function test1(userInput) {
     //ruleid:js-open-redirect
-    location.replace(userInput);
-}
-
-function test2(userInput) {
+    location.href = hi;
     //ruleid:js-open-redirect
-    location.href = "https://www.hardcoded.place" + userInput;
+    location.href = hi1.get('gamer');
+    //ruleid:js-open-redirect
+    location.href = hi2.searchParams.get('gamer');
+    //ruleid:js-open-redirect
+    location.href = hi3;
 }
 
-function testOk() {
-    //ok:js-open-redirect
-    window.location.href = "/hardcoded-place";
+
+function test4(userInput) {
+    // ok:js-open-redirect
+    location.href = `https://www.hardcoded.place/${userInput}`
+    // ok:js-open-redirect
+    location.href = "https://www.hardcoded.place/" + userInput;
 }
+

--- a/javascript/browser/security/open-redirect.yaml
+++ b/javascript/browser/security/open-redirect.yaml
@@ -1,37 +1,96 @@
 rules:
   - id: js-open-redirect
     message: >-
-      Possible open redirect
+      The application accepts potentially user-controlled input `$PROP` which
+      can control the location of the current window context. This can lead two
+      types of vulnerabilities open-redirection and Cross-Site-Scripting
+      (XSS)  with JavaScript URIs. It is recommended to validate
+      user-controllable  input before allowing it to control the redirection.
     metadata:
       cwe: "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
-      owasp: "A1: Injection"
+      owasp:
+        - A10:2013 - Unvalidated Redirects and Forwards
+        - A07:2017 - Cross-Site Scripting
+        - A03:2021 - Injection
       asvs:
         section: V5 Validation, Sanitization and Encoding
         control_id: 5.5.1 Insecue Redirect
         control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x13-V5-Validation-Sanitization-Encoding.md#v51-input-validation
         version: "4"
       category: security
+      confidence: HIGH
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
       technology:
         - browser
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
     languages:
       - javascript
       - typescript
     severity: WARNING
-    patterns:
-      - pattern-either:
-          - pattern: |
-              window.location.replace($URL)
-          - pattern: |
-              location.replace($URL)
-          - pattern: |
-              window.location.href = $URL
-          - pattern: |
-              location.href = $URL
-      - pattern-not: |
-          window.location.href = "..."
-      - pattern-not: |
-          location.href = "..."
-      - pattern-not: |
-          location.replace("...")
-      - pattern-not: |-
-          window.location.replace("...")
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $PROP = new URLSearchParams($WINDOW. ... .location.search).get('...')
+                  ...
+              - pattern-inside: |
+                  $PROP = new URLSearchParams(location.search).get('...')
+                  ...
+              - pattern-inside: |
+                  $PROP = new URLSearchParams($WINDOW. ... .location.hash.substring(1)).get('...')
+                  ...
+              - pattern-inside: |
+                  $PROP = new URLSearchParams(location.hash.substring(1)).get('...')
+                  ...
+          - pattern: $PROP
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $PROPS = new URLSearchParams($WINDOW. ... .location.search)
+                  ...
+              - pattern-inside: |
+                  $PROPS = new URLSearchParams(location.search)
+                  ...
+              - pattern-inside: |
+                  $PROPS = new URLSearchParams($WINDOW. ... .location.hash.substring(1))
+                  ...
+              - pattern-inside: |
+                  $PROPS = new URLSearchParams(location.hash.substring(1))
+                  ...
+          - pattern: $PROPS.get('...')
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $PROPS = new URL($WINDOW. ... .location.href)
+                  ...
+              - pattern-inside: |
+                  $PROPS = new URL(location.href)
+                  ...
+          - pattern: $PROPS.searchParams.get('...')
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $PROPS = new URL($WINDOW. ... .location.href).searchParams.get('...')
+                  ...
+              - pattern-inside: |
+                  $PROPS = new URL(location.href).searchParams.get('...')
+                  ...
+          - pattern: $PROPS
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: location.href = $SINK
+              - pattern: $THIS. ... .location.href = $SINK
+              - pattern: location.replace($SINK)
+              - pattern: $THIS. ... .location.replace($SINK)
+          - focus-metavariable: $SINK
+          - metavariable-pattern:
+              metavariable: $SINK
+              patterns:
+                - pattern-not: |
+                    "..." + $VALUE
+                - pattern-not: |
+                    `...${$VALUE}`
+                    


### PR DESCRIPTION
Resolves https://github.com/returntocorp/semgrep-rules/issues/2149 which had issues with hard-coded values capturing, rewrote it with client-side sources and taint mode.