### PR TITLE
Removed autofix from use-defused-xml

### DIFF
--- a/python/lang/security/use-defused-xml.yaml
+++ b/python/lang/security/use-defused-xml.yaml
@@ -1,11 +1,11 @@
 rules:
   - id: use-defused-xml
-    fix-regex:
-      regex: xml
-      replacement: defusedxml
     metadata:
-      owasp: "A4: XML External Entities (XXE)"
-      cwe: "CWE-611: Improper Restriction of XML External Entity Reference"
+      owasp:
+        - "A04:2017 - XML External Entities (XXE)"
+        - "A05:2021 - Security Misconfiguration"
+      cwe:
+        - "CWE-611: Improper Restriction of XML External Entity Reference"
       references:
         - https://docs.python.org/3/library/xml.html
         - https://github.com/tiran/defusedxml


### PR DESCRIPTION
In reference to https://github.com/returntocorp/semgrep-rules/issues/2153. There are too many ways to import something in Python for the current autofix implementation to cover.