### PR TITLE
Update `changed-semgrepignore` to match entire lines and ignore lines starting with `#`

### DIFF
--- a/generic/ci/audit/changed-semgrepignore.yaml
+++ b/generic/ci/audit/changed-semgrepignore.yaml
@@ -11,7 +11,7 @@ rules:
       - pattern-not-regex: |
           ^#.*$
     message: >-
-      $1 has been added to the .semgrepignore list of ignored paths. Someone from app-sec may want to audit these changes.
+      `$1` has been added to the .semgrepignore list of ignored paths. Someone from app-sec may want to audit these changes.
     languages:
       - generic
     severity: WARNING

--- a/generic/ci/audit/changed-semgrepignore.yaml
+++ b/generic/ci/audit/changed-semgrepignore.yaml
@@ -4,12 +4,14 @@ rules:
       include:
         - .semgrepignore
     patterns:
-      - pattern: $LINE
-      - metavariable-regex:
-          metavariable: $LINE
-          regex: ^.*$
+      - pattern-regex: |
+          ^(.*)$
+      - pattern-not-regex: |
+          ^\n.*$
+      - pattern-not-regex: |
+          ^#.*$
     message: >-
-      $LINE has been added to the .semgrepignore list of ignored paths. Someone from app-sec may want to audit these changes.
+      $1 has been added to the .semgrepignore list of ignored paths. Someone from app-sec may want to audit these changes.
     languages:
       - generic
     severity: WARNING


### PR DESCRIPTION
Fixes https://linear.app/r2c/issue/RULES-882/regex-interpolation-issue-on-changed-semgrepignore