### PR TITLE
fix: Fix false positives in rule hugo/invalid-base-url

### DIFF
--- a/generic/hugo/best-practice/invalid-base-url.toml
+++ b/generic/hugo/best-practice/invalid-base-url.toml
@@ -16,3 +16,9 @@ identifer = "about"
 name = "About"
 url = "/about.html"
 weight = -110
+
+# ok: invalid-base-url
+baseURL = "http://example.com"
+
+# ok: invalid-base-url
+baseURL = "https://example.com"

--- a/generic/hugo/best-practice/invalid-base-url.yaml
+++ b/generic/hugo/best-practice/invalid-base-url.yaml
@@ -2,11 +2,11 @@ rules:
   - id: invalid-base-url
     patterns:
       - pattern: baseURL = "..."
-      - pattern-regex: (?!.*http).*
+      - pattern-not-regex: (.*http).*
     severity: WARNING
     message: >-
       The 'baseURL' is invalid. This may cause links to not work if deployed.
-      Include the scheme (e.g., https://).
+      Include the scheme (e.g., http:// or https://).
     languages: [generic]
     metadata:
       category: best-practice


### PR DESCRIPTION
Found a false positive with the rule `invalid-base-url` in `generic.hugo`, which does not seem to work as expected.

Added some tests that the rule should not flag on, as specified in `CONTRIBUTING.md`, then fixed the rule!