### PR TITLE
dockerfile/use-workdir: improved match and cleaner message

### DIFF
--- a/dockerfile/best-practice/use-workdir.dockerfile
+++ b/dockerfile/best-practice/use-workdir.dockerfile
@@ -3,7 +3,7 @@ FROM busybox
 # ruleid: use-workdir
 RUN cd semgrep && git clone https://github.com/returntocorp/semgrep
 
-# ruleid: use-workdir
+# ok: use-workdir
 RUN pip3 install semgrep && cd ..
 
 # ok: use-workdir

--- a/dockerfile/best-practice/use-workdir.yaml
+++ b/dockerfile/best-practice/use-workdir.yaml
@@ -1,9 +1,21 @@
 rules:
   - id: use-workdir
-    pattern: RUN ... cd $DIR
+    options:
+      implicit_deep_exprstmt: false
+    patterns:
+      - pattern-either:
+        - pattern-inside: |
+            RUN $ CMD ...
+        - pattern-inside: |
+            RUN $CMD ... && ...
+      - metavariable-pattern:
+          metavariable: $CMD
+          pattern: cd
+      - focus-metavariable: $CMD
     message: >-
-      Use 'WORKDIR' instead of 'RUN cd ...'. Using 'RUN cd ...' may not
-      work as expected in a conatiner.
+      As recommended by Docker's documentation, it is best to use 'WORKDIR'
+      instead of 'RUN cd ...' for improved clarity and reliability. Also, 'RUN cd
+      ...' may not work as expected in a container.
     severity: WARNING
     languages: [dockerfile]
     metadata:


### PR DESCRIPTION
Improved both message and match to address developer sentiment.
It requires Semgrep > 0.102.0 (unreleased at the moment).