### PR TITLE
edited username and password rule to be less FP heavy

### DIFF
--- a/generic/secrets/security/detected-username-and-password-in-uri.txt
+++ b/generic/secrets/security/detected-username-and-password-in-uri.txt
@@ -1,8 +1,8 @@
 # ruleid: detected-username-and-password-in-uri
-https://username:password@example.com
+https://username:passworD123*@example.com
 
 # ruleid: detected-username-and-password-in-uri
-https://username:**sswor*@example.com
+https://username:**sswor*D12@example.com
 
 # ok: detected-username-and-password-in-uri
 https://example.com
@@ -14,7 +14,7 @@ https://example.com/path/to/something
 https://example.com/path/to/something?pass=word
 
 # ok: detected-username-and-password-in-uri
-https://username:***@example.com
+https://username:************@example.com
 
 # ok: detected-username-and-password-in-uri
 https://username:*********@example.com
@@ -23,10 +23,10 @@ https://username:*********@example.com
 https://username:••••••••@example.com
 
 # ruleid: detected-username-and-password-in-uri
-db_url=mysql+pymysql://sampleuser:samplepassword@merchantdb/collection
+db_url=mysql+pymysql://sampleuser:Sample%password12@merchantdb/collection
 
 # ruleid: detected-username-and-password-in-uri
-zxc=https://makka+chakka:chakka@example.com
+zxc=https://makka-chakkaf:chakkA12+@example.com
 
 # ok: detected-username-and-password-in-uri
 xvy=https://www.googly@yoyo.com/yomax#
@@ -35,25 +35,31 @@ xvy=https://www.googly@yoyo.com/yomax#
 yy=http://google@seeyou.com/mandrek
 
 # ruleid: detected-username-and-password-in-uri
-samp=http://uu:pp@totalsuccess@megafailure/yourname
+samp=http://username:f12*Password@totalsuccess@megafailure/yourname
 
 # ruleid: detected-username-and-password-in-uri
-db_url=mysql+pymysql://sampleuser:samplepassword@merchantdb.com/collection
+db_url=mysql+pymysql://sampleuser:samplEpassword12*@merchantdb.com/collection
 
 # ruleid: detected-username-and-password-in-uri
-HTTP (ex : `http://user:password@192.168.0.1:3128/`)
+HTTP (ex : `http://user123:Password12^@192.168.0.1:3128/`)
 
 # ruleid: detected-username-and-password-in-uri
-HTTPS (ex : `https://user:password@192.168.0.1:3128/`)
+HTTPS (ex : `https://user123:passworD0+@192.168.0.1:3128/`)
 
 # ruleid: detected-username-and-password-in-uri
-curl -kvsX PUT \"https://user:pass@something.host.test:8088/search/\" -H \"Content-Type: application/xml\"
+curl -kvsX PUT \"https://user123:passw0rD1&@something.host.test:8088/search/\" -H \"Content-Type: application/xml\"
 
 # ok: detected-username-and-password-in-uri
-f"https://user:{_github_pat(github_secret_name)}@github.com/"
+f"https://user123:{_github_pat(github_secret_name)}@github.com/"
 
 # ok: detected-username-and-password-in-uri
 f"https://{get_user_name}:{_github_pat(github_secret_name)}@github.com/"
 
 # ruleid: detected-username-and-password-in-uri
-f"https://{get_user_name}:pwd@github.com/"
+f"https://{get_user_name}:pwdTest123+@github.com/"
+
+# ok: detected-username-and-password-in-uri
+https://docker.ouroath.com:4443/paranoids/cameo@sha256:35f1ea3d0ae9dc9b058dd8d224f1bb7e053bc58615778f9317c27b73c86dd806
+
+# ok: detected-username-and-password-in-uri
+[https://npm.vzbuilders.com/-/icon/@vzmi/navrail-utils/latest](http://npm.vzbuilders.com/-/package/@vzmi/navrail-utils)

--- a/generic/secrets/security/detected-username-and-password-in-uri.yaml
+++ b/generic/secrets/security/detected-username-and-password-in-uri.yaml
@@ -1,9 +1,18 @@
 rules:
 - id: detected-username-and-password-in-uri
   patterns:
-  - pattern-regex: ([\w+]{1,24})(://)([^$<]{1})([^\s";]{1,}):(?![\x{2022}*]+?@)([^$<\{]{1})([^\s";]{1,})@[-a-zA-Z0-9@:%._\+~#=]{1,256}[a-zA-Z0-9()]{1,24}([^\s]+)
+  - pattern: $PROTOCOL://$...USERNAME:$...PASSWORD@$END
+  - metavariable-regex:
+      metavariable: $...USERNAME
+      regex: ({?)([A-Za-z])([A-Za-z0-9_-]){5,31}(}?) #username must start with alphabet letters, be between 6-32 chars of alphanumeric/underscore/dash. Can optionally be surrounded by brackets
+  - metavariable-regex:
+      metavariable: $...PASSWORD
+      regex: (?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]){6,32} #password must have at least one number, one uppercase letter, one 'special character' defined by OWASP, be between 6-32 chars
+  - metavariable-regex:
+      metavariable: $PROTOCOL
+      regex: (.*http.*)|(.*sql.*)|(.*ftp.*)|(.*smtp.*)
   languages:
-  - regex
+  - generic
   message: Username and password in URI detected
   severity: ERROR
   metadata:

--- a/generic/secrets/security/detected-username-and-password-in-uri.yaml
+++ b/generic/secrets/security/detected-username-and-password-in-uri.yaml
@@ -16,7 +16,11 @@ rules:
   message: Username and password in URI detected
   severity: ERROR
   metadata:
-    source-rule-url: https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go
+    owasp:
+    - A05:2021 - Security Misconfiguration
+    cwe: "CWE-798: Use of Hard-coded Credentials"
+    references:
+    - https://github.com/grab/secret-scanner/blob/master/scanner/signatures/pattern.go
     category: security
     technology:
     - secrets


### PR DESCRIPTION
This is for RULES-952 but also because we have had multiple complaints that this rule is very FP-heavy.

What I did: 
* changed the rule from regex rule to a generic rule
* made the 'PROTOCOL' portion match only `http, sql, ftp, smtp` URLS. I wanted to be specific about the protocol to eliminate FPs.
* defined 'usernames' to start with an alphabetical letter, and have between 5-31 other alphanumeric, underscore, or dash characters (more rigid than our previous definition). Usernames can also optionally be between brackets (var names essentially)
* defined 'passwords' to must include 1 number, 1 uppercase letter, one special character (as defined by OWASP). These 'passwords' must also be between 6-32 chars. This will make it so we're more likely to actually capture a password. 
* I did indeed try to use `metavariable-entropy`, but it didn't match on any of my examples so we are back to regexes :D 

_To test:_
run `semgrep -f detected-username-and-password-in-uri.yaml detected-username-and-password-in-uri.txt`

_Note:_
* this has not been tested on OSS repos.