### PR TITLE
Update `direct-use-of-httpresponse` rule

### DIFF
--- a/python/django/security/audit/xss/direct-use-of-httpresponse.py
+++ b/python/django/security/audit/xss/direct-use-of-httpresponse.py
@@ -1,4 +1,5 @@
 import urllib
+import json
 from django.db.models import Q
 from django.auth import User
 from django.http import HttpResponse, HttpResponseBadRequest
@@ -47,3 +48,12 @@ def vote(request, question_id):
         return HttpResponseBadRequest(
             "This view can not handle method {0}\n".format(request.method), status=405
         )
+
+def endpoint():
+    # ok:direct-use-of-httpresponse
+    return HttpResponse(json.dumps({ 'status': 'ERROR', 'error': str(e) }), content_type='text/json')
+
+
+def dangerous_endpoint():
+    # ruleid:direct-use-of-httpresponse
+    return HttpResponse(json.dumps({ 'status': 'ERROR', 'error': str(e) }), content_type='text/html')

--- a/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
+++ b/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
@@ -24,10 +24,25 @@ rules:
       - pattern-not: django.http.$ANY(status=...)
       - pattern-not: django.http.HttpResponseNotAllowed([...])
       - pattern-either:
-          - pattern: django.http.HttpResponse(...)
-          - pattern: django.http.HttpResponseBadRequest(...)
-          - pattern: django.http.HttpResponseNotFound(...)
-          - pattern: django.http.HttpResponseForbidden(...)
-          - pattern: django.http.HttpResponseNotAllowed(...)
-          - pattern: django.http.HttpResponseGone(...)
-          - pattern: django.http.HttpResponseServerError(...)
+          - patterns:
+            - pattern-either:
+              - pattern: django.http.HttpResponse(...)
+              - pattern: django.http.HttpResponseBadRequest(...)
+              - pattern: django.http.HttpResponseNotFound(...)
+              - pattern: django.http.HttpResponseForbidden(...)
+              - pattern: django.http.HttpResponseNotAllowed(...)
+              - pattern: django.http.HttpResponseGone(...)
+              - pattern: django.http.HttpResponseServerError(...)
+            - pattern-not: django.http.$ANY(...,content_type=$TYPE,...)
+          - patterns:
+            - pattern-either:
+              - pattern: django.http.HttpResponse(...,content_type=$TYPE,...)
+              - pattern: django.http.HttpResponseBadRequest(...,content_type=$TYPE,...)
+              - pattern: django.http.HttpResponseNotFound(...,content_type=$TYPE,...)
+              - pattern: django.http.HttpResponseForbidden(...,content_type=$TYPE,...)
+              - pattern: django.http.HttpResponseNotAllowed(...,content_type=$TYPE,...)
+              - pattern: django.http.HttpResponseGone(...,content_type=$TYPE,...)
+              - pattern: django.http.HttpResponseServerError(...,content_type=$TYPE,...)
+            - metavariable-regex:
+                metavariable: $TYPE
+                regex: '.*[tT][eE][xX][tT]/[hH][tT][mM][lL].*'

--- a/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
+++ b/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
@@ -7,7 +7,9 @@ rules:
       template engine to safely render HTML.
     metadata:
       cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-      owasp: "A7: Cross-Site Scripting (XSS)"
+      owasp: 
+      - A07:2017 - Cross-Site Scripting (XSS)
+      - A03:2021 - Injection
       references:
         - https://docs.djangoproject.com/en/3.1/intro/tutorial03/#a-shortcut-render
         - https://docs.djangoproject.com/en/3.1/topics/http/shortcuts/#render


### PR DESCRIPTION
Remove FPs for `direct-use-of-httpresponse`: there is no XSS when `content_type` is not "text/html" (or when there is no `content_type` set, since "text/html" is default)

from user: https://github.com/returntocorp/semgrep-rules/issues/2196