### PR TITLE
fix test for field sensitive taint

### DIFF
--- a/javascript/angular/security/detect-angular-element-methods.js
+++ b/javascript/angular/security/detect-angular-element-methods.js
@@ -4,8 +4,12 @@ app.controller('myCtrl', function($scope,$sanitize) {
     $scope.foo = getData();
     // ok: detect-angular-element-methods
     angular.element('div').html('hi')
-    // ruleid: detect-angular-element-methods
+    // ok: detect-angular-element-methods
     angular.element('div').html($rootScope.foo)
-    // ruleid: detect-angular-element-methods
+    // ok: detect-angular-element-methods
     angular.element('div').html($scope.foo)
+    // ruleid: detect-angular-element-methods
+    angular.element('div').html($rootScope)
+    // ruleid: detect-angular-element-methods
+    angular.element('div').html($scope)
 });


### PR DESCRIPTION
Updates a rule to account for the addition of [field sensitive tainting](https://github.com/returntocorp/semgrep/pull/5697). See [this slack thread](https://returntocorp.slack.com/archives/C01AX0QCEET/p1656690109447139) for an explanation as to why this is needed. We will have to do some force merging somewhere 😕 