### PR TITLE
Do not include whitespace in passwords (generic.secrets.security.detected-username-and-password-in-uri)

### DIFF
--- a/generic/secrets/security/detected-username-and-password-in-uri.txt
+++ b/generic/secrets/security/detected-username-and-password-in-uri.txt
@@ -63,3 +63,6 @@ https://docker.ouroath.com:4443/paranoids/cameo@sha256:35f1ea3d0ae9dc9b058dd8d22
 
 # ok: detected-username-and-password-in-uri
 [https://npm.vzbuilders.com/-/icon/@vzmi/navrail-utils/latest](http://npm.vzbuilders.com/-/package/@vzmi/navrail-utils)
+
+# ok: detected-username-and-password-in-uri
+https://localhost: Example+1@example.com

--- a/generic/secrets/security/detected-username-and-password-in-uri.yaml
+++ b/generic/secrets/security/detected-username-and-password-in-uri.yaml
@@ -7,7 +7,7 @@ rules:
       regex: ({?)([A-Za-z])([A-Za-z0-9_-]){5,31}(}?) #username must start with alphabet letters, be between 6-32 chars of alphanumeric/underscore/dash. Can optionally be surrounded by brackets
   - metavariable-regex:
       metavariable: $...PASSWORD
-      regex: (?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]){6,32} #password must have at least one number, one uppercase letter, one 'special character' defined by OWASP, be between 6-32 chars
+      regex: (?!.*[\s])(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]){6,32} #password must have at least one number, one uppercase letter, one 'special character' defined by OWASP, be between 6-32 chars
   - metavariable-regex:
       metavariable: $PROTOCOL
       regex: (.*http.*)|(.*sql.*)|(.*ftp.*)|(.*smtp.*)


### PR DESCRIPTION
# What
This performs a negative lookahead in the `$...PASSWORD` metavariable in order to ensure that it does not contain whitespace. A test is included that was previously considered a username/password combination.

# Why
The current check results in too many false positives where URLs and code examples/Markdown mix (e.g., YAML, Bazel build files, etc).