### PR TITLE
fix url credential + tests

### DIFF
--- a/generic/secrets/security/detected-username-and-password-in-uri.txt
+++ b/generic/secrets/security/detected-username-and-password-in-uri.txt
@@ -63,3 +63,32 @@ https://docker.ouroath.com:4443/paranoids/cameo@sha256:35f1ea3d0ae9dc9b058dd8d22
 
 # ok: detected-username-and-password-in-uri
 [https://npm.vzbuilders.com/-/icon/@vzmi/navrail-utils/latest](http://npm.vzbuilders.com/-/package/@vzmi/navrail-utils)
+
+# ok: detected-username-and-password-in-uri
+[https://npm.vzbuilders.com/-/icon/@vzmi/navrail-utils/latest](http://npm.vzbuilders.com/-/package/@vzmi/navrail-utils)
+
+
+    "jest-worker": {
+      "version": "28.1.1",
+      # ok: detected-username-and-password-in-uri
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.1.1.tgz",
+      "integrity": "sha512-Au7slXB08C6h+xbJPp7VIb6U0XX5Kc9uel/WFc6/rcTzGiaVCBRngBExSYuXSLFPULPSYU3cJ3ybS988lNFQhQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "8.1.1",
+          # ok: detected-username-and-password-in-uri
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },

--- a/generic/secrets/security/detected-username-and-password-in-uri.yaml
+++ b/generic/secrets/security/detected-username-and-password-in-uri.yaml
@@ -4,7 +4,7 @@ rules:
   - pattern: $PROTOCOL://$...USERNAME:$...PASSWORD@$END
   - metavariable-regex:
       metavariable: $...USERNAME
-      regex: ({?)([A-Za-z])([A-Za-z0-9_-]){5,31}(}?) #username must start with alphabet letters, be between 6-32 chars of alphanumeric/underscore/dash. Can optionally be surrounded by brackets
+      regex: \A({?)([A-Za-z])([A-Za-z0-9_-]){5,31}(}?)\Z #username must start with alphabet letters, be between 6-32 chars of alphanumeric/underscore/dash. Can optionally be surrounded by brackets
   - metavariable-regex:
       metavariable: $...PASSWORD
       regex: (?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~]){6,32} #password must have at least one number, one uppercase letter, one 'special character' defined by OWASP, be between 6-32 chars


### PR DESCRIPTION
Missing line boundary on user regex, causing multiline things to be captured as a "user" for things like lockfile definitions `package@version`