### PR TITLE
update direct-response-write

### DIFF
--- a/javascript/express/security/audit/xss/direct-response-write.js
+++ b/javascript/express/security/audit/xss/direct-response-write.js
@@ -2,35 +2,6 @@
 const express = require('express')
 const router = express.Router()
 
-// cf. juice-shop
-exports.promotionVideo = () => {
-    return (req, res) => {
-      fs.readFile('views/promotionVideo.pug', function (err, buf) {
-        if (err) throw err
-        let template = buf.toString()
-        const subs = getSubsFromFile()
-
-        utils.solveIf(challenges.videoXssChallenge, () => { return utils.contains(subs, '</script><script>alert(`xss`)</script>') })
-
-        const theme = themes[config.get('application.theme')]
-        template = template.replace(/_title_/g, config.get('application.name'))
-        template = template.replace(/_favicon_/g, favicon())
-        template = template.replace(/_bgColor_/g, theme.bgColor)
-        template = template.replace(/_textColor_/g, theme.textColor)
-        template = template.replace(/_navColor_/g, theme.navColor)
-        template = template.replace(/_primLight_/g, theme.primLight)
-        template = template.replace(/_primDark_/g, theme.primDark)
-        const fn = pug.compile(template)
-        let compiledTemplate = fn()
-        compiledTemplate = compiledTemplate.replace('<script id="subtitle"></script>', '<script id="subtitle" type="text/vtt" data-label="English" data-lang="en">' + subs + '</script>')
-        // ruleid: direct-response-write
-        res.send(compiledTemplate)
-      })
-    }
-    function favicon () {
-      return utils.extractFilename(config.get('application.favicon'))
-    }
-  }
 
 
 router.get('/greeting', (req, res) => {
@@ -73,13 +44,6 @@ app.get('/2', function (req, res) {
     res.send('Response</br>' + user.name);
 });
 
-app.get('/1', function (req, res) {
-    var user = req.query.name;
-    var msg = [];
-    msg.push(user);
-    // ruleid: direct-response-write
-    res.send('Response</br>' + msg[0]);
-});
 
 app.get('/4', function (req, res) {
     var user = req.query.name;
@@ -90,10 +54,6 @@ app.get('/4', function (req, res) {
     // ruleid: direct-response-write
     res.send(output);
 });
-
-
-
-
 
 var express = require('express');
 var app = express();
@@ -111,7 +71,7 @@ app.get('/3', function (req, res) {
 app.get('/3', function (req, res) {
     var resp = req.foo;
     var x = 1;
-    // ruleid: direct-response-write
+    // ok: direct-response-write
     res.write('Response</br>' + resp);
 });
 
@@ -125,7 +85,8 @@ app.get('/xss', function (req, res) {
     res.write('Response</br>' + req.query('doo'));
 });
 app.get('/xss', function (req, res) {
-    // ruleid: direct-response-write
+    // ok: direct-response-write
+    res.set('Content-Type','text/plain')
     res.write('Response</br>' + req.query.name);
 });
 
@@ -138,7 +99,7 @@ app.get('/noxss', function (req, res) {
 app.get('/noxs2s', function (req, res) {
     var resp = req.query.name;
     // ruleid: direct-response-write
-    res.write('Response</br>' + foo);
+    res.write('Response</br>' + resp);
 });
 
 app.get('/xss', function (req, res) {

--- a/javascript/express/security/audit/xss/direct-response-write.yaml
+++ b/javascript/express/security/audit/xss/direct-response-write.yaml
@@ -10,6 +10,8 @@ rules:
       - typescript
     severity: WARNING
     metadata:
+      references: 
+        - https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html
       owasp: 
         - A03:2021 - Injection
         - A07:2017 - Cross-Site Scripting (XSS)

--- a/javascript/express/security/audit/xss/direct-response-write.yaml
+++ b/javascript/express/security/audit/xss/direct-response-write.yaml
@@ -1,39 +1,104 @@
 rules:
   - id: direct-response-write
     message: >-
-      Detected directly writing to a Response object. This bypasses
-      any HTML escaping and may expose your app to a cross-site scripting
+      Detected directly writing to a Response object from user-defined input. This bypasses
+      any HTML escaping and may expose your application to a Cross-Site-scripting
       (XSS) vulnerability. Instead, use 'resp.render()' to render
       safely escaped HTML.
     languages:
       - javascript
       - typescript
-    severity: ERROR
+    severity: WARNING
     metadata:
-      owasp: "A7: Cross-Site Scripting (XSS)"
-      cwe: >-
-        CWE-79: Improper Neutralization of Input During Web Page Generation
-        ('Cross-site Scripting')
+      owasp: 
+        - A03:2021 - Injection
+        - A07:2017 - Cross-Site Scripting (XSS)
+      cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
       category: security
       technology:
         - express
-    patterns:
-      - pattern-either:
-          - pattern-inside: function ($REQ, $RES) {...}
-          - pattern-inside: function $FUNC($REQ, $RES) {...}
-          - pattern-inside: function ($REQ, $RES, $NEXT) {...}
-          - pattern-inside: function $FUNC($REQ, $RES, $NEXT) {...}
-          - pattern-inside: $X = function $FUNC($REQ, $RES) {...}
-          - pattern-inside: $X = function $FUNC($REQ, $RES, $NEXT) {...}
-          - pattern-inside: $APP.get(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.post(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.put(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.head(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.delete(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.options(..., function $FUNC($REQ, $RES) {...})
-      - pattern-not: $RES.write("...")
-      - pattern-not: $RES.send("...")
-      - pattern-either:
-          - pattern: $RES.write($ARG)
-          - pattern: $RES.send($ARG)
-    fix: $RES.render($ARG)
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: function ... ($REQ, $RES) {...}
+              - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
+              - patterns:
+                  - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
+                  - metavariable-regex:
+                      metavariable: $METHOD
+                      regex: ^(get|post|put|head|delete|options)
+          - pattern-not-inside: |
+              function ... ($REQ, $RES) {
+                  ...
+                  $RES.$SET('Content-Type', '$TYPE')
+              }
+          - pattern-not-inside: |
+              $APP.$METHOD(..., function $FUNC($REQ, $RES) {
+                  ...
+                  $RES.$SET('Content-Type', '$TYPE')
+              })
+          - pattern-not-inside: |
+              function ... ($REQ, $RES, $NEXT) {
+                  ...
+                  $RES.$SET('Content-Type', '$TYPE')
+              }
+          - pattern-not-inside: |
+              function ... ($REQ, $RES) {
+                  ...
+                  $RES.set('$TYPE')
+              }
+          - pattern-not-inside: |
+              $APP.$METHOD(..., function $FUNC($REQ, $RES) {
+                  ...
+                  $RES.set('$TYPE')
+              })
+          - pattern-not-inside: |
+              function ... ($REQ, $RES, $NEXT) {
+                  ...
+                  $RES.set('$TYPE')
+              }
+          - pattern-either:
+              - pattern: $REQ.query
+              - pattern: $REQ.body
+              - pattern: $REQ.params
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
+                  {...}
+              - pattern-inside: |
+                  ({ $REQ }: Request,$RES: Response) => {...}
+          - pattern-not-inside: |
+              ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
+              {
+                  ...
+                  $RES.$SET('Content-Type', '$TYPE')
+              }
+          - pattern-not-inside: |
+              ({ $REQ }: Request,$RES: Response) => {
+                  ...
+                  $RES.$SET('Content-Type', '$TYPE')
+              }
+          - pattern-not-inside: |
+              ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
+              {
+                  ...
+                  $RES.set('$TYPE')
+              }
+          - pattern-not-inside: |
+              ({ $REQ }: Request,$RES: Response) => {
+                  ...
+                  $RES.$SET('$TYPE')
+              }
+          - focus-metavariable: $REQ
+          - pattern-either:
+              - pattern: params
+              - pattern: query
+              - pattern: body
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $RES.write($ARG)
+              - pattern: $RES.send($ARG)
+          - focus-metavariable: $ARG


### PR DESCRIPTION
Updated to use express sources, narrowed down to only obvious sources since its direct reflection. 

Removed the set-content header since it will likely introduce FPs will write a new rule to capture that edge case where text/html is set. 