### PR TITLE
csharp mass assign fix

### DIFF
--- a/csharp/dotnet/security/audit/mass-assignment.cs
+++ b/csharp/dotnet/security/audit/mass-assignment.cs
@@ -1,15 +1,22 @@
 using Microsoft.AspNetCore.Mvc;
 
-// ruleid: mass-assignment
 public IActionResult Create(UserModel model)
 {
     context.SaveChanges();
+    // ruleid: mass-assignment
     return View("Index", model);
 }
 
-// ok: mass-assignment
 public IActionResult Create([Bind(nameof(UserModel.Name))] UserModel model)
 {
     context.SaveChanges();
+    // ok: mass-assignment
     return View("Index", model);
+}
+
+[HttpGet("/")]
+public IActionResult Index()
+{
+    // ok: mass-assignment
+    return NoContent();
 }

--- a/csharp/dotnet/security/audit/mass-assignment.yaml
+++ b/csharp/dotnet/security/audit/mass-assignment.yaml
@@ -3,7 +3,6 @@ rules:
   mode: taint
   pattern-sources:
     - patterns:
-      - focus-metavariable: $ARG
       - pattern-either:
         - pattern: |
             public IActionResult $METHOD(..., $TYPE $ARG, ...){
@@ -24,6 +23,7 @@ rules:
           public ActionResult $METHOD(..., [Bind(...)] $TYPE $ARG, ...){
             ...
           }
+      - focus-metavariable: $ARG
   pattern-sinks:
     - pattern: View(...)
   message: Mass assignment or Autobinding vulnerability in code allows an attacker

--- a/csharp/dotnet/security/audit/mass-assignment.yaml
+++ b/csharp/dotnet/security/audit/mass-assignment.yaml
@@ -1,26 +1,31 @@
 rules:
 - id: mass-assignment
-  patterns:
-  - pattern-either:
-    - pattern: |
-        public IActionResult $METHOD(...){
+  mode: taint
+  pattern-sources:
+    - patterns:
+      - focus-metavariable: $ARG
+      - pattern-either:
+        - pattern: |
+            public IActionResult $METHOD(..., $TYPE $ARG, ...){
+              ...
+            }
+        - pattern: |
+            public ActionResult $METHOD(..., $TYPE $ARG, ...){
+              ...
+            }
+      - pattern-inside: |
+          using Microsoft.AspNetCore.Mvc;
           ...
-        }
-    - pattern: |
-        public ActionResult $METHOD(...){
-          ...
-        }
-  - pattern-inside: |
-      using Microsoft.AspNetCore.Mvc;
-      ...
-  - pattern-not: |
-      public IActionResult $METHOD(..., [Bind(...)] $TYPE $ARG){
-        ...
-      }
-  - pattern-not: |
-      public ActionResult $METHOD(..., [Bind(...)] $TYPE $ARG){
-        ...
-      }
+      - pattern-not: |
+          public IActionResult $METHOD(..., [Bind(...)] $TYPE $ARG, ...){
+            ...
+          }
+      - pattern-not: |
+          public ActionResult $METHOD(..., [Bind(...)] $TYPE $ARG, ...){
+            ...
+          }
+  pattern-sinks:
+    - pattern: View(...)
   message: Mass assignment or Autobinding vulnerability in code allows an attacker
     to execute over-posting attacks, which could create a new parameter in the binding
     request and manipulate the underlying object in the application.


### PR DESCRIPTION
To address https://github.com/returntocorp/semgrep-rules/issues/2276. 

This changes the csharp mass assignment rule to a taint rule, and makes sure that the method involved has an argument. 