### PR TITLE
Add support for github actions inputs

### DIFF
--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -3,6 +3,10 @@ name: docker
 
 on:
   workflow_dispatch:
+    inputs:
+      message_to_print:
+        type: string
+        required: false
   push:
     branches:
       - develop
@@ -83,7 +87,9 @@ jobs:
           echo "PR title did not start with 'octocat'"
           exit 1
           fi
-
+      - name: Print a message
+        run: |
+          echo "${{github.event.inputs.message_to_print}}""
       - name: Show author email
         # ruleid: run-shell-injection
         run: |

--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -89,7 +89,7 @@ jobs:
           fi
       - name: Print a message
         run: |
-          echo "${{github.event.inputs.message_to_print}}""
+          echo "${{github.event.inputs.message_to_print}}"
       - name: Show author email
         # ruleid: run-shell-injection
         run: |

--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -88,6 +88,7 @@ jobs:
           exit 1
           fi
       - name: Print a message
+        # ruleid: run-shell-injection
         run: |
           echo "${{github.event.inputs.message_to_print}}"
       - name: Show author email

--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -45,4 +45,5 @@ rules:
                 - pattern: ${{ github.event.pull_request.head.label }}
                 - pattern: ${{ github.event.pull_request.head.repo.default_branch }}
                 - pattern: ${{ github.head_ref }}
+                - pattern: ${{ github.event.inputs ... }}
     severity: ERROR


### PR DESCRIPTION
Github actions/workflows can have external [inputs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs), which are hold in the `github.event.input` variable.

Added support for those cases as well