### PR TITLE
Tainted shell call fix fp

### DIFF
--- a/ruby/rails/security/audit/avoid-tainted-shell-call.rb
+++ b/ruby/rails/security/audit/avoid-tainted-shell-call.rb
@@ -16,3 +16,23 @@ def foo
   Shell.cat("/var/log/www/access.log")
 
 end
+
+def self.call(params)
+  # ok: avoid-tainted-shell-call
+  new(params).call
+end
+
+def self.execute(site, params, user)
+  # ok: avoid-tainted-shell-call
+  new(site, params, user).execute
+end
+
+def self.execute(relation, params)
+  # ok: avoid-tainted-shell-call
+  new(relation, params).execute
+end
+
+def self.execute(relation, params, site)
+  # ok: avoid-tainted-shell-call
+  new(relation, params, site).execute
+end

--- a/ruby/rails/security/audit/avoid-tainted-shell-call.rb
+++ b/ruby/rails/security/audit/avoid-tainted-shell-call.rb
@@ -17,22 +17,22 @@ def foo
 
 end
 
-def self.call(params)
+def foo2(param1)
   # ok: avoid-tainted-shell-call
   new(params).call
 end
 
-def self.execute(site, params, user)
+def foo3(param1, param2, param3)
   # ok: avoid-tainted-shell-call
-  new(site, params, user).execute
+  new(param1, params2, param3).execute
 end
 
-def self.execute(relation, params)
+def foo4(param1, param2)
   # ok: avoid-tainted-shell-call
-  new(relation, params).execute
+  new(param1, param2).execute
 end
 
-def self.execute(relation, params, site)
+def foo5(param1, param2, param3)
   # ok: avoid-tainted-shell-call
-  new(relation, params, site).execute
+  new(param1, param2, param3).execute
 end

--- a/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
+++ b/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
@@ -15,7 +15,8 @@ rules:
     severity: ERROR
     mode: taint
     pattern-sources:
-      - pattern: params
+    - pattern-either:
+      - pattern: params[...]
       - pattern: cookies
       - pattern: request.env
     pattern-sinks:
@@ -54,6 +55,7 @@ rules:
                     - pattern: load_file
                     - pattern: makedirs
                     - pattern: move
+                    - pattern: new
                     - pattern: open
                     - pattern: read
                     - pattern: readlines

--- a/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
+++ b/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: avoid-tainted-shell-call
     metadata:
-      owasp: "A1: Injection"
+      owasp: "A01:2017 - Injection"
       cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
       references:
         - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/file_access/index.markdown

--- a/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
+++ b/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
@@ -1,7 +1,9 @@
 rules:
   - id: avoid-tainted-shell-call
     metadata:
-      owasp: "A01:2017 - Injection"
+      owasp: 
+      - A01:2017 - Injection
+      - A03:2021 - Injection
       cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
       references:
         - https://github.com/presidentbeef/brakeman/blob/main/docs/warning_types/file_access/index.markdown

--- a/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
+++ b/ruby/rails/security/audit/avoid-tainted-shell-call.yaml
@@ -54,7 +54,6 @@ rules:
                     - pattern: load_file
                     - pattern: makedirs
                     - pattern: move
-                    - pattern: new
                     - pattern: open
                     - pattern: read
                     - pattern: readlines


### PR DESCRIPTION
* fix some FP for this rule in cases where `params` is overloaded.
* changed taint source to be specifically accessing `params` keys

_To Test:_
Run `semgrep --test .` in the repository