### PR TITLE
Add `escapeHtml={false}` check in the react-markdown-insecure-html rule

### DIFF
--- a/typescript/react/security/react-markdown-insecure-html.jsx
+++ b/typescript/react/security/react-markdown-insecure-html.jsx
@@ -15,7 +15,17 @@ function bad1() {
     return <ReactMarkdown astPlugins={[parseHtml]} allowDangerousHtml children={markdown} />;
 }
 
+function bad2() {
+// ruleid: react-markdown-insecure-html
+    return <ReactMarkdown astPlugins={[parseHtml]} escapeHtml={false} children={markdown} />;
+}
+
 function ok1() {
 // ok: react-markdown-insecure-html
     return <ReactMarkdown renderers={renderers} children={markdown} />;
+}
+
+function ok2() {
+// ok: react-markdown-insecure-html
+    return <ReactMarkdown renderers={renderers} escapeHtml={true} children={markdown} />;
 }

--- a/typescript/react/security/react-markdown-insecure-html.tsx
+++ b/typescript/react/security/react-markdown-insecure-html.tsx
@@ -15,7 +15,17 @@ function bad1() {
     return <ReactMarkdown astPlugins={[parseHtml]} allowDangerousHtml children={markdown} />;
 }
 
+function bad2() {
+// ruleid: react-markdown-insecure-html
+    return <ReactMarkdown astPlugins={[parseHtml]} escapeHtml={false} children={markdown} />;
+}
+
 function ok1() {
 // ok: react-markdown-insecure-html
     return <ReactMarkdown renderers={renderers} children={markdown} />;
+}
+
+function ok2() {
+// ok: react-markdown-insecure-html
+    return <ReactMarkdown renderers={renderers} escapeHtml={true} children={markdown} />;
 }

--- a/typescript/react/security/react-markdown-insecure-html.yaml
+++ b/typescript/react/security/react-markdown-insecure-html.yaml
@@ -18,11 +18,13 @@ rules:
           - pattern: |
               <$EL allowDangerousHtml />
           - pattern: |
+              <$EL escapeHtml={false} />
+          - pattern: |
               <$EL transformLinkUri=... />
           - pattern: |
               <$EL transformImageUri=... />
     message: >-
-      Overwriting `transformLinkUri` or `transformImageUri` to something insecure or turning `allowDangerousHtml` on, will open code up to XSS vectors.
+      Overwriting `transformLinkUri` or `transformImageUri` to something insecure, or turning `allowDangerousHtml` on, or turning `escapeHtml` off, will open the code up to XSS vectors.
     metadata:
       cwe: "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
       owasp: "A7: Cross-Site Scripting (XSS)"


### PR DESCRIPTION
While auditing some code, I came across `<ReactMarkdown escapeHtml={false} />`, which may lead to XSS. The use of `escapeHtml` is [deprecated and removed](https://github.com/remarkjs/react-markdown/blob/bd8e53b4969a0a6f5cfd0fb1d4fe5d97d2cfa630/changelog.md#remove-buggy-html-in-markdown-parser), but [many projects still use it](https://cs.github.com/?scopeName=All+repos&scope=&q=escapeHtml%3D%7Bfalse%7D).

This PR adds detection to the `<ReactMarkdown escapeHtml={false} />` pattern.