### PR TITLE
Exclude constants from file inclusion in PHP

### DIFF
--- a/php/lang/security/file-inclusion.php
+++ b/php/lang/security/file-inclusion.php
@@ -35,3 +35,6 @@ include_safe(__DIR__ . $user_input);
 
 // ok: file-inclusion
 require_once(CONFIG_DIR . '/constant.php');
+
+// ok: file-inclusion
+require_once( dirname( __FILE__ ) . '/admin.php' );

--- a/php/lang/security/file-inclusion.php
+++ b/php/lang/security/file-inclusion.php
@@ -32,3 +32,6 @@ include(__DIR__ . 'constant.php');
 
 // ok: file-inclusion
 include_safe(__DIR__ . $user_input);
+
+// ok: file-inclusion
+require_once(CONFIG_DIR . '/constant.php');

--- a/php/lang/security/file-inclusion.yaml
+++ b/php/lang/security/file-inclusion.yaml
@@ -1,12 +1,14 @@
 rules:
   - id: file-inclusion
     patterns:
-      - pattern: $FUNC(...);
-      - pattern-not: $FUNC("...");
-      - pattern-not: $FUNC(__DIR__ . "...");
+      - pattern-inside: $FUNC(...);
+      - pattern: $VAR
       - metavariable-regex:
           metavariable: $FUNC
           regex: \b(include|include_once|require|require_once)\b
+      - metavariable-regex:
+          metavariable: $VAR
+          regex: \W?\$.+
     message: >-
       Detected non-constant file inclusion. This can lead to local file inclusion (LFI) or remote file inclusion (RFI) if user input reaches this statement. LFI and RFI could lead to sensitive files being obtained by attackers. Instead, explicitly specify what to include. If that is not a viable solution, validate user input thoroughly.
     metadata:


### PR DESCRIPTION
Assuming constants are trusted we can exclude them from findings. This can help remove tons of False Positives. 

I changed the logic of the rule to only report findings where a regular variable (starting with $) is found inside the require function. 