### PR TITLE
rewrite ruby-eval in taint mode

### DIFF
--- a/ruby/lang/security/no-eval.rb
+++ b/ruby/lang/security/no-eval.rb
@@ -1,61 +1,11 @@
-class Person
-end
-
 # ruleid:ruby-eval
-Person.class_eval do
-  def say_hello
-   "Hello!"
-  end
-end
-
-jimmy = Person.new
-jimmy.say_hello # "Hello!"
-
-# ruleid:ruby-eval
-Person.instance_eval do
-  def human?
-    true
-  end
-end
-
-Person.human? # true
-
-# ok:ruby-eval
-Person.foo do
-  def bar?
-    true
-  end
-end
-
-# ruleid:ruby-eval
-Array.class_eval(array_second)
-
-
-
-class Account < ActiveRecord::Base
-  validates_format_of :name, :with => /^[a-zA-Z]+$/
-  validates_format_of :blah, :with => /\A[a-zA-Z]+$/
-  validates_format_of :something, :with => /[a-zA-Z]\z/
-  validates_format_of :good_valid, :with => /\A[a-zA-Z]\z/ #No warning
-  validates_format_of :not_bad, :with => /\A[a-zA-Z]\Z/ #No warning
-
-  def mass_assign_it
-    Account.new(params[:account_info]).some_other_method
-  end
-
-  def test_class_eval
-    # ruleid:ruby-eval
-    User.class_eval do
-      attr_reader :some_private_thing
-    end
-  end
-end
+Array.class_eval(cookies['tainted_cookie'])
 
 def zen
   41
 end
 
-# ruleid:ruby-eval
+# ok:ruby-eval
 eval("def zen; 42; end")
 
 puts zen
@@ -63,21 +13,44 @@ puts zen
 class Thing
 end
 a = %q{def hello() "Hello there!" end}
-# ruleid:ruby-eval
+# not user-controllable, this is ok
+# ok:ruby-eval
 Thing.module_eval(a)
 puts Thing.new.hello()
+b = params['something']
+#ruleid:ruby-eval
+Thing.module_eval(b)
 
+#ruleid:ruby-eval
+eval(b)
+#ruleid:ruby-eval
+eval(b,some_binding)
 
 def get_binding(param)
   binding
 end
 b = get_binding("hello")
-# ruleid:ruby-eval
-b.eval("param")
+# ok:ruby-eval
+b.eval("some_func")
+
+# ok:ruby-eval
+eval("some_func",b)
+
+#ruleid:ruby-eval
+eval(params['cmd'],b)
 
 # ruleid:ruby-eval
+RubyVM::InstructionSequence.compile(foo).eval
+
+# ok:ruby-eval
 RubyVM::InstructionSequence.compile("1 + 2").eval
 
-iseq = RubyVM::InstructionSequence.compile('num = 1 + 2')
+iseq = RubyVM::InstructionSequence.compile(foo)
 # ruleid:ruby-eval
 iseq.eval
+
+
+iseq = RubyVM::InstructionSequence.compile('num = 1 + 2')
+# ok:ruby-eval
+iseq.eval
+

--- a/ruby/lang/security/no-eval.yaml
+++ b/ruby/lang/security/no-eval.yaml
@@ -45,3 +45,4 @@ rules:
         - https://owasp.org/www-community/attacks/Code_Injection
       technology:
         - ruby
+        - rails

--- a/ruby/lang/security/no-eval.yaml
+++ b/ruby/lang/security/no-eval.yaml
@@ -1,44 +1,37 @@
 rules:
   - id: ruby-eval
     message: >-
-      Use of eval detected. This can lead to attackers running arbitrary code. Ensure external data
+      Use of eval with user-controllable input detected. This can lead to attackers running arbitrary code. Ensure external data
       does not reach here, otherwise this is a security vulnerability.
       Consider other ways to do this without eval.
     languages: [ruby]
     severity: WARNING
-    pattern-either:
+    mode: taint
+    pattern-sources:
+      - pattern-either:
+        - pattern: params[...]
+        - pattern: cookies[...]
+        - patterns:
+          - pattern: |
+              RubyVM::InstructionSequence.compile(...)
+          - pattern-not: |
+              RubyVM::InstructionSequence.compile("...")
+    pattern-sinks:
       - patterns:
         - pattern-either:
-          - pattern: $EVAL(...)
-          - pattern: $BIND.$EVAL(...)
-          - pattern: |
-              $VM.compile(...).$EVAL
-          - patterns:
-              - pattern-inside: |
-                  $IS = $VM.compile(...)
-                  ...
-              - pattern: |
-                  $IS.$EVAL
-        - focus-metavariable: $EVAL
-        - metavariable-pattern:
-            metavariable: $EVAL
-            pattern: eval
-      - patterns:
-          - pattern-either:
-              - pattern: |
-                  $CLASS.$EVAL do
-                    ...
-                  end
-              - pattern: |
-                  $CLASS.$EVAL(...)
-          - focus-metavariable: $EVAL
-          - metavariable-pattern:
-              metavariable: $EVAL
-              patterns:
-                - pattern-either:
-                    - pattern: class_eval
-                    - pattern: instance_eval
-                    - pattern: module_eval
+            - pattern: $X.eval
+            - pattern: $X.class_eval
+            - pattern: $X.instance_eval
+            - pattern: $X.module_eval
+            - pattern: $X.eval(...)
+            - pattern: $X.class_eval(...)
+            - pattern: $X.instance_eval(...)
+            - pattern: $X.module_eval(...)
+            - pattern: eval(...)
+            - pattern: class_eval(...)
+            - pattern: module_eval(...)
+            - pattern: instance_eval(...)
+        - pattern-not: $M("...",...)
     metadata:
       source-rule-url: https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_evaluation.rb
       category: security


### PR DESCRIPTION
Rewrite `ruby-eval` in taint mode.  Changes:

* taint mode
* restrict to Rails sources and dynamic instructions
* fix tests for same - tests were flagging idiomatic Ruby metaprogramming incorrectly