### PR TITLE
Add Spring Actuators check for YAML configuration

### DIFF
--- a/java/spring/security/audit/spring-actuator-fully-enabled-yaml.test.yaml
+++ b/java/spring/security/audit/spring-actuator-fully-enabled-yaml.test.yaml
@@ -1,0 +1,10 @@
+server:
+  port: 8081
+management:
+  endpoints:
+    web:
+      # ok: spring-actuator-fully-enabled-yaml
+      base-path: /internal
+      exposure:
+        # ruleid: spring-actuator-fully-enabled-yaml
+        include: "*"

--- a/java/spring/security/audit/spring-actuator-fully-enabled-yaml.yaml
+++ b/java/spring/security/audit/spring-actuator-fully-enabled-yaml.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: spring-actuator-fully-enabled-yaml
+    patterns: 
+      - pattern-inside: |
+          management:
+            ...
+            endpoints:
+              ...
+              web:
+                ...
+                exposure:
+                  ...
+      - pattern: | 
+          include: "*"
+    message: >-
+      Spring Boot Actuator is fully enabled. This exposes sensitive endpoints such as /actuator/env, /actuator/logfile, /actuator/heapdump and others.
+      Unless you have Spring Security enabled or another means to protect these endpoints, this functionality is available without authentication, causing a severe security risk.
+    severity: WARNING
+    languages: [yaml]
+    paths:
+      include:
+        - "*yaml"
+        - "*yml"
+    metadata:
+      owasp: "A6: Security Misconfiguration"
+      references:
+        - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-exposing-endpoints
+        - https://medium.com/walmartglobaltech/perils-of-spring-boot-actuators-misconfiguration-185c43a0f785
+      category: security
+      technology:
+        - spring


### PR DESCRIPTION
Spring actuators can be configured using both a .properties file and a .yaml file. There is already a check for the .properties files that verifies if actuators are too-widely activated. This PR adds a version of this rule that performs the same check for Spring installations that are configured through a YAML file.