### PR TITLE
Find sensitive Bicep parameters without @secure() attribute

### DIFF
--- a/generic/bicep/security/secure-parameter-for-secrets.bicep
+++ b/generic/bicep/security/secure-parameter-for-secrets.bicep
@@ -1,0 +1,12 @@
+// ok: secure-parameter-for-secrets
+@secure()
+param demoPassword string
+
+// ok: secure-parameter-for-secrets
+param normalParam string
+
+// ruleid: secure-parameter-for-secrets
+param somethingPassword string
+
+// ruleid: secure-parameter-for-secrets
+param somethingSecret string

--- a/generic/bicep/security/secure-parameter-for-secrets.yaml
+++ b/generic/bicep/security/secure-parameter-for-secrets.yaml
@@ -1,0 +1,28 @@
+rules:
+- id: secure-parameter-for-secrets
+  patterns:
+  - pattern: param $NAME string
+  - pattern-not-inside: |
+      @secure()
+      param $NAME string
+  - metavariable-regex:
+      metavariable: $NAME
+      regex: (?i).*(password|secret|token)
+  message: >-
+    Mark sensitive parameters with the @secure() decorator.
+    This avoids logging the value or displaying it in the Azure portal, Azure CLI, or Azure PowerShell.
+  metadata:
+    category: security
+    technology:
+      - bicep
+    cwe: "CWE-532: Insertion of Sensitive Information into Log File"
+    references:
+      - https://cwe.mitre.org/data/definitions/532.html
+      - https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/scenarios-secrets
+    owasp: A09:2021 – Security Logging and Monitoring Failures
+  languages:
+    - generic
+  paths:
+    include:
+      - "*.bicep"
+  severity: WARNING


### PR DESCRIPTION
Determine from the parameter name whether it is sensitive. I left out "key" for now, because that may trigger too many false positives.

Marking a parameter with @secure() prevents logging and displaying in Azure.