### PR TITLE
Rule to detect secrets in build time arguments in Docker

### DIFF
--- a/dockerfile/security/secret-in-build-arg.dockerfile
+++ b/dockerfile/security/secret-in-build-arg.dockerfile
@@ -1,0 +1,36 @@
+# ok: secret-in-build-arg
+ARG BASE_IMG=rust
+# ok: secret-in-build-arg
+ARG BASE_TAG=latest
+
+FROM ${BASE_IMG}:${BASE_TAG}
+
+# ok: secret-in-build-arg
+ARG environment
+
+# ok: secret-in-build-arg
+ARG BUILD_PACKAGES="ruby-dev build-base curl-dev git openssl bash"
+
+# ok: secret-in-build-arg
+ARG DEV_PACKAGES="postgresql-dev"
+
+# ok: secret-in-build-arg
+ARG RUBY_PACKAGES="tzdata"
+
+# ok: secret-in-build-arg
+ARG NAME_IS_OK="secret password token key"
+
+# ruleid: secret-in-build-arg
+ARG SECRET_KEY_BASE
+
+# ruleid: secret-in-build-arg
+ARG SECRET_TOKEN
+
+# ruleid: secret-in-build-arg
+ARG DJANGO_SECRET_KEY
+
+# ruleid: secret-in-build-arg
+ARG NEXUS_PASSWORD
+
+# ruleid: secret-in-build-arg
+ARG nexus_password

--- a/dockerfile/security/secret-in-build-arg.yaml
+++ b/dockerfile/security/secret-in-build-arg.yaml
@@ -1,0 +1,27 @@
+rules:
+- id: secret-in-build-arg
+  patterns:
+  - pattern: ARG $ARG
+  - metavariable-regex:
+      metavariable: $ARG
+      regex: (?i).*(password|secret|token)
+  message: >-
+    Docker build time arguments are not suited for secrets, because the
+    argument values are saved with the image. Running `docker image history` on the
+    image will show information on how the image was built, including arguments. If
+    these contain secrets, anyone with access to the docker image can access those
+    secrets.
+  metadata:
+    category: security
+    technology:
+      - dockerfile
+    cwe: "CWE-538: Insertion of Sensitive Information into Externally-Accessible File or Directory"
+    owasp:
+      - A03:2017 - Sensitive Data Exposure
+      - A01:2021 - Broken Access Control
+    references:
+      - https://cwe.mitre.org/data/definitions/538.html
+      - https://docs.docker.com/engine/reference/builder/#arg
+  languages:
+    - dockerfile
+  severity: WARNING


### PR DESCRIPTION
It is not recommended to use build-time variables for passing secrets like github keys, user credentials etc. Build-time variable values are visible to any user of the image with the docker history command.