### PR TITLE
Catch up with latest semgrep (or vice-versa)

### DIFF
--- a/csharp/dotnet/security/audit/open-directory-listing.cs
+++ b/csharp/dotnet/security/audit/open-directory-listing.cs
@@ -2,18 +2,18 @@
 public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     var builder = WebApplication.CreateBuilder(args);
-    // ruleid : open-directory-listing
+    // ruleid: open-directory-listing
     builder.Services.AddDirectoryBrowser();
 
     var fileProvider = new PhysicalFileProvider(Path.Combine(builder.Environment.WebRootPath, "data"));
     var requestPath = "/data";
 
-    // ruleid : open-directory-listing
+    // ruleid: open-directory-listing
     app.UseDirectoryBrowser(new DirectoryBrowserOptions
     {
         FileProvider = fileProvider,
         RequestPath = requestPath
-    });    
+    });
 }
 
 
@@ -24,5 +24,5 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     builder.Services.AddRazorPages();
 
     // ok : open-directory-listing
-    app.UseHttpsRedirection();  
+    app.UseHttpsRedirection();
 }

--- a/csharp/lang/security/cryptography/unsigned-security-token.cs
+++ b/csharp/lang/security/cryptography/unsigned-security-token.cs
@@ -1,6 +1,6 @@
 services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
             {
-​
+
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     // ruleid: unsigned-security-token

--- a/csharp/lang/security/cryptography/unsigned-security-token.cs
+++ b/csharp/lang/security/cryptography/unsigned-security-token.cs
@@ -9,10 +9,9 @@ services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(
                     ValidateAudience = false
                 };
             });
-​
+
 services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
             {
-​
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     // ok: unsigned-security-token

--- a/csharp/lang/security/open-redirect.cs
+++ b/csharp/lang/security/open-redirect.cs
@@ -24,7 +24,7 @@ public ActionResult LogOn(LogOnModel model, string returnUrl)
     }
 }
 
-​
+
 [HttpPost]
 public ActionResult LogOn(LogOnModel model, string returnUrl)
 {

--- a/csharp/lang/security/open-redirect.cs
+++ b/csharp/lang/security/open-redirect.cs
@@ -50,7 +50,7 @@ public ActionResult LogOn(LogOnModel model, string returnUrl)
         }
     }
 }
-​
+
 [HttpPost]
 public ActionResult LogOn(LogOnModel model, string returnUrl)
 {

--- a/csharp/lang/security/stacktrace-disclosure.cs
+++ b/csharp/lang/security/stacktrace-disclosure.cs
@@ -1,27 +1,26 @@
-public void Configure(IApplicationBuilder app, IWebHostEnvironment env)  
-{  
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
         if (!env.IsDevelopment())
-        {  
+        {
             // ruleid: stacktrace-disclosure
-            app.UseDeveloperExceptionPage();  
-        }  
-    else  
-        {  
-            app.UseExceptionHandler("/Error");  
-        }  
-​
+            app.UseDeveloperExceptionPage();
+        }
+    else
+        {
+            app.UseExceptionHandler("/Error");
+        }
+
 }
-​
-public void Configure(IApplicationBuilder app, IWebHostEnvironment env)  
-{  
-        if (env.IsDevelopment())  
-        {  
-            // ok: stacktrace-disclosure                
-            app.UseDeveloperExceptionPage();  
-        }  
-    else  
-        {  
-            app.UseExceptionHandler("/Error");  
-        }  
-​
+
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+        if (env.IsDevelopment())
+        {
+            // ok: stacktrace-disclosure
+            app.UseDeveloperExceptionPage();
+        }
+    else
+        {
+            app.UseExceptionHandler("/Error");
+        }
 }

--- a/javascript/lang/security/audit/sqli/node-postgres-sqli.js
+++ b/javascript/lang/security/audit/sqli/node-postgres-sqli.js
@@ -27,7 +27,7 @@ function bad3(userinput) {
     await client.connect()
     let query = "SELECT name FROM users WHERE age=".concat(userinput)
     // passes on 0.111.0 and higher
-    // todoruleid: node-postgres-sqli
+    // ruleid: node-postgres-sqli
     const res = await client.query(query)
     console.log(res.rows[0].message) // Hello world!
     await client.end()
@@ -43,7 +43,7 @@ function bad4(req) {
     pool.connect((err, client, done) => {
       if (err) throw err
       // passes on 0.111.0 and higher
-      // todoruleid: node-postgres-sqli
+      // ruleid: node-postgres-sqli
       client.query("SELECT name FROM users WHERE age=" + req.FormValue("age"), (err, res) => {
         done()
         if (err) {

--- a/python/lang/security/audit/dangerous-subprocess-use.py
+++ b/python/lang/security/audit/dangerous-subprocess-use.py
@@ -1,0 +1,3 @@
+# The rule is deprecated.
+# This file exists only to satisfy test suites that expect one test target
+# per rule.

--- a/ruby/rails/security/audit/sqli/ruby-pg-sqli.rb
+++ b/ruby/rails/security/audit/sqli/ruby-pg-sqli.rb
@@ -29,7 +29,7 @@ def bad4(userinput)
     query = "SELECT name FROM users WHERE age="
     query << params[userinput]
     # passes on 0.111.0 and higher
-    # todoruleid: ruby-pg-sqli
+    # ruleid: ruby-pg-sqli
     con.exec(query)
 end
 

--- a/typescript/react/security/audit/react-styled-components-injection.jsx
+++ b/typescript/react/security/audit/react-styled-components-injection.jsx
@@ -24,10 +24,12 @@ function Vulnerable2(userInput) {
 function Vulnerable3(nevermind, {userInput}) {
   const input = '#' + userInput;
 
-  return styled.div`background: ${
+  return styled.div`
+    background: ${
       // ok: react-styled-components-injection
       input
     };
+  `
 }
 
 function OkTest({siteUrl, input}) {

--- a/typescript/react/security/audit/react-styled-components-injection.tsx
+++ b/typescript/react/security/audit/react-styled-components-injection.tsx
@@ -24,10 +24,12 @@ function Vulnerable2(userInput) {
 function Vulnerable3(nevermind, {userInput}) {
   const input = '#' + userInput;
 
-  return styled.div`background: ${
+  return styled.div`
+    background: ${
       // ok: react-styled-components-injection
       input
     };
+  `
 }
 
 function OkTest({siteUrl, input}) {


### PR DESCRIPTION
The semgrep repo now points to a specific commit of semgrep-rules (via a git submodule) which doesn't get updated automatically. Today, we had a problem caused by a new behavior in semgrep which would have been fixed by using a more recent version of semgrep-rules. So, we upgraded semgrep-rules. This gave us 8 new errors of various nature that this PR fixes. The tests now pass when using the latest version of semgrep.

Here's a description of the different issues and possible long-term improvements:
* semgrep-core recognizes `ruleid:` but not `ruleid :`. We should agree on whether a space is allowed and use the same spec everywhere.
* there were stray zero-width spaces (normally used to define breaking points within words) in C# targets.They result in partial parsing of the target files, which in this case is totally fine since these characters end up being treated like other ignorable whitespace. It would be good to treat these errors as test failures so as to get the same behavior as semgrep-core tests.
* similarly, there was an unclosed string literal in a typescript target which results in partial parsing of the target.
* one deprecated python rule file didn't have a matching target, which was a problem for semgrep-core. We can fix this in semgrep-core if necessary in the future or if having an empty python target is not desirable.
* two different rules had new matches in places that were marked as "to do", so I removed the `todo` prefix. This was nice.

The CI failure for this PR is:
```
The following test(s) failed with Semgrep v0.108.0 are caused by this PR:
javascript/lang/security/audit/sqli/node-postgres-sqli.js
ruby/rails/security/audit/sqli/ruby-pg-sqli.rb
```
... which correspond to the to-dos that are now implemented. :tada: 

The semgrep repo is now depending on this branch. To avoid surprises with git/github, it's best to either merge it with a merge commit (easier) OR squash and update the submodule accordingly in the semgrep repo.
