### PR TITLE
Misc fixes to make tests pass in semgrep repo

### DIFF
--- a/csharp/dotnet/security/audit/open-directory-listing.cs
+++ b/csharp/dotnet/security/audit/open-directory-listing.cs
@@ -2,13 +2,13 @@
 public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     var builder = WebApplication.CreateBuilder(args);
-    // ruleid : open-directory-listing
+    // ruleid: open-directory-listing
     builder.Services.AddDirectoryBrowser();
 
     var fileProvider = new PhysicalFileProvider(Path.Combine(builder.Environment.WebRootPath, "data"));
     var requestPath = "/data";
 
-    // ruleid : open-directory-listing
+    // ruleid: open-directory-listing
     app.UseDirectoryBrowser(new DirectoryBrowserOptions
     {
         FileProvider = fileProvider,

--- a/csharp/lang/security/cryptography/unsigned-security-token.cs
+++ b/csharp/lang/security/cryptography/unsigned-security-token.cs
@@ -1,6 +1,5 @@
 services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
             {
-​
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     // ruleid: unsigned-security-token
@@ -9,10 +8,8 @@ services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(
                     ValidateAudience = false
                 };
             });
-​
 services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(options =>
             {
-​
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     // ok: unsigned-security-token

--- a/csharp/lang/security/open-redirect.cs
+++ b/csharp/lang/security/open-redirect.cs
@@ -24,7 +24,6 @@ public ActionResult LogOn(LogOnModel model, string returnUrl)
     }
 }
 
-​
 [HttpPost]
 public ActionResult LogOn(LogOnModel model, string returnUrl)
 {
@@ -50,7 +49,7 @@ public ActionResult LogOn(LogOnModel model, string returnUrl)
         }
     }
 }
-​
+
 [HttpPost]
 public ActionResult LogOn(LogOnModel model, string returnUrl)
 {

--- a/csharp/lang/security/stacktrace-disclosure.cs
+++ b/csharp/lang/security/stacktrace-disclosure.cs
@@ -9,9 +9,8 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {  
             app.UseExceptionHandler("/Error");  
         }  
-​
 }
-​
+
 public void Configure(IApplicationBuilder app, IWebHostEnvironment env)  
 {  
         if (env.IsDevelopment())  
@@ -23,5 +22,4 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {  
             app.UseExceptionHandler("/Error");  
         }  
-​
 }

--- a/javascript/lang/security/audit/sqli/node-postgres-sqli.js
+++ b/javascript/lang/security/audit/sqli/node-postgres-sqli.js
@@ -26,8 +26,7 @@ function bad3(userinput) {
     const client = new Client()
     await client.connect()
     let query = "SELECT name FROM users WHERE age=".concat(userinput)
-    // passes on 0.111.0 and higher
-    // todoruleid: node-postgres-sqli
+    // ruleid: node-postgres-sqli
     const res = await client.query(query)
     console.log(res.rows[0].message) // Hello world!
     await client.end()
@@ -42,8 +41,7 @@ function bad4(req) {
     })
     pool.connect((err, client, done) => {
       if (err) throw err
-      // passes on 0.111.0 and higher
-      // todoruleid: node-postgres-sqli
+      // ruleid: node-postgres-sqli
       client.query("SELECT name FROM users WHERE age=" + req.FormValue("age"), (err, res) => {
         done()
         if (err) {

--- a/ruby/rails/security/audit/sqli/ruby-pg-sqli.rb
+++ b/ruby/rails/security/audit/sqli/ruby-pg-sqli.rb
@@ -28,8 +28,7 @@ def bad4(userinput)
     con = PG.connect :dbname => 'testdb', :user => 'janbodnar'
     query = "SELECT name FROM users WHERE age="
     query << params[userinput]
-    # passes on 0.111.0 and higher
-    # todoruleid: ruby-pg-sqli
+    # ruleid: ruby-pg-sqli
     con.exec(query)
 end
 

--- a/typescript/react/security/audit/react-styled-components-injection.jsx
+++ b/typescript/react/security/audit/react-styled-components-injection.jsx
@@ -27,7 +27,7 @@ function Vulnerable3(nevermind, {userInput}) {
   return styled.div`background: ${
       // ok: react-styled-components-injection
       input
-    };
+    }`;
 }
 
 function OkTest({siteUrl, input}) {

--- a/typescript/react/security/audit/react-styled-components-injection.tsx
+++ b/typescript/react/security/audit/react-styled-components-injection.tsx
@@ -27,7 +27,7 @@ function Vulnerable3(nevermind, {userInput}) {
   return styled.div`background: ${
       // ok: react-styled-components-injection
       input
-    };
+    }`;
 }
 
 function OkTest({siteUrl, input}) {


### PR DESCRIPTION
I'm updating the semgrep-rules submodule in semgrep, which we use for
testing purposes. I think there must be some differences in behavior
between the test runner that we use in the semgrep repo and the test
runner used here.

Most of these are parse errors. The tree-sitter error recovery appears
to do a pretty good job in the face of these issues, so they don't
prevent Semgrep from running. In particular, there were several files
that had the U+200B (zero width space) character, which led to parse
errors.

A few places used `todoruleid:`. The necessary Semgrep version has been
released so I just changed them to `ruleid:`. One file used `ruleid :`
with a space before the colon. I removed the space.