### PR TITLE
Fix syntax error in httpservlet-path-traversal.java

### DIFF
--- a/java/lang/security/httpservlet-path-traversal.java
+++ b/java/lang/security/httpservlet-path-traversal.java
@@ -117,3 +117,5 @@ public class BenchmarkTest00045 extends HttpServlet {
         } catch (Exception e) {
             System.out.println("Couldn't open FileOutputStream on file: '" + fileName + "'");
         }
+    }
+}


### PR DESCRIPTION
The last two curly braces are missing. I'm not sure why Semgrep
currently parses this without errors, but the changes I'm making in
https://github.com/returntocorp/ocaml-tree-sitter-semgrep/pull/339 lead
to a parse error here. I'm not sure why, but since this is clearly
malformed code, I don't intend to spend time figuring it out.