### PR TITLE
add github-script-injection rule

### DIFF
--- a/yaml/github-actions/security/github-script-injection.test.yaml
+++ b/yaml/github-actions/security/github-script-injection.test.yaml
@@ -1,0 +1,69 @@
+name: test-script-run
+
+on:
+- push
+
+jobs:
+  script-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run script 1
+        uses: actions/github-script@v6
+        if: steps.report-diff.outputs.passed == 'true'
+        with:
+          # ruleid: github-script-injection
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/file.txt', {encoding: 'utf8'});
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '${{ github.event.pull_request.title }}' + body
+            })
+
+            return true;
+
+      - name: Run script 2
+        uses: actions/github-script@latest
+        with:
+          # ruleid: github-script-injection
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('/tmp/${{ github.event.issue.title }}.txt', {encoding: 'utf8'});
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Thanks for reporting!'
+            })
+
+            return true;
+
+      - name: Ok script 1
+        uses: not-github/custom-action@latest
+        with:
+          # ok: github-script-injection
+          script: |
+            return ${{ github.event.issue.title }};
+
+      - name: Ok script 2
+        uses: actions/github-script@latest
+        with:
+          # ok: github-script-injection
+          script: |
+            console.log('${{ github.event.workflow_run.artifacts_url }}');
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Thanks for reporting!'
+            })
+
+            return true;

--- a/yaml/github-actions/security/github-script-injection.yaml
+++ b/yaml/github-actions/security/github-script-injection.yaml
@@ -11,7 +11,9 @@ rules:
   metadata:
     category: security
     cwe: "CWE-94: Improper Control of Generation of Code ('Code Injection')"
-    owasp: "A1: Injection"
+    owasp:
+      - "A03:2021 - Injection"
+      - "A01:2017 - Injection"
     references:
       - https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
       - https://securitylab.github.com/research/github-actions-untrusted-input/

--- a/yaml/github-actions/security/github-script-injection.yaml
+++ b/yaml/github-actions/security/github-script-injection.yaml
@@ -1,0 +1,58 @@
+rules:
+- id: github-script-injection
+  languages:
+    - yaml
+  message: >-
+    Using variable interpolation `${{...}}` with `github` context data in a `actions/github-script`'s `script:` step could allow an attacker to
+    inject their own code into the runner. This would allow them to steal secrets and code. `github` context data can have
+    arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with `env:`
+    to store the data and use the environment variable in the `run:` script. Be sure to use double-quotes the environment
+    variable, like this: "$ENVVAR".
+  metadata:
+    category: security
+    cwe: "CWE-94: Improper Control of Generation of Code ('Code Injection')"
+    owasp: "A1: Injection"
+    references:
+      - https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
+      - https://securitylab.github.com/research/github-actions-untrusted-input/
+      - https://github.com/actions/github-script
+    technology:
+      - github-actions
+  patterns:
+    - pattern-inside: "steps: [...]"
+    - pattern-inside: |
+        uses: $ACTION
+        ...
+    - pattern-inside: |
+        with:
+          ...
+          script: ...
+          ...
+    - pattern: "script: $SHELL"
+    - metavariable-regex:
+        metavariable: $ACTION
+        regex: actions/github-script@.*
+    - metavariable-pattern:
+        language: generic
+        metavariable: $SHELL
+        patterns:
+        - pattern-either:
+          - pattern: ${{ github.event.issue.title }}
+          - pattern: ${{ github.event.issue.body }}
+          - pattern: ${{ github.event.pull_request.title }}
+          - pattern: ${{ github.event.pull_request.body }}
+          - pattern: ${{ github.event.comment.body }}
+          - pattern: ${{ github.event.review.body }}
+          - pattern: ${{ github.event.review_comment.body }}
+          - pattern: ${{ github.event.pages. ... .page_name}}
+          - pattern: ${{ github.event.head_commit.message }}
+          - pattern: ${{ github.event.head_commit.author.email }}
+          - pattern: ${{ github.event.head_commit.author.name }}
+          - pattern: ${{ github.event.commits ... .author.email }}
+          - pattern: ${{ github.event.commits ... .author.name }}
+          - pattern: ${{ github.event.pull_request.head.ref }}
+          - pattern: ${{ github.event.pull_request.head.label }}
+          - pattern: ${{ github.event.pull_request.head.repo.default_branch }}
+          - pattern: ${{ github.head_ref }}
+          - pattern: ${{ github.event.inputs ... }}
+  severity: ERROR


### PR DESCRIPTION
The rule is similar to: https://github.com/returntocorp/semgrep-rules/blob/develop/yaml/github-actions/security/run-shell-injection.yaml but targets popular [`actions/github-script`](https://github.com/actions/github-script) action