### PR TITLE
deprecate detect-non-literal-require and add audit version

### DIFF
--- a/javascript/lang/security/audit/detect-non-literal-require.js
+++ b/javascript/lang/security/audit/detect-non-literal-require.js
@@ -1,0 +1,39 @@
+function dynamicRequire1(packageName) {
+    // ruleid: detect-non-literal-require
+    var a = require(packageName)
+    return a;
+}
+
+function dynamicRequire2(source, file) {
+    // ruleid: detect-non-literal-require
+    require(path.resolve(process.cwd(), file, source));
+}
+
+function okDynamicRequire1() {
+    var lib = path.join(path.dirname(fs.realpathSync(__filename)), "index.js");
+    // ok: detect-non-literal-require
+    require(lib).run(process.argv.slice(2)); 
+}
+
+function okDynamicRequire2(userInput) {
+    var name = process.env.NAME
+    var path = name + '/smth/path';
+    var mod = path + '/module.js';
+    // ok: detect-non-literal-require
+    require(mk).main(top, userInput);
+}
+
+function okDynamicRequire3(userInput) {
+    var lib  = path.join(path.dirname(fs.realpathSync(__filename)), 'lib');
+    // ok: detect-non-literal-require
+    require(lib + '/foobar').run(userInput);
+}
+
+function okDynamicRequire4(userInput) {
+    // ok:detect-non-literal-require
+    var a = require('b')
+}
+function okDynamicRequire5(userInput) {
+    // ok:detect-non-literal-require
+    var a = require(process.env.VAR)
+}

--- a/javascript/lang/security/audit/detect-non-literal-require.yaml
+++ b/javascript/lang/security/audit/detect-non-literal-require.yaml
@@ -1,0 +1,26 @@
+rules:
+- id: detect-non-literal-require
+  mode: taint
+  metadata:
+    cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')"
+    owasp: "A01:2017 - Injection"
+    source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-non-literal-require.js
+    references:
+    - https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-non-literal-require.js
+    category: security
+    technology:
+      - javascript
+  message: >-
+    Detected the use of require(variable). Calling require with a non-literal
+    argument might allow an attacker to load and run arbitrary code, or
+    access arbitrary files.
+  pattern-sources:
+  - patterns:
+      - pattern-inside: function ... (..., $ARG,...) {...}
+      - focus-metavariable: $ARG
+  pattern-sinks:
+    - pattern: require(...)
+  severity: WARNING
+  languages:
+    - javascript
+    - typescript

--- a/javascript/lang/security/detect-non-literal-require.js
+++ b/javascript/lang/security/detect-non-literal-require.js
@@ -1,8 +1,8 @@
-// ok:detect-non-literal-require
+// detect-non-literal-require
 var a = require('b')
 
-// ok:detect-non-literal-require
+// detect-non-literal-require
 var a = require(process.env.VAR)
 
-// ruleid:detect-non-literal-require
+// detect-non-literal-require
 var a = require(c)

--- a/javascript/lang/security/detect-non-literal-require.yaml
+++ b/javascript/lang/security/detect-non-literal-require.yaml
@@ -10,13 +10,10 @@ rules:
       technology:
         - javascript
     message: >-
-      Detected the use of require(variable). Calling require with a non-literal
-      argument might allow an attacker to load and run arbitrary code, or
-      access arbitrary files.
+      This rule is deprecated.
     patterns:
-      - pattern: require($OBJ)
-      - pattern-not: require(process.env.$ENVVAR)
-      - pattern-not: require('...')
+    - pattern: a()
+    - pattern: b()
     severity: WARNING
     languages:
       - javascript


### PR DESCRIPTION
due to VERY low fix rate, I propose to deprecate the `detect-non-literal-require` rule and create an `audit` version of it