### PR TITLE
Add rule to find classic crypto mode of operations without MAC

### DIFF
--- a/python/cryptography/security/mode-without-authentication.py
+++ b/python/cryptography/security/mode-without-authentication.py
@@ -1,0 +1,29 @@
+import os
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives import hashes, hmac
+
+
+def example1():
+  # Hazmat CBC without mac
+
+  key = os.urandom(32)
+  iv = os.urandom(16)
+  # ruleid: crypto-mode-without-authentication
+  cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+  encryptor = cipher.encryptor()
+  ct = encryptor.update(b"a secret message") + encryptor.finalize()
+
+
+def example2():
+  # Hazmat CBC with mac
+
+  key = os.urandom(32)
+  iv = os.urandom(16)
+  # ok: crypto-mode-without-authentication
+  cipher = Cipher(algorithms.AES(key), modes.CBC(iv))
+  encryptor = cipher.encryptor()
+  ct = encryptor.update(b"a secret message") + encryptor.finalize()
+
+  h = hmac.HMAC(os.urandom(32), hashes.SHA256())
+  h.update(ct)
+  hmac = h.finalize()

--- a/python/cryptography/security/mode-without-authentication.yaml
+++ b/python/cryptography/security/mode-without-authentication.yaml
@@ -1,0 +1,38 @@
+rules:
+  - id: crypto-mode-without-authentication
+    message: >- 
+        An encryption mode of operation is being used without proper message authentication. 
+        This can potentially result in the encrypted content to be decrypted by an attacker. 
+        Consider instead use an AEAD mode of operation like GCM. 
+    languages: 
+        - python
+    severity: ERROR
+    metadata:
+        category: security
+        technology:
+            - cryptography
+        cwe:  CWE-327
+        owasp: "A02:2021 - Cryptographic Failures"
+    patterns: 
+        - pattern-either: 
+            - patterns: 
+                - pattern: |
+                    Cipher(..., $HAZMAT_MODE(...),...)
+                - pattern-not-inside: | 
+                    Cipher(..., $HAZMAT_MODE(...),...)
+                    ...
+                    HMAC(...)
+                - pattern-not-inside: | 
+                    Cipher(..., $HAZMAT_MODE(...),...)
+                    ...
+                    hmac.HMAC(...)
+                
+        - metavariable-pattern:
+            metavariable: $HAZMAT_MODE
+            patterns:
+                - pattern-either:
+                    - pattern: modes.CTR
+                    - pattern: modes.CBC
+                    - pattern: modes.CFB
+                    - pattern: modes.OFB
+

--- a/python/pycryptodome/security/mode-without-authentication.py
+++ b/python/pycryptodome/security/mode-without-authentication.py
@@ -1,0 +1,29 @@
+from Crypto.Random import get_random_bytes
+from Crypto.Cipher import AES
+from Crypto.Util.Padding import pad
+from base64 import b64encode
+from Crypto.Hash import HMAC, SHA256
+
+
+def example1():
+  # AES CBC, no mac
+  sensitive_data = b"ALIENS DO EXIST!!!!"
+  key = get_random_bytes(16)
+  # ruleid: crypto-mode-without-authentication
+  cipher = AES.new(key, AES.MODE_CBC)
+  ciphertext = cipher.encrypt(pad(sensitive_data, AES.block_size))
+
+
+def example2():
+  # AES CBC with HMAC
+
+  key = get_random_bytes(16)
+  # ok: crypto-mode-without-authentication
+  cipher = AES.new(key, AES.MODE_CBC)
+  iv = b64encode(cipher.iv).decode('utf-8')
+  sensitive_data = b"ALIENS DO EXIST!!!!"
+  encrypted_bytes = cipher.encrypt(pad("data_to_encrypt", AES.block_size))
+
+  hmac = HMAC.new(get_random_bytes(16), digestmod=SHA256)
+  hmac.update(encrypted_bytes)
+  mac_bytes = hmac.digest()

--- a/python/pycryptodome/security/mode-without-authentication.yaml
+++ b/python/pycryptodome/security/mode-without-authentication.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: crypto-mode-without-authentication
+    message: >- 
+      An encryption mode of operation is being used without proper message authentication. 
+      This can potentially result in the encrypted content to be decrypted by an attacker. 
+      Consider instead use an AEAD mode of operation like GCM. 
+    languages: 
+      - python
+    severity: ERROR
+    metadata:
+      category: security
+      technology:
+        - cryptography
+      cwe:  CWE-327
+      owasp: "A02:2021 - Cryptographic Failures"
+    patterns:
+      - pattern-either:
+        - patterns:
+          - pattern-either:   
+            - pattern: |
+                AES.new(..., $PYCRYPTODOME_MODE)
+          - pattern-not-inside: | 
+              AES.new(..., $PYCRYPTODOME_MODE)
+              ...
+              HMAC.new
+          - metavariable-pattern:
+              metavariable: $PYCRYPTODOME_MODE
+              patterns:
+                - pattern-either:
+                  - pattern: AES.MODE_CBC
+                  - pattern: AES.MODE_CTR
+                  - pattern: AES.MODE_CFB
+                  - pattern: AES.MODE_OFB


### PR DESCRIPTION
Rules to find modes of operation (CTR, CBC, CFB, OFB) without MAC (in this case HMAC only) which makes them somewhat insecure. 

I created two rules, one for pycryptodome(x) and another for cryptography package

 