### PR TITLE
Rearrange tests for completeness and for sharing with semgrep repo's CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,18 +17,27 @@ SEMGREP ?= semgrep
 #
 # The semgrep repo also runs this as part of its CI.
 #
+.PHONY: test
 test:
+	$(MAKE) validate
+	$(MAKE) test-only
+
+.PHONY: validate
+validate:
 	for root in $(RULE_FOLDERS); do \
 	  echo "======== validate rule files in $$root ========"; \
 	  time -p $(SEMGREP) --validate \
 	    --strict --disable-version-check \
 	    --metrics=off --verbose \
 	    --config="$$root"; \
-	done
+	done 2>&1
+
+.PHONY: test-only
+test-only:
 	for root in $(RULE_FOLDERS); do \
 	  echo "========= test rules in $$root ========="; \
 	  time -p $(SEMGREP) --test --test-ignore-todo \
 	    --strict --disable-version-check \
 	    --metrics=off --verbose \
 	    "$$root"; \
-	done
+	done 2>&1

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ validate:
 	  time -p $(SEMGREP) --validate \
 	    --strict --disable-version-check \
 	    --metrics=off --verbose \
-	    --config="$$root"; \
+	    --config="./$$root"; \
 	done >&2
 
 .PHONY: test-only
@@ -46,5 +46,5 @@ test-only:
 	  time -p $(SEMGREP) --test --test-ignore-todo \
 	    --strict --disable-version-check \
 	    --metrics=off --verbose \
-	    "$$root"; \
+	    "./$$root"; \
 	done >&2

--- a/Makefile
+++ b/Makefile
@@ -22,22 +22,29 @@ test:
 	$(MAKE) validate
 	$(MAKE) test-only
 
+# stdout is redirected to stderr so as to see the whole output in the correct
+# order when running this from pytest.
+# (pytest captures stdout and stderr separately and prints them later,
+# if at all).
+#
 .PHONY: validate
 validate:
+	set -eu; \
 	for root in $(RULE_FOLDERS); do \
 	  echo "======== validate rule files in $$root ========"; \
 	  time -p $(SEMGREP) --validate \
 	    --strict --disable-version-check \
 	    --metrics=off --verbose \
 	    --config="$$root"; \
-	done 2>&1
+	done >&2
 
 .PHONY: test-only
 test-only:
+	set -eu; \
 	for root in $(RULE_FOLDERS); do \
 	  echo "========= test rules in $$root ========="; \
 	  time -p $(SEMGREP) --test --test-ignore-todo \
 	    --strict --disable-version-check \
 	    --metrics=off --verbose \
 	    "$$root"; \
-	done 2>&1
+	done >&2

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 # may contain .yml files that are not Semgrep rules and would result
 # in errors.
 #
-RULE_FOLDERS = $(shell ls -d */ | grep -v '^stats')
+RULE_FOLDERS = $(shell ls -d */ \
+                | grep -v '^\(stats\|trusted_python\|fingerprints\)/\?$')
 
 # This is for running using a dev version of semgrep such as:
 #

--- a/javascript/angular/security/detect-angular-element-methods.js
+++ b/javascript/angular/security/detect-angular-element-methods.js
@@ -4,8 +4,12 @@ app.controller('myCtrl', function($scope,$sanitize) {
     $scope.foo = getData();
     // ok: detect-angular-element-methods
     angular.element('div').html('hi')
-    // ruleid: detect-angular-element-methods
+    // ok: detect-angular-element-methods
     angular.element('div').html($rootScope.foo)
-    // ruleid: detect-angular-element-methods
+    // ok: detect-angular-element-methods
     angular.element('div').html($scope.foo)
+    // ruleid: detect-angular-element-methods
+    angular.element('div').html($rootScope)
+    // ruleid: detect-angular-element-methods
+    angular.element('div').html($scope)
 });


### PR DESCRIPTION
There were 2 issues:
* `semgrep --test` was not strict enough, ignoring parse errors in target code
* `make test` wasn't testing all the rules and targets

Relevant issues:
https://github.com/returntocorp/semgrep/issues/6068
https://github.com/returntocorp/semgrep/issues/6069

After this, `make test` will take longer. If a quick version of `make test` that only tests a few rules is desired, let me know. The semgrep repo will start relying on this `make test` to validate and test all the rules in semgrep-rules.
