### PR TITLE
Improve $RECORD matching for check-regex-dos

### DIFF
--- a/ruby/rails/security/brakeman/check-regex-dos.rb
+++ b/ruby/rails/security/brakeman/check-regex-dos.rb
@@ -14,6 +14,10 @@ def some_rails_controller
   foo = Record.read_attribute("some_attribute")
   #ruleid: check-regex-dos
   Regexp.new(foo).match("some_string")
+
+  bar = ENV['someEnvVar']
+  #ok: check-regex-dos
+  Regexp.new(bar).match("some_string")
 end
 
 def use_params_in_regex

--- a/ruby/rails/security/brakeman/check-regex-dos.yaml
+++ b/ruby/rails/security/brakeman/check-regex-dos.yaml
@@ -25,7 +25,7 @@ rules:
                 $RECORD[$Y]
           - metavariable-regex:
               metavariable: $RECORD
-              regex: '[A-Z]\w+'
+              regex: '[A-Z][a-z]+'
   pattern-sinks:
   - patterns:
     - pattern-either:


### PR DESCRIPTION
The old rule was matching on `\w+` which matches things like `ENV[...]`. Idomatic ActiveRecord classes will be PascalCase.

see https://linear.app/r2c/issue/RULES-1495/policygenius-feedback-on-rubyrailssecuritybrakemancheck-regex-doscheck