### PR TITLE
fix test for detect-replaceall-sanitization

### DIFF
--- a/javascript/audit/detect-replaceall-sanitization.ts
+++ b/javascript/audit/detect-replaceall-sanitization.ts
@@ -1,4 +1,4 @@
-encodeProductDescription (tableData: any[]) {
+function encodeProductDescription (tableData: any[]) {
   for (let i = 0; i < tableData.length; i++) {
     // ruleid: detect-replaceall-sanitization
     tableData[i].description = tableData[i].description.replaceAll('<', '&lt;').replaceAll('>', '&gt;')


### PR DESCRIPTION
Suspect fixes to parser introduced by https://github.com/returntocorp/semgrep/blob/develop/CHANGELOG.md#01120---2022-09-07 caused the (malformed) test case to start failing parsing checks explicitly.