### PR TITLE
Add Spring Actuator rules for non-wildcard actuator activations

### DIFF
--- a/java/spring/security/audit/spring-actuator-fully-enabled-yaml.yaml
+++ b/java/spring/security/audit/spring-actuator-fully-enabled-yaml.yaml
@@ -17,15 +17,12 @@ rules:
       Unless you have Spring Security enabled or another means to protect these endpoints, this functionality is available without authentication, causing a severe security risk.
     severity: WARNING
     languages: [yaml]
-    paths:
-      include:
-        - "*yaml"
-        - "*yml"
     metadata:
       owasp: "A6: Security Misconfiguration"
       references:
         - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-exposing-endpoints
         - https://medium.com/walmartglobaltech/perils-of-spring-boot-actuators-misconfiguration-185c43a0f785
+        - https://blog.maass.xyz/spring-actuator-security-part-1-stealing-secrets-using-spring-actuators
       category: security
       technology:
         - spring

--- a/java/spring/security/audit/spring-actuator-fully-enabled.yaml
+++ b/java/spring/security/audit/spring-actuator-fully-enabled.yaml
@@ -14,6 +14,7 @@ rules:
       references:
         - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-exposing-endpoints
         - https://medium.com/walmartglobaltech/perils-of-spring-boot-actuators-misconfiguration-185c43a0f785
+        - https://blog.maass.xyz/spring-actuator-security-part-1-stealing-secrets-using-spring-actuators
       category: security
       technology:
         - spring

--- a/java/spring/security/audit/spring-actuator-non-health-enabled-yaml.test.yaml
+++ b/java/spring/security/audit/spring-actuator-non-health-enabled-yaml.test.yaml
@@ -1,0 +1,13 @@
+server:
+  port: 8081
+management:
+  endpoints:
+    web:
+      # ok: spring-actuator-dangerous-endpoints-enabled-yaml
+      base-path: /internal
+      exposure:
+        # ruleid: spring-actuator-dangerous-endpoints-enabled-yaml
+        include:
+          - "health"  # Should be OK (but will still be shown in the output)
+          - "prometheus"  # Should match
+          - "logfile"  # Should match

--- a/java/spring/security/audit/spring-actuator-non-health-enabled-yaml.yaml
+++ b/java/spring/security/audit/spring-actuator-non-health-enabled-yaml.yaml
@@ -1,0 +1,35 @@
+rules:
+  - id: spring-actuator-dangerous-endpoints-enabled-yaml
+    patterns:
+      - pattern-inside: |
+          management:
+            ...
+            endpoints:
+              ...
+              web:
+                ...
+                exposure:
+                  ...
+                  include:
+                    ...
+      - pattern: |
+          include: [..., $ACTUATOR, ...]
+      - metavariable-comparison:
+          metavariable: $ACTUATOR
+          # We accept the health actuator, as it is usually harmless (and exposed by default either way)
+          # We ignore the wildcard (*), as it is handled in another rule
+          comparison: not str($ACTUATOR) in ["health","*"]
+    message: Spring Boot Actuator "$ACTUATOR" is enabled. Depending on the actuator, this can pose a significant security risk. 
+      Please double-check if the actuator is needed and properly secured.
+    severity: WARNING
+    languages:
+      - yaml
+    metadata:
+      owasp: "A6: Security Misconfiguration"
+      references:
+        - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-exposing-endpoints
+        - https://medium.com/walmartglobaltech/perils-of-spring-boot-actuators-misconfiguration-185c43a0f785
+        - https://blog.maass.xyz/spring-actuator-security-part-1-stealing-secrets-using-spring-actuators
+      category: security
+      technology:
+        - spring

--- a/java/spring/security/audit/spring-actuator-non-health-enabled.properties
+++ b/java/spring/security/audit/spring-actuator-non-health-enabled.properties
@@ -1,0 +1,8 @@
+# ok: spring-actuator-dangerous-endpoints-enabled
+foo=bar
+# ruleid: spring-actuator-dangerous-endpoints-enabled
+management.endpoints.web.exposure.include=health,prometheus,logfile,env
+# ok: spring-actuator-dangerous-endpoints-enabled
+management.endpoints.web.exposure.include=health
+# ok: spring-actuator-dangerous-endpoints-enabled
+management.endpoints.web.exposure.include=*

--- a/java/spring/security/audit/spring-actuator-non-health-enabled.yaml
+++ b/java/spring/security/audit/spring-actuator-non-health-enabled.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: spring-actuator-dangerous-endpoints-enabled
+    patterns:
+      - pattern: management.endpoints.web.exposure.include=$...ACTUATORS
+      - metavariable-comparison:
+          metavariable: $...ACTUATORS
+          # We accept the health actuator, as it is usually harmless (and exposed by default either way)
+          # We ignore the wildcard (*), as it is handled in another rule
+          comparison: not str($...ACTUATORS) in ["health","*"]
+    message: Spring Boot Actuators "$...ACTUATORS" are enabled. Depending on the actuators, this can pose a significant security risk. 
+      Please double-check if the actuators are needed and properly secured.
+    severity: WARNING
+    languages:
+      - generic
+    options:
+      # Limit matches to a single line to work with a limitation of the generic parser
+      generic_ellipsis_max_span: 0
+    metadata:
+      owasp: "A6: Security Misconfiguration"
+      references:
+        - https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-exposing-endpoints
+        - https://medium.com/walmartglobaltech/perils-of-spring-boot-actuators-misconfiguration-185c43a0f785
+        - https://blog.maass.xyz/spring-actuator-security-part-1-stealing-secrets-using-spring-actuators
+      category: security
+      technology:
+        - spring


### PR DESCRIPTION
There are already some rules for Spring Actuators in the registry, but they only check for activating all actuators using the wildcard operator. This Pull Request makes the following changes:
- Add an [extra link](https://blog.maass.xyz/spring-actuator-security-part-1-stealing-secrets-using-spring-actuators) to the existing rules that contains some information on the dangers of actuators (NB: this blog post was written by me, but I believe it is helpful and more up-to-date than the other resources)
- Remove some cruft from the YAML matching rule that I forgot to remove before sending the previous pull request (#2337)
- Add two new rules for matching actuator activations that are not the wildcard operator, but specific actuators. This case was not covered in the previous rules.

The new rules accept it if the "health" actuator is active, as it is active by default anyway. They also accept exposing the wildcard operator, as this is covered by existing rules, and I assume that the rules will be run in tandem. Finally, they are set to WARNING instead of ERROR, as the outcome is likely less severe than the wildcard operator, but can still be quite severe (so I thought that INFO would be insufficient). However, I am open to changing values, if desired.

The rules were written as part of a [blog article on using semgrep to find dangerous actuators](https://blog.maass.xyz/spring-actuator-security-part-2-finding-actuators-using-static-code-analysis-with-semgrep).