### PR TITLE
Updated open redirect in express

### DIFF
--- a/javascript/express/security/audit/express-open-redirect.js
+++ b/javascript/express/security/audit/express-open-redirect.js
@@ -18,6 +18,13 @@ module.exports.redirect = function (req, res) {
 	// ruleid: express-open-redirect
 	res.redirect(req.query.url+config_value.url)
 
+	const a = req.body.url
+	// ruleid: express-open-redirect
+	res.redirect(a)
+	// ruleid: express-open-redirect
+	res.redirect(`${a}/fooo`)
+	// ruleid: express-open-redirect
+	res.redirect(a+config_value.url)
 
 	// ruleid: express-open-redirect
 	res.redirect(req.body['url'])

--- a/javascript/express/security/audit/express-open-redirect.js
+++ b/javascript/express/security/audit/express-open-redirect.js
@@ -26,6 +26,20 @@ module.exports.redirect = function (req, res) {
 	// ruleid: express-open-redirect
 	res.redirect(a+config_value.url)
 
+	// ok: express-open-redirect
+	res.redirect(c+a)
+	// ok: express-open-redirect
+	res.redirect(`${c}${a}/fooo`)
+	// ok: express-open-redirect
+	res.redirect(c+a+config_value.url)
+
+	// ok: express-open-redirect
+	res.redirect(c)
+	// ok: express-open-redirect
+	res.redirect(`${c}`)
+	// ok: express-open-redirect
+	res.redirect(c+config_value.url)
+
 	// ruleid: express-open-redirect
 	res.redirect(req.body['url'])
 	// ruleid: express-open-redirect

--- a/javascript/express/security/audit/express-open-redirect.js
+++ b/javascript/express/security/audit/express-open-redirect.js
@@ -12,11 +12,26 @@ module.exports.redirect = function (req, res) {
 	res.redirect(config_value.foo+req)
 
 	// ruleid: express-open-redirect
-	res.redirect(req.query.url)
+	res.redirect(req.body.url)
 	// ruleid: express-open-redirect
 	res.redirect(`${req.query.url}/fooo`)
 	// ruleid: express-open-redirect
 	res.redirect(req.query.url+config_value.url)
+
+
+	// ruleid: express-open-redirect
+	res.redirect(req.body['url'])
+	// ruleid: express-open-redirect
+	res.redirect(`${req.body['url']}/fooo`)
+	// ruleid: express-open-redirect
+	res.redirect(req.body['url']+config_value.url)
+
+	// ruleid: express-open-redirect
+	res.redirect("https://"+req.body['url'])
+	// ruleid: express-open-redirect
+	res.redirect(`https://${req.body['url']}/fooo`)
+	// ruleid: express-open-redirect
+	res.redirect("https://"+req.body['url']+config_value.url)
 
 	// todo: express-open-redirect
 	res.redirect("https://google.com"+req.query.url)

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -60,52 +60,20 @@ rules:
   pattern-sinks:
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE)
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE + $...A)
-            - pattern: $RES.redirect(`$HTTP${$REQ. ... .$VALUE}...`)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ...)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... + $...A)
+            - pattern: $RES.redirect(`$HTTP${$REQ. ...}...`)
             - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...])
             - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...] + $...A)
             - pattern: $RES.redirect(`$HTTP${$REQ.$VALUE[...]}...`)
         - metavariable-regex:
             metavariable: $HTTP
             regex: ^https?:\/\/$
-        - pattern-either:
-            - pattern: $REQ. ... .$VALUE
-            - pattern: $REQ.$VALUE['...']
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect($REQ. ... .$VALUE)
-            - pattern: $RES.redirect($REQ. ... .$VALUE + $...A)
-            - pattern: $RES.redirect(`${$REQ. ... .$VALUE}...`)
-        - pattern: $REQ. ... .$VALUE
-    - patterns:
-        - pattern-either:
+            - pattern: $RES.redirect($REQ. ...)
+            - pattern: $RES.redirect($REQ. ... + $...A)
+            - pattern: $RES.redirect(`${$REQ. ...}...`)
             - pattern: $RES.redirect($REQ.$VALUE['...'])
             - pattern: $RES.redirect($REQ.$VALUE['...'] + $...A)
             - pattern: $RES.redirect(`${$REQ.$VALUE['...']}...`)
-        - pattern: $REQ.$VALUE['...']
-    - patterns:
-        - pattern-either:
-            - pattern-inside: |
-                $ASSIGN = $REQ. ... .$VALUE
-                ...
-            - pattern-inside: |
-                $ASSIGN = $REQ.$VALUE['...']
-                ...
-            - pattern-inside: |
-                $ASSIGN = $REQ. ... .$VALUE + $...A
-                ...
-            - pattern-inside: |
-                $ASSIGN = $REQ.$VALUE['...'] + $...A
-                ...     
-            - pattern-inside: |
-                $ASSIGN = `${$REQ. ... .$VALUE}...`
-                ...
-            - pattern-inside: |
-                $ASSIGN = `${$REQ.$VALUE['...']}...`
-                ...                    
-        - pattern-either:
-            - pattern: $RES.redirect($ASSIGN)
-            - pattern: $RES.redirect($ASSIGN + $...FOO)
-            - pattern: $RES.redirect(`${$ASSIGN}...`)
-        - pattern: $ASSIGN

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -17,7 +17,7 @@ rules:
     - vuln
     likelihood: HIGH
     impact: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
   languages:
   - javascript
   - typescript

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -57,44 +57,56 @@ rules:
             - pattern: cookies
             - pattern: headers
             - pattern: body
-    pattern-sinks:
-      - patterns:
-          - pattern-either:
-              - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING)
-              - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING + $...ANYTHING)
-              - pattern: $RES.redirect(`$HTTP${$REQ. ... .$ANYTHING}...`)
-              - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...])
-              - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...] + $...ANYTHING)
-              - pattern: $RES.redirect(`$HTTP${$REQ.$ANYTHING[...]}...`)
-          - metavariable-regex:
-              metavariable: $HTTP
-              regex: ^https?:\/\/$
-          - pattern-either:
-              - pattern: $REQ. ... .$ANYTHING
-              - pattern: $REQ.$ANYTHING['...']
-      - patterns:
-          - pattern-either:
-              - pattern: $RES.redirect($REQ. ... .$ANYTHING)
-              - pattern: $RES.redirect($REQ. ... .$ANYTHING + $...ANYTHING)
-              - pattern: $RES.redirect(`${$REQ. ... .$ANYTHING}...`)
-          - pattern: $REQ. ... .$ANYTHING
-      - patterns:
-          - pattern-either:
-              - pattern: $RES.redirect($REQ.$ANYTHING['...'])
-              - pattern: $RES.redirect($REQ.$ANYTHING['...'] + $...FOO)
-              - pattern: $RES.redirect(`${$REQ.$ANYTHING['...']}...`)
-          - pattern: $REQ.$ANYTHING['...']
-      - patterns:
-          - pattern-either:
-              - pattern-inside: |
-                  $ASSIGN = $REQ. ... .$ANYTHING
-                  ...
-              - pattern-inside: |
-                  $ASSIGN = $REQ.$ANYTHING['...']
-                  ...                  
-          - pattern-either:
-              - pattern: $RES.redirect($ASSIGN)
-              - pattern: $RES.redirect($ASSIGN + $...FOO)
-              - pattern: $RES.redirect(`${$ASSIGN}...`)
-          - pattern: $ASSIGN
-          
+  pattern-sinks:
+    - patterns:
+        - pattern-either:
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING + $...ANYTHING)
+            - pattern: $RES.redirect(`$HTTP${$REQ. ... .$ANYTHING}...`)
+            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...])
+            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...] + $...ANYTHING)
+            - pattern: $RES.redirect(`$HTTP${$REQ.$ANYTHING[...]}...`)
+        - metavariable-regex:
+            metavariable: $HTTP
+            regex: ^https?:\/\/$
+        - pattern-either:
+            - pattern: $REQ. ... .$ANYTHING
+            - pattern: $REQ.$ANYTHING['...']
+    - patterns:
+        - pattern-either:
+            - pattern: $RES.redirect($REQ. ... .$ANYTHING)
+            - pattern: $RES.redirect($REQ. ... .$ANYTHING + $...ANYTHING)
+            - pattern: $RES.redirect(`${$REQ. ... .$ANYTHING}...`)
+        - pattern: $REQ. ... .$ANYTHING
+    - patterns:
+        - pattern-either:
+            - pattern: $RES.redirect($REQ.$ANYTHING['...'])
+            - pattern: $RES.redirect($REQ.$ANYTHING['...'] + $...FOO)
+            - pattern: $RES.redirect(`${$REQ.$ANYTHING['...']}...`)
+        - pattern: $REQ.$ANYTHING['...']
+    - patterns:
+        - pattern-either:
+            - pattern-inside: |
+                $ASSIGN = $REQ. ... .$ANYTHING
+                ...
+            - pattern-inside: |
+                $ASSIGN = $REQ.$ANYTHING['...']
+                ...
+            - pattern-inside: |
+                $ASSIGN = $REQ. ... .$ANYTHING + $...A
+                ...
+            - pattern-inside: |
+                $ASSIGN = $REQ.$ANYTHING['...'] + $...A
+                ...     
+            - pattern-inside: |
+                $ASSIGN = `${$REQ. ... .$ANYTHING}...`
+                ...
+            - pattern-inside: |
+                $ASSIGN = `${$REQ.$ANYTHING['...']}...`
+                ...                    
+        - pattern-either:
+            - pattern: $RES.redirect($ASSIGN)
+            - pattern: $RES.redirect($ASSIGN + $...FOO)
+            - pattern: $RES.redirect(`${$ASSIGN}...`)
+        - pattern: $ASSIGN
+        

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -24,6 +24,7 @@ rules:
   severity: WARNING
   options:
     taint_unify_mvars: true
+    symbolic_propagation: true
   mode: taint
   pattern-sources:
     - patterns:
@@ -60,20 +61,53 @@ rules:
   pattern-sinks:
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect("$HTTP"+$REQ. ...)
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... + $...A)
-            - pattern: $RES.redirect(`$HTTP${$REQ. ...}...`)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE + $...A)
+            - pattern: $RES.redirect(`$HTTP${$REQ. ... .$VALUE}...`)
             - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...])
             - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...] + $...A)
             - pattern: $RES.redirect(`$HTTP${$REQ.$VALUE[...]}...`)
         - metavariable-regex:
             metavariable: $HTTP
             regex: ^https?:\/\/$
+        - pattern-either:
+            - pattern: $REQ. ... .$VALUE
+            - pattern: $REQ.$VALUE['...']
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect($REQ. ...)
-            - pattern: $RES.redirect($REQ. ... + $...A)
-            - pattern: $RES.redirect(`${$REQ. ...}...`)
+            - pattern: $RES.redirect($REQ. ... .$VALUE)
+            - pattern: $RES.redirect($REQ. ... .$VALUE + $...A)
+            - pattern: $RES.redirect(`${$REQ. ... .$VALUE}...`)
+        - pattern: $REQ. ... .$VALUE
+    - patterns:
+        - pattern-either:
             - pattern: $RES.redirect($REQ.$VALUE['...'])
             - pattern: $RES.redirect($REQ.$VALUE['...'] + $...A)
             - pattern: $RES.redirect(`${$REQ.$VALUE['...']}...`)
+        - pattern: $REQ.$VALUE['...']
+    - patterns:
+        - pattern-either:
+            - pattern-inside: |
+                $ASSIGN = $REQ. ... .$VALUE
+                ...
+            - pattern-inside: |
+                $ASSIGN = $REQ.$VALUE['...']
+                ...
+            - pattern-inside: |
+                $ASSIGN = $REQ. ... .$VALUE + $...A
+                ...
+            - pattern-inside: |
+                $ASSIGN = $REQ.$VALUE['...'] + $...A
+                ...     
+            - pattern-inside: |
+                $ASSIGN = `${$REQ. ... .$VALUE}...`
+                ...
+            - pattern-inside: |
+                $ASSIGN = `${$REQ.$VALUE['...']}...`
+                ...                    
+        - pattern-either:
+            - pattern: $RES.redirect($ASSIGN)
+            - pattern: $RES.redirect($ASSIGN + $...FOO)
+            - pattern: $RES.redirect(`${$ASSIGN}...`)
+        - pattern: $ASSIGN
+        

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -22,65 +22,68 @@ rules:
   - javascript
   - typescript
   severity: WARNING
+  options:
+    taint_unify_mvars: true
   mode: taint
   pattern-sources:
-  - patterns:
-    - pattern-either:
-      - pattern-inside: function ... ($REQ, $RES) {...}
-      - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
-      - patterns:
+    - patterns:
         - pattern-either:
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})
-        - metavariable-regex:
-            metavariable: $METHOD
-            regex: ^(get|post|put|head|delete|options)$
-    - pattern-either:
-      - pattern: $REQ.query
-      - pattern: $REQ.body
-      - pattern: $REQ.params
-      - pattern: $REQ.cookies
-      - pattern: $REQ.headers
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
-          {...}
-      - pattern-inside: |
-          ({ $REQ }: Request,$RES: Response) => {...}
-    - focus-metavariable: $REQ
-    - pattern-either:
-      - pattern: params
-      - pattern: query
-      - pattern: cookies
-      - pattern: headers
-      - pattern: body
+            - pattern-inside: function ... ($REQ, $RES) {...}
+            - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
+            - patterns:
+                - pattern-either:
+                    - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
+                    - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})
+                - metavariable-regex:
+                    metavariable: $METHOD
+                    regex: ^(get|post|put|head|delete|options)$
+        - pattern-either:
+            - pattern: $REQ.query
+            - pattern: $REQ.body
+            - pattern: $REQ.params
+            - pattern: $REQ.cookies
+            - pattern: $REQ.headers
+    - patterns:
+        - pattern-either:
+            - pattern-inside: |
+                ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
+                {...}
+            - pattern-inside: |
+                ({ $REQ }: Request,$RES: Response) => {...}
+        - focus-metavariable: $REQ
+        - pattern-either:
+            - pattern: params
+            - pattern: query
+            - pattern: cookies
+            - pattern: headers
+            - pattern: body
   pattern-sinks:
-  - patterns:
-    - pattern-either:
-      - pattern-inside: function ... ($REQ, $RES) {...}
-      - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
-      - patterns:
-        - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
-        - metavariable-regex:
-            metavariable: $METHOD
-            regex: ^(get|post|put|head|delete|options)
-    - pattern-either:
-      - pattern-inside: $RES.redirect($QUERY)
-    - pattern-not-inside: $RES.redirect("..."+<... $REQ ...>)
-    - pattern-not-inside: $RES.redirect(`$FOO${<... $REQ ...>}...`)
-    - pattern-not-inside: $RES.redirect($VAR. ...+<... $REQ ...>)
-    - pattern: $QUERY
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
-          {...}
-      - pattern-inside: |
-          ({ $REQ }: Request,$RES: Response) => {...}
-    - pattern-either:
-      - pattern-inside: $RES.redirect($QUERY)
-    - pattern-not-inside: $RES.redirect("..."+<... $REQ ...>)
-    - pattern-not-inside: $RES.redirect(`$FOO${<... $REQ ...>}...`)
-    - pattern-not-inside: $RES.redirect($VAR. ...+<... $REQ ...>)
-    - pattern: $QUERY
+    - patterns:
+        - pattern-either:
+            - pattern: $RES.redirect($HTTP+$REQ. ... .$ANYTHING)
+            - pattern: $RES.redirect($HTTP+$REQ. ... .$ANYTHING + $...ANYTHING)
+            - pattern: $RES.redirect(`$HTTP${$REQ. ... .$ANYTHING}...`)
+        - metavariable-regex: 
+              metavariable: $HTTP
+              regex: ^https?:\/\/$
+        - pattern-either:
+          - pattern: $REQ. ... .$ANYTHING
+          - pattern: $REQ.$ANYTHING['...']
+    - patterns:
+        - pattern-either:
+            - pattern: $RES.redirect($REQ. ... .$ANYTHING)
+            - pattern: $RES.redirect($REQ. ... .$ANYTHING + $...ANYTHING)
+            - pattern: $RES.redirect(`${$REQ. ... .$ANYTHING}...`)
+            - pattern: $RES.redirect(`https://${$REQ. ... .$ANYTHING}...`)
+            - pattern: $RES.redirect("https://"+$REQ. ... .$ANYTHING + $...ANYTHING)
+        - pattern: $REQ. ... .$ANYTHING
+    - patterns:
+        - pattern-either:
+            - pattern: $RES.redirect($REQ.$ANYTHING['...'])
+            - pattern: $RES.redirect($REQ.$ANYTHING['...'] + $...FOO)
+            - pattern: $RES.redirect(`${$REQ.$ANYTHING['...']}...`)
+            - pattern: $RES.redirect("https://"+$REQ.$ANYTHING['...'])
+            - pattern: $RES.redirect("https://"+$REQ.$ANYTHING['...'] + $...FOO)
+            - pattern: $RES.redirect(`https://${$REQ.$ANYTHING['...']}...`)
+        - pattern: $REQ.$ANYTHING['...']
+        

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -61,10 +61,10 @@ rules:
     - patterns:
         - pattern-either:
             - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE)
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE + $...VALUE)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE + $...FOO)
             - pattern: $RES.redirect(`$HTTP${$REQ. ... .$VALUE}...`)
             - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...])
-            - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...] + $...VALUE)
+            - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...] + $...FOO)
             - pattern: $RES.redirect(`$HTTP${$REQ.$VALUE[...]}...`)
         - metavariable-regex:
             metavariable: $HTTP
@@ -75,7 +75,7 @@ rules:
     - patterns:
         - pattern-either:
             - pattern: $RES.redirect($REQ. ... .$VALUE)
-            - pattern: $RES.redirect($REQ. ... .$VALUE + $...VALUE)
+            - pattern: $RES.redirect($REQ. ... .$VALUE + $...FOO)
             - pattern: $RES.redirect(`${$REQ. ... .$VALUE}...`)
         - pattern: $REQ. ... .$VALUE
     - patterns:

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -60,9 +60,12 @@ rules:
   pattern-sinks:
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect($HTTP+$REQ. ... .$ANYTHING)
-            - pattern: $RES.redirect($HTTP+$REQ. ... .$ANYTHING + $...ANYTHING)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING + $...ANYTHING)
             - pattern: $RES.redirect(`$HTTP${$REQ. ... .$ANYTHING}...`)
+            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...])
+            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...] + $...ANYTHING)
+            - pattern: $RES.redirect(`$HTTP${$REQ.$ANYTHING[...]}...`)
         - metavariable-regex: 
               metavariable: $HTTP
               regex: ^https?:\/\/$
@@ -74,16 +77,10 @@ rules:
             - pattern: $RES.redirect($REQ. ... .$ANYTHING)
             - pattern: $RES.redirect($REQ. ... .$ANYTHING + $...ANYTHING)
             - pattern: $RES.redirect(`${$REQ. ... .$ANYTHING}...`)
-            - pattern: $RES.redirect(`https://${$REQ. ... .$ANYTHING}...`)
-            - pattern: $RES.redirect("https://"+$REQ. ... .$ANYTHING + $...ANYTHING)
         - pattern: $REQ. ... .$ANYTHING
     - patterns:
         - pattern-either:
             - pattern: $RES.redirect($REQ.$ANYTHING['...'])
             - pattern: $RES.redirect($REQ.$ANYTHING['...'] + $...FOO)
             - pattern: $RES.redirect(`${$REQ.$ANYTHING['...']}...`)
-            - pattern: $RES.redirect("https://"+$REQ.$ANYTHING['...'])
-            - pattern: $RES.redirect("https://"+$REQ.$ANYTHING['...'] + $...FOO)
-            - pattern: $RES.redirect(`https://${$REQ.$ANYTHING['...']}...`)
         - pattern: $REQ.$ANYTHING['...']
-        

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: express-open-redirect
-  message: The application redirects to a URL specified by user-supplied input ($QUERY) that is not validated.
+  message: The application redirects to a URL specified by user-supplied input `$REQ` that is not validated.
     This could redirect users to malicious locations. Consider using an allow-list approach to validate
     URLs, or warn users they are being redirected to a third-party website.
   metadata:
@@ -60,53 +60,52 @@ rules:
   pattern-sinks:
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING)
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING + $...ANYTHING)
-            - pattern: $RES.redirect(`$HTTP${$REQ. ... .$ANYTHING}...`)
-            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...])
-            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...] + $...ANYTHING)
-            - pattern: $RES.redirect(`$HTTP${$REQ.$ANYTHING[...]}...`)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE + $...VALUE)
+            - pattern: $RES.redirect(`$HTTP${$REQ. ... .$VALUE}...`)
+            - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...])
+            - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...] + $...VALUE)
+            - pattern: $RES.redirect(`$HTTP${$REQ.$VALUE[...]}...`)
         - metavariable-regex:
             metavariable: $HTTP
             regex: ^https?:\/\/$
         - pattern-either:
-            - pattern: $REQ. ... .$ANYTHING
-            - pattern: $REQ.$ANYTHING['...']
+            - pattern: $REQ. ... .$VALUE
+            - pattern: $REQ.$VALUE['...']
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect($REQ. ... .$ANYTHING)
-            - pattern: $RES.redirect($REQ. ... .$ANYTHING + $...ANYTHING)
-            - pattern: $RES.redirect(`${$REQ. ... .$ANYTHING}...`)
-        - pattern: $REQ. ... .$ANYTHING
+            - pattern: $RES.redirect($REQ. ... .$VALUE)
+            - pattern: $RES.redirect($REQ. ... .$VALUE + $...VALUE)
+            - pattern: $RES.redirect(`${$REQ. ... .$VALUE}...`)
+        - pattern: $REQ. ... .$VALUE
     - patterns:
         - pattern-either:
-            - pattern: $RES.redirect($REQ.$ANYTHING['...'])
-            - pattern: $RES.redirect($REQ.$ANYTHING['...'] + $...FOO)
-            - pattern: $RES.redirect(`${$REQ.$ANYTHING['...']}...`)
-        - pattern: $REQ.$ANYTHING['...']
+            - pattern: $RES.redirect($REQ.$VALUE['...'])
+            - pattern: $RES.redirect($REQ.$VALUE['...'] + $...FOO)
+            - pattern: $RES.redirect(`${$REQ.$VALUE['...']}...`)
+        - pattern: $REQ.$VALUE['...']
     - patterns:
         - pattern-either:
             - pattern-inside: |
-                $ASSIGN = $REQ. ... .$ANYTHING
+                $ASSIGN = $REQ. ... .$VALUE
                 ...
             - pattern-inside: |
-                $ASSIGN = $REQ.$ANYTHING['...']
+                $ASSIGN = $REQ.$VALUE['...']
                 ...
             - pattern-inside: |
-                $ASSIGN = $REQ. ... .$ANYTHING + $...A
+                $ASSIGN = $REQ. ... .$VALUE + $...A
                 ...
             - pattern-inside: |
-                $ASSIGN = $REQ.$ANYTHING['...'] + $...A
+                $ASSIGN = $REQ.$VALUE['...'] + $...A
                 ...     
             - pattern-inside: |
-                $ASSIGN = `${$REQ. ... .$ANYTHING}...`
+                $ASSIGN = `${$REQ. ... .$VALUE}...`
                 ...
             - pattern-inside: |
-                $ASSIGN = `${$REQ.$ANYTHING['...']}...`
+                $ASSIGN = `${$REQ.$VALUE['...']}...`
                 ...                    
         - pattern-either:
             - pattern: $RES.redirect($ASSIGN)
             - pattern: $RES.redirect($ASSIGN + $...FOO)
             - pattern: $RES.redirect(`${$ASSIGN}...`)
         - pattern: $ASSIGN
-        

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -57,30 +57,44 @@ rules:
             - pattern: cookies
             - pattern: headers
             - pattern: body
-  pattern-sinks:
-    - patterns:
-        - pattern-either:
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING)
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING + $...ANYTHING)
-            - pattern: $RES.redirect(`$HTTP${$REQ. ... .$ANYTHING}...`)
-            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...])
-            - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...] + $...ANYTHING)
-            - pattern: $RES.redirect(`$HTTP${$REQ.$ANYTHING[...]}...`)
-        - metavariable-regex: 
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING)
+              - pattern: $RES.redirect("$HTTP"+$REQ. ... .$ANYTHING + $...ANYTHING)
+              - pattern: $RES.redirect(`$HTTP${$REQ. ... .$ANYTHING}...`)
+              - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...])
+              - pattern: $RES.redirect("$HTTP"+$REQ.$ANYTHING[...] + $...ANYTHING)
+              - pattern: $RES.redirect(`$HTTP${$REQ.$ANYTHING[...]}...`)
+          - metavariable-regex:
               metavariable: $HTTP
               regex: ^https?:\/\/$
-        - pattern-either:
+          - pattern-either:
+              - pattern: $REQ. ... .$ANYTHING
+              - pattern: $REQ.$ANYTHING['...']
+      - patterns:
+          - pattern-either:
+              - pattern: $RES.redirect($REQ. ... .$ANYTHING)
+              - pattern: $RES.redirect($REQ. ... .$ANYTHING + $...ANYTHING)
+              - pattern: $RES.redirect(`${$REQ. ... .$ANYTHING}...`)
           - pattern: $REQ. ... .$ANYTHING
+      - patterns:
+          - pattern-either:
+              - pattern: $RES.redirect($REQ.$ANYTHING['...'])
+              - pattern: $RES.redirect($REQ.$ANYTHING['...'] + $...FOO)
+              - pattern: $RES.redirect(`${$REQ.$ANYTHING['...']}...`)
           - pattern: $REQ.$ANYTHING['...']
-    - patterns:
-        - pattern-either:
-            - pattern: $RES.redirect($REQ. ... .$ANYTHING)
-            - pattern: $RES.redirect($REQ. ... .$ANYTHING + $...ANYTHING)
-            - pattern: $RES.redirect(`${$REQ. ... .$ANYTHING}...`)
-        - pattern: $REQ. ... .$ANYTHING
-    - patterns:
-        - pattern-either:
-            - pattern: $RES.redirect($REQ.$ANYTHING['...'])
-            - pattern: $RES.redirect($REQ.$ANYTHING['...'] + $...FOO)
-            - pattern: $RES.redirect(`${$REQ.$ANYTHING['...']}...`)
-        - pattern: $REQ.$ANYTHING['...']
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $ASSIGN = $REQ. ... .$ANYTHING
+                  ...
+              - pattern-inside: |
+                  $ASSIGN = $REQ.$ANYTHING['...']
+                  ...                  
+          - pattern-either:
+              - pattern: $RES.redirect($ASSIGN)
+              - pattern: $RES.redirect($ASSIGN + $...FOO)
+              - pattern: $RES.redirect(`${$ASSIGN}...`)
+          - pattern: $ASSIGN
+          

--- a/javascript/express/security/audit/express-open-redirect.yaml
+++ b/javascript/express/security/audit/express-open-redirect.yaml
@@ -61,10 +61,10 @@ rules:
     - patterns:
         - pattern-either:
             - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE)
-            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE + $...FOO)
+            - pattern: $RES.redirect("$HTTP"+$REQ. ... .$VALUE + $...A)
             - pattern: $RES.redirect(`$HTTP${$REQ. ... .$VALUE}...`)
             - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...])
-            - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...] + $...FOO)
+            - pattern: $RES.redirect("$HTTP"+$REQ.$VALUE[...] + $...A)
             - pattern: $RES.redirect(`$HTTP${$REQ.$VALUE[...]}...`)
         - metavariable-regex:
             metavariable: $HTTP
@@ -75,13 +75,13 @@ rules:
     - patterns:
         - pattern-either:
             - pattern: $RES.redirect($REQ. ... .$VALUE)
-            - pattern: $RES.redirect($REQ. ... .$VALUE + $...FOO)
+            - pattern: $RES.redirect($REQ. ... .$VALUE + $...A)
             - pattern: $RES.redirect(`${$REQ. ... .$VALUE}...`)
         - pattern: $REQ. ... .$VALUE
     - patterns:
         - pattern-either:
             - pattern: $RES.redirect($REQ.$VALUE['...'])
-            - pattern: $RES.redirect($REQ.$VALUE['...'] + $...FOO)
+            - pattern: $RES.redirect($REQ.$VALUE['...'] + $...A)
             - pattern: $RES.redirect(`${$REQ.$VALUE['...']}...`)
         - pattern: $REQ.$VALUE['...']
     - patterns:


### PR DESCRIPTION
This update uses unified_mvars to attempt to capture only `req` define in source to reach the 'first' value of `res.redirect` which .... is fairly complicated to do with normal taint mode 