### PR TITLE
Fix 'make test'

### DIFF
--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -42,7 +42,7 @@ fi
 #
 set_rule_folders() {
   rule_folders=$(find . -mindepth 1 -maxdepth 1 -type d \
-    | grep -v '^./\(stats\|trusted_python\|fingerprints\|scripts\)/\?$')
+    | grep -v '^./\(\..*\|stats\|trusted_python\|fingerprints\|scripts\)/\?$')
   if [[ -z "$rule_folders" ]]; then
     error "Cannot find any rule folders to scan in $(pwd)"
   fi

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -42,7 +42,8 @@ fi
 #
 set_rule_folders() {
   rule_folders=$(find . -mindepth 1 -maxdepth 1 -type d \
-    | grep -v '^./\(\..*\|stats\|trusted_python\|fingerprints\|scripts\)/\?$')
+    | grep -v '^./\(\..*\|stats\|trusted_python\|fingerprints\|scripts\)/\?$' \
+    | sort)
   if [[ -z "$rule_folders" ]]; then
     error "Cannot find any rule folders to scan in $(pwd)"
   fi


### PR DESCRIPTION
`make test` is going to be used [imminently in CI](https://github.com/returntocorp/semgrep-rules/pull/2405). This fixes the script that collects the roots to scan.

Test plan:
```
make test
```
should succeed (with the current development version of semgrep)
