### PR TITLE
Update ruby-eval to catch other access to params + cookies

### DIFF
--- a/ruby/lang/security/no-eval.rb
+++ b/ruby/lang/security/no-eval.rb
@@ -18,12 +18,12 @@ a = %q{def hello() "Hello there!" end}
 Thing.module_eval(a)
 puts Thing.new.hello()
 b = params['something']
-#ruleid:ruby-eval
+# ruleid:ruby-eval
 Thing.module_eval(b)
 
-#ruleid:ruby-eval
+# ruleid:ruby-eval
 eval(b)
-#ruleid:ruby-eval
+# ruleid:ruby-eval
 eval(b,some_binding)
 
 def get_binding(param)
@@ -36,7 +36,7 @@ b.eval("some_func")
 # ok:ruby-eval
 eval("some_func",b)
 
-#ruleid:ruby-eval
+# ruleid:ruby-eval
 eval(params['cmd'],b)
 
 # ruleid:ruby-eval

--- a/ruby/lang/security/no-eval.rb
+++ b/ruby/lang/security/no-eval.rb
@@ -40,6 +40,12 @@ eval("some_func",b)
 eval(params['cmd'],b)
 
 # ruleid:ruby-eval
+eval(params.dig('cmd'))
+
+# ruleid:ruby-eval
+eval(cookies.delete('foo'))
+
+# ruleid:ruby-eval
 RubyVM::InstructionSequence.compile(foo).eval
 
 # ok:ruby-eval

--- a/ruby/lang/security/no-eval.yaml
+++ b/ruby/lang/security/no-eval.yaml
@@ -9,8 +9,8 @@ rules:
     mode: taint
     pattern-sources:
       - pattern-either:
-        - pattern: params[...]
-        - pattern: cookies[...]
+        - pattern: params
+        - pattern: cookies
         - patterns:
           - pattern: |
               RubyVM::InstructionSequence.compile(...)


### PR DESCRIPTION
In #2332 params + cookies were added to this rule

params often refers to ActionController::Parameter
cookies often refers to ActionDispatch::Cookie

The user input residing in these classes can be accessed in more ways
than just via [...] such as params.dig(...) or cookies.delete(...)

This updates the rule and test cases to catch this.