### PR TITLE
Fix wrong use of todook:

### DIFF
--- a/java/jax-rs/security/insecure-resteasy.java
+++ b/java/jax-rs/security/insecure-resteasy.java
@@ -6,64 +6,63 @@ import javax.ws.rs.core.*;
 
 @Path("/")
 public class PoC_resource {
-    @POST
-    @Path("/concat")
-    @Produces(MediaType.APPLICATION_JSON)
-    // todoid: insecure-resteasy-deserialization
-    @Consumes({"*/*"})
-    public Map<String, String> doConcat(Pair pair) {
-        HashMap<String, String> result = new HashMap<String, String>();
-        result.put("Result", pair.getP1() + pair.getP2());
+  @POST
+  @Path("/concat")
+  @Produces(MediaType.APPLICATION_JSON)
+  // ruleid: insecure-resteasy-deserialization
+  @Consumes({ "*/*" })
+  public Map<String, String> doConcat(Pair pair) {
+    HashMap<String, String> result = new HashMap<String, String>();
+    result.put("Result", pair.getP1() + pair.getP2());
 
-        return result;
-    }
-    // ruleid:default-resteasy-provider-abuse
-    @POST
-    @Path("/vulnerable")
-    @Produces(MediaType.APPLICATION_JSON)
-    public Map<String, String> doConcat(Pair pair) {
-        HashMap<String, String> result = new HashMap<String, String>();
-        result.put("Result", pair.getP1() + pair.getP2());
+    return result;
+  }
 
-        return result;
-    }
+  // ruleid:default-resteasy-provider-abuse
+  @POST
+  @Path("/vulnerable")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Map<String, String> doConcat(Pair pair) {
+    HashMap<String, String> result = new HashMap<String, String>();
+    result.put("Result", pair.getP1() + pair.getP2());
 
-    @POST
-    @Path("/count")
-    @Produces(MediaType.APPLICATION_JSON)
-    // todo: insecure-resteasy-deserialization
-    @Consumes(MediaType.APPLICATION_JSON)
-    public Map<String, Integer> doCount(ArrayList<Object> elements) {
-        HashMap<String, Integer> result = new HashMap<String, Integer>();
-        result.put("Result", elements.size());
+    return result;
+  }
 
-        return result;
-    }
+  @POST
+  @Path("/count")
+  @Produces(MediaType.APPLICATION_JSON)
+  // todook: insecure-resteasy-deserialization
+  @Consumes(MediaType.APPLICATION_JSON)
+  public Map<String, Integer> doCount(ArrayList<Object> elements) {
+    HashMap<String, Integer> result = new HashMap<String, Integer>();
+    result.put("Result", elements.size());
 
+    return result;
+  }
 
-    // ok: default-resteasy-provider-abuse
-    @GET
-    @Path("/tenantmode")
-    @Produces(MediaType.TEXT_PLAIN)
-    public String getTenantMode() {
-        return kubernetesService.getMessage();
-    }
+  // ok: default-resteasy-provider-abuse
+  @GET
+  @Path("/tenantmode")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String getTenantMode() {
+    return kubernetesService.getMessage();
+  }
 
 }
-
 
 @Path("/")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 public class PoC_resource {
 
-    // ok: default-resteasy-provider-abuse
-    @POST
-    @Path("/concat")
-    public Map<String, String> doConcat(Pair pair) {
-        HashMap<String, String> result = new HashMap<String, String>();
-        result.put("Result", pair.getP1() + pair.getP2());
-        return result;
-    }
+  // ok: default-resteasy-provider-abuse
+  @POST
+  @Path("/concat")
+  public Map<String, String> doConcat(Pair pair) {
+    HashMap<String, String> result = new HashMap<String, String>();
+    result.put("Result", pair.getP1() + pair.getP2());
+    return result;
+  }
 
 }

--- a/java/jax-rs/security/insecure-resteasy.java
+++ b/java/jax-rs/security/insecure-resteasy.java
@@ -31,7 +31,7 @@ public class PoC_resource {
     @POST
     @Path("/count")
     @Produces(MediaType.APPLICATION_JSON)
-    // todook: insecure-resteasy-deserialization
+    // todo: insecure-resteasy-deserialization
     @Consumes(MediaType.APPLICATION_JSON)
     public Map<String, Integer> doCount(ArrayList<Object> elements) {
         HashMap<String, Integer> result = new HashMap<String, Integer>();

--- a/java/jax-rs/security/insecure-resteasy.yaml
+++ b/java/jax-rs/security/insecure-resteasy.yaml
@@ -1,31 +1,60 @@
 rules:
-- id: default-resteasy-provider-abuse
+- id: insecure-resteasy-deserialization
+  message: >-
+    When a Restful webservice endpoint is configured to use wildcard  mediaType {*/*} as a value for the
+    @Consumes annotation, an attacker  could abuse the SerializableProvider by sending a HTTP Request
+    with a  Content-Type of application/x-java-serialized-object. The body of that  request would be processed
+    by the SerializationProvider and could  contain a malicious payload, which may lead to arbitrary code
+    execution  when calling the $Y.getObject method.
   severity: WARNING
-  languages:
-  - java
   metadata:
-    cwe:
-    - 'CWE-502: Deserialization of Untrusted Data'
+    confidence: MEDIUM
+    category: security
+    cwe: 'CWE-502: Deserialization of Untrusted Data'
     owasp:
     - A08:2017 - Insecure Deserialization
-    - A08:2021 - Software and Data Integrity Failures
     references:
     - https://access.redhat.com/blogs/766093/posts/3162112
-    category: security
     technology:
     - jax-rs
-    confidence: LOW
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
+  languages:
+  - java
+  pattern-either:
+  - pattern: |
+      @Consumes({"application/x-java-serialized-object"})
+  - pattern: |
+      @Consumes({"*/*"})
+  - pattern: |
+      @Consumes("*/*")
+  - pattern: |
+      @Consumes({MediaType.WILDCARD_TYPE})
+- id: default-resteasy-provider-abuse
   message: >-
     When a Restful webservice endpoint isn't configured with a @Consumes  annotation, an attacker could
     abuse the SerializableProvider by sending a  HTTP Request with a Content-Type of application/x-java-serialized-object.  The
     body of that request would be processed by the SerializationProvider  and could contain a malicious
     payload, which may lead to arbitrary code  execution.
+  severity: WARNING
+  metadata:
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    cwe2021-top25: true
+    cwe2022-top25: true
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    references:
+    - https://access.redhat.com/blogs/766093/posts/3162112
+    subcategory:
+    - audit
+    technology:
+    - jax-rs
+  languages:
+  - java
   patterns:
   - pattern: |
       @Path("...")

--- a/java/jax-rs/security/insecure-resteasy.yaml
+++ b/java/jax-rs/security/insecure-resteasy.yaml
@@ -8,13 +8,21 @@ rules:
     execution  when calling the $Y.getObject method.
   severity: WARNING
   metadata:
-    confidence: MEDIUM
+    likelihood: LOW
+    impact: MEDIUM
+    confidence: LOW
     category: security
-    cwe: 'CWE-502: Deserialization of Untrusted Data'
+    cwe:
+    - 'CWE-502: Deserialization of Untrusted Data'
+    cwe2021-top25: true
+    cwe2022-top25: true
     owasp:
     - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
     references:
     - https://access.redhat.com/blogs/766093/posts/3162112
+    subcategory:
+    - audit
     technology:
     - jax-rs
   languages:

--- a/python/flask/security/audit/hardcoded-config.py
+++ b/python/flask/security/audit/hardcoded-config.py
@@ -2,21 +2,21 @@ import os
 import flask
 app = flask.Flask(__name__)
 
-# todoid: avoid_hardcoded_config_TESTING
+# ruleid: avoid_hardcoded_config_TESTING
 app.config["TESTING"] = True
-# todoid: avoid_hardcoded_config_TESTING
+# ruleid: avoid_hardcoded_config_TESTING
 app.config["TESTING"] = False
-# todoid: avoid_hardcoded_config_TESTING
+# ruleid: avoid_hardcoded_config_TESTING
 app.config.update(TESTING=True)
 
-# todoid: avoid_hardcoded_config_SECRET_KEY
+# ruleid: avoid_hardcoded_config_SECRET_KEY
 app.config.update(SECRET_KEY="aaaa")
-# todoid: avoid_hardcoded_config_SECRET_KEY
+# ruleid: avoid_hardcoded_config_SECRET_KEY
 app.config["SECRET_KEY"] = '_5#y2L"F4Q8z\n\xec]/'
 
-# todoid: avoid_hardcoded_config_ENV
+# ruleid: avoid_hardcoded_config_ENV
 app.config["ENV"] = "development"
-# todoid: avoid_hardcoded_config_ENV
+# ruleid: avoid_hardcoded_config_ENV
 app.config["ENV"] = "production"
 
 # ruleid: avoid_hardcoded_config_DEBUG
@@ -24,20 +24,20 @@ app.config["DEBUG"] = True
 # ruleid: avoid_hardcoded_config_DEBUG
 app.config["DEBUG"] = False
 
-# todo: avoid_hardcoded_config_TESTING
+# ok: avoid_hardcoded_config_TESTING
 app.config["TESTING"] = os.getenv("TESTING")
-# todo: avoid_hardcoded_config_TESTING
+# ok: avoid_hardcoded_config_TESTING
 app.config["TESTING"] = "aa"
 
-# todo: avoid_hardcoded_config_SECRET_KEY
+# ok: avoid_hardcoded_config_SECRET_KEY
 app.config.update(SECRET_KEY=os.getenv("SECRET_KEY"))
-# todo: avoid_hardcoded_config_SECRET_KEY
+# ok: avoid_hardcoded_config_SECRET_KEY
 app.config.update(SECRET_KEY=os.environ["SECRET_KEY"])
 
-# todo: avoid_hardcoded_config_ENV
+# ok: avoid_hardcoded_config_ENV
 app.config["ENV"] = os.environ["development"]
 
-# todo: avoid_hardcoded_config_DEBUG
+# ok: avoid_hardcoded_config_DEBUG
 app.config["DEBUG"] = os.environ["DEBUG"] or True
-# todo: avoid_hardcoded_config_DEBUG
+# ok: avoid_hardcoded_config_DEBUG
 app.config["DEBUG"] = os.environ["DEBUG"] or False

--- a/python/flask/security/audit/hardcoded-config.py
+++ b/python/flask/security/audit/hardcoded-config.py
@@ -24,20 +24,20 @@ app.config["DEBUG"] = True
 # ruleid: avoid_hardcoded_config_DEBUG
 app.config["DEBUG"] = False
 
-# todook: avoid_hardcoded_config_TESTING
+# todo: avoid_hardcoded_config_TESTING
 app.config["TESTING"] = os.getenv("TESTING")
-# todook: avoid_hardcoded_config_TESTING
+# todo: avoid_hardcoded_config_TESTING
 app.config["TESTING"] = "aa"
 
-# todook: avoid_hardcoded_config_SECRET_KEY
+# todo: avoid_hardcoded_config_SECRET_KEY
 app.config.update(SECRET_KEY=os.getenv("SECRET_KEY"))
-# todook: avoid_hardcoded_config_SECRET_KEY
+# todo: avoid_hardcoded_config_SECRET_KEY
 app.config.update(SECRET_KEY=os.environ["SECRET_KEY"])
 
-# todook: avoid_hardcoded_config_ENV
+# todo: avoid_hardcoded_config_ENV
 app.config["ENV"] = os.environ["development"]
 
-# todook: avoid_hardcoded_config_DEBUG
+# todo: avoid_hardcoded_config_DEBUG
 app.config["DEBUG"] = os.environ["DEBUG"] or True
-# todook: avoid_hardcoded_config_DEBUG
+# todo: avoid_hardcoded_config_DEBUG
 app.config["DEBUG"] = os.environ["DEBUG"] or False

--- a/python/flask/security/audit/hardcoded-config.yaml
+++ b/python/flask/security/audit/hardcoded-config.yaml
@@ -1,26 +1,101 @@
 rules:
+- id: avoid_hardcoded_config_TESTING
+  message: Hardcoded variable `TESTING` detected. Use environment variables or config files instead
+  severity: WARNING
+  metadata:
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-489: Active Debug Code'
+    owasp:
+    - A06:2021 - Security Misconfiguration
+    references:
+    - https://bento.dev/checks/flask/avoid-hardcoded-config/
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#builtin-configuration-values
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features
+    subcategory:
+    - audit
+    technology:
+    - flask
+  languages: [python]
+  pattern-either:
+  - pattern: $M.config['TESTING'] = True
+  - pattern: $M.config['TESTING'] = False
+  - pattern: $M.update(TESTING=True, ...)
+  - pattern: $M.update(TESTING=False, ...)
+- id: avoid_hardcoded_config_SECRET_KEY
+  message: Hardcoded variable `SECRET_KEY` detected. Use environment variables or config files instead
+  severity: ERROR
+  metadata:
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-489: Active Debug Code'
+    owasp:
+    - A06:2021 - Security Misconfiguration
+    references:
+    - https://bento.dev/checks/flask/avoid-hardcoded-config/
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#builtin-configuration-values
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features
+    subcategory:
+    - audit
+    technology:
+    - flask
+  languages: [python]
+  pattern-either:
+  - pattern: $M.update(SECRET_KEY="=~/.*/")
+  - pattern: $M.config['SECRET_KEY'] = "=~/.*/"
+- id: avoid_hardcoded_config_ENV
+  message: Hardcoded variable `ENV` detected. Set this by using FLASK_ENV environment variable
+  severity: WARNING
+  metadata:
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-489: Active Debug Code'
+    owasp:
+    - A06:2021 - Security Misconfiguration
+    references:
+    - https://bento.dev/checks/flask/avoid-hardcoded-config/
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#builtin-configuration-values
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features
+    subcategory:
+    - audit
+    technology:
+    - flask
+  languages: [python]
+  pattern-either:
+  - pattern: $M.update(ENV="=~/^development|production$/")
+  - pattern: $M.config['ENV'] = "=~/^development|production$/"
 - id: avoid_hardcoded_config_DEBUG
+  message: Hardcoded variable `DEBUG` detected. Set this by using FLASK_DEBUG environment variable
+  severity: WARNING
+  metadata:
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-489: Active Debug Code'
+    owasp:
+    - A06:2021 - Security Misconfiguration
+    references:
+    - https://bento.dev/checks/flask/avoid-hardcoded-config/
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#builtin-configuration-values
+    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features
+    subcategory:
+    - audit
+    technology:
+    - flask
+  languages: [python]
   pattern-either:
   - pattern: $M.update(DEBUG=True)
   - pattern: $M.update(DEBUG=False)
   - pattern: $M.config['DEBUG'] = True
   - pattern: $M.config['DEBUG'] = False
-  message: Hardcoded variable `DEBUG` detected. Set this by using FLASK_DEBUG environment variable
-  metadata:
-    cwe:
-    - 'CWE-489: Active Debug Code'
-    owasp: 'A6: Security Misconfiguration'
-    references:
-    - https://bento.dev/checks/flask/avoid-hardcoded-config/
-    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#builtin-configuration-values
-    - https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features
-    category: security
-    technology:
-    - flask
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: LOW
-    confidence: LOW
-  languages: [python]
-  severity: WARNING

--- a/scripts/run-tests
+++ b/scripts/run-tests
@@ -29,7 +29,7 @@ error() {
 # e.g.
 #   PIPENV_PIPFILE=~/semgrep/cli/Pipfile SEMGREP='pipenv run semgrep' make test
 #
-if [[ -z "$SEMGREP" ]]; then
+if [[ -z "${SEMGREP-}" ]]; then
   SEMGREP="semgrep"
 fi
 


### PR DESCRIPTION
Those todook: are used in other files to indicate that semgrep
currently reports a match, but at some point should not
and should become an ok:.
In the 2 files in this PR it is used for something else, which
then introduces some regressions in semgrep-core rules regressions
infra.

test plan:
make test in semgrep-core now works