### PR TITLE
Fix copy/paste error in message of OCaml physical vs structural rule

### DIFF
--- a/ocaml/lang/correctness/physical-vs-structural.yaml
+++ b/ocaml/lang/correctness/physical-vs-structural.yaml
@@ -1,13 +1,15 @@
 rules:
   - id: physical-equal
     pattern: $X == $Y
-    message: You probably want the structural inequality operator =
+    message: You probably want the structural equality operator =
     languages: [ocaml]
     severity: WARNING
     metadata:
       category: correctness
       technology:
         - ocaml
+      references:
+        - https://v2.ocaml.org/api/Stdlib.html#1_Comparisons
   - id: physical-not-equal
     pattern: $X != $Y
     message: You probably want the structural inequality operator <>
@@ -17,3 +19,5 @@ rules:
       category: correctness
       technology:
         - ocaml
+      references:
+        - https://v2.ocaml.org/api/Stdlib.html#1_Comparisons


### PR DESCRIPTION
This rule is about the equality operator, not inequality.