### PR TITLE
Do not detect GCP tls configuration in Azure detection rules.

### DIFF
--- a/terraform/azure/security/appservice/appservice-use-secure-tls-policy.tf
+++ b/terraform/azure/security/appservice/appservice-use-secure-tls-policy.tf
@@ -18,6 +18,13 @@ resource "azurerm_app_service" "good_example" {
   }
 }
 
+resource "google_compute_ssl_policy" "good_example" {
+  # ok: appservice-use-secure-tls-policy
+  min_tls_version = "TLS_1_2"
+  name            = "modern-ssl-policy"
+  profile         = "MODERN"
+}
+
 # fail
 
 resource "azurerm_app_service" "bad_example" {
@@ -26,8 +33,8 @@ resource "azurerm_app_service" "bad_example" {
   resource_group_name = azurerm_resource_group.example.name
   app_service_plan_id = azurerm_app_service_plan.example.id
 
+  # ruleid: appservice-use-secure-tls-policy
   site_config {
-    # ruleid: appservice-use-secure-tls-policy
       min_tls_version = "1.0"
   }
 }
@@ -38,8 +45,8 @@ resource "azurerm_app_service" "bad_example" {
   resource_group_name = azurerm_resource_group.example.name
   app_service_plan_id = azurerm_app_service_plan.example.id
 
+  # ruleid: appservice-use-secure-tls-policy
   site_config {
-    # ruleid: appservice-use-secure-tls-policy
       min_tls_version = "1.1"
   }
 }

--- a/terraform/azure/security/appservice/appservice-use-secure-tls-policy.yaml
+++ b/terraform/azure/security/appservice/appservice-use-secure-tls-policy.yaml
@@ -5,8 +5,9 @@ rules:
     "1.2"`
     in your resource block.
   patterns:
-  - pattern: min_tls_version = $ANYTHING
-  - pattern-not-inside: min_tls_version = "1.2"
+  - pattern-regex: site_config\s*{\n?(\s*#.*\n)*\s*min_tls_version\s*=\s*"\d\.\d"\n?\s*}
+  - pattern-not-regex: 
+      \s*min_tls_version\s*=\s*"1.2"
   metadata:
     cwe:
     - 'CWE-326: Inadequate Encryption Strength'


### PR DESCRIPTION
GCP configuration should not be impacted by Azure detection rules.

See issue https://github.com/returntocorp/semgrep-rules/issues/2465