### PR TITLE
Add rule for redirecting to current request URI in PHP

### DIFF
--- a/php/lang/security/redirect-to-request-uri.php
+++ b/php/lang/security/redirect-to-request-uri.php
@@ -1,0 +1,34 @@
+<?php
+
+// ruleid: redirect-to-request-uri
+header('Location: '.$_SERVER['REQUEST_URI']);
+
+// ruleid: redirect-to-request-uri
+header('location:'.$_SERVER['REQUEST_URI']);
+
+// ruleid: redirect-to-request-uri
+header('Location: '.$_SERVER['REQUEST_URI'].'/');
+
+// ruleid: redirect-to-request-uri
+header("Location: ".$_SERVER['REQUEST_URI']);
+
+// ruleid: redirect-to-request-uri
+header('Location: '.$_SERVER["REQUEST_URI"]);
+
+// ok: redirect-to-request-uri
+header('Location: '.$_SERVER['PHP_SELF']);
+
+// ok: redirect-to-request-uri
+header('X-Request-Uri: '.$_SERVER['REQUEST_URI']);
+
+// ok: redirect-to-request-uri
+header('Location: https://semgrep.dev'.$_SERVER['REQUEST_URI']);
+
+// ok: redirect-to-request-uri
+header('Location: '.$BASE_URL.$_SERVER['REQUEST_URI']);
+
+// ok: redirect-to-request-uri
+header('Location: '.$SERVER['HTTP_HOST'].$_SERVER['REQUEST_URI']);
+
+// ok: redirect-to-request-uri
+header('Location: /foo');

--- a/php/lang/security/redirect-to-request-uri.yaml
+++ b/php/lang/security/redirect-to-request-uri.yaml
@@ -1,0 +1,33 @@
+rules:
+- id: redirect-to-request-uri
+  patterns:
+  - pattern-either:
+    - pattern: |
+        header('$LOCATION' . $_SERVER['REQUEST_URI']);
+    - pattern: |
+        header('$LOCATION' . $_SERVER['REQUEST_URI'] . $MORE);
+  - metavariable-regex:
+      metavariable: $LOCATION
+      regex: '^(?i)location:\s*$'
+  message: >-
+    Redirecting to the current request URL may redirect to another domain, if
+    the current path starts with two slashes. 
+    E.g. in https://www.example.com//attacker.com, the value of REQUEST_URI
+    is //attacker.com, and redirecting to it will redirect to that domain.
+  metadata:
+    references:
+    - https://www.php.net/manual/en/reserved.variables.server.php
+    - https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control.html
+    category: security
+    technology:
+    - php
+    owasp:
+    - A05:2017 - Broken Access Control
+    - A01:2021 - Broken Access Control
+    cwe:
+    - "CWE-601: URL Redirection to Untrusted Site ('Open Redirect')"
+    likelihood: MEDIUM
+    impact: LOW
+    confidence: MEDIUM
+  languages: [php]
+  severity: WARNING


### PR DESCRIPTION
The request URI can start with two slashes, in which case it will redirect to another domain.

Whether this is actually possible depends for a great deal if a redirecting page can be requested on the target server with a name that is also a valid domain.