### PR TITLE
Add `workflow-run-target-code-checkout` rule for Github actions

### DIFF
--- a/yaml/github-actions/security/workflow-run-target-code-checkout.test.yaml
+++ b/yaml/github-actions/security/workflow-run-target-code-checkout.test.yaml
@@ -1,0 +1,74 @@
+on:
+  # pull_request_target:
+  workflow_run:
+    workflows: ["smth-else"]
+    types:
+    - completed
+  pull_request:
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: workflow-run-target-code-checkout
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.workflow_run.head.sha }}
+
+      - uses: actions/setup-node@v1
+      - run: |
+          npm install
+          npm build
+
+      - uses: completely/fakeaction@v2
+        with:
+          arg1: ${{ secrets.supersecret }}
+
+      - uses: fakerepo/comment-on-pr@v1
+        with:
+          message: |
+            Thank you!
+
+  build2:
+    name: Build and test 2
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: workflow-run-target-code-checkout
+      - uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ github.event.workflow_run.head.sha }}
+
+      - uses: actions/setup-node@v1
+      - run: |
+          npm install
+          npm build
+
+      - uses: completely/fakeaction@v2
+        with:
+          arg1: ${{ secrets.supersecret }}
+
+      - uses: fakerepo/comment-on-pr@v1
+        with:
+          message: |
+            Thank you!
+
+  this-is-safe-because-no-checkout:
+    name: Echo
+    runs-on: ubuntu-latest
+    steps:
+      # ok: workflow-run-target-code-checkout
+      - name: echo
+        run: |
+          echo "Hello, world"
+
+  spelling:
+    name: Spell checking
+    runs-on: ubuntu-latest
+    steps:
+      # ruleid: workflow-run-target-code-checkout
+      - name: checkout-merge
+        if: contains(github.event_name, 'pull_request')
+        uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{github.event.workflow_run.number}}/merge

--- a/yaml/github-actions/security/workflow-run-target-code-checkout.yaml
+++ b/yaml/github-actions/security/workflow-run-target-code-checkout.yaml
@@ -1,0 +1,55 @@
+rules:
+- id: workflow-run-target-code-checkout
+  languages:
+    - yaml
+  message: >-
+    This GitHub Actions workflow file uses `workflow_run` and checks out code
+    from the incoming pull request. When using `workflow_run`, the Action
+    runs in the context of the target repository, which includes access to all repository
+    secrets. Normally, this is safe because the Action only runs code from the target
+    repository, not the incoming PR. However, by checking out the incoming PR code, you're now using
+    the incoming code for the rest of the action. You may be inadvertently executing arbitrary code
+    from the incoming PR with access to repository secrets, which would let an attacker steal repository secrets.
+    This normally happens by running build scripts (e.g., `npm build` and `make`) or dependency installation
+    scripts (e.g., `python setup.py install`).
+    Audit your workflow file to make sure no code from the incoming PR is executed.
+    Please see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for additional
+    mitigations.
+  metadata:
+    category: security
+    owasp: "A1: Injection"
+    cwe: "CWE-913: Improper Control of Dynamically-Managed Code Resources"
+    references:
+      - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - https://github.com/justinsteven/advisories/blob/master/2021_github_actions_checkspelling_token_leak_via_advice_symlink.md
+    technology:
+      - github-actions
+  patterns:
+    - pattern-inside: |
+        on:
+          ...
+          workflow_run: ...
+          ...
+        ...
+    - pattern-inside: |
+        jobs:
+          ...
+          $JOBNAME:
+            ...
+            steps:
+              ...
+    - pattern: |
+        ...
+        uses: "$ACTION"
+        with:
+          ...
+          ref: $EXPR
+    - metavariable-regex:
+        metavariable: $ACTION
+        regex: actions/checkout@.*
+    - metavariable-pattern:
+        language: generic
+        metavariable: $EXPR
+        patterns:
+          - pattern: ${{ github.event.workflow_run ... }}
+  severity: WARNING


### PR DESCRIPTION
According to https://www.legitsecurity.com/blog/github-privilege-escalation-vulnerability

checking out user supplied code on `workflow_run` is dangerous in a similar way as on `pull_request_target`

the rule is basically a copy-paste of this one: https://github.com/returntocorp/semgrep-rules/blob/develop/yaml/github-actions/security/pull-request-target-code-checkout.yaml

but I decided to create a separate rule in case if something change for the way `workflow_run` or `pull_request_target` it will be easier to update and test