### PR TITLE
Normalize CWE-185 (bad regex) to CWE-1333 (reDOS)

### DIFF
--- a/contrib/nodejsscan/regex_dos.yaml
+++ b/contrib/nodejsscan/regex_dos.yaml
@@ -64,7 +64,7 @@ rules:
     severity: WARNING
     metadata:
       owasp: "A6: Security Misconfiguration"
-      cwe: "CWE-185: Incorrect Regular Expression"
+      cwe: "CWE-1333: Inefficient Regular Expression Complexity"
       category: security
       technology:
         - node.js

--- a/javascript/lang/security/audit/detect-non-literal-regexp.yaml
+++ b/javascript/lang/security/audit/detect-non-literal-regexp.yaml
@@ -8,7 +8,7 @@ rules:
     - A05:2021 - Security Misconfiguration
     - A06:2017 - Security Misconfiguration
     cwe:
-    - 'CWE-185: Incorrect Regular Expression'
+    - "CWE-1333: Inefficient Regular Expression Complexity"
     references:
     - https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
     source-rule-url: https://github.com/nodesecurity/eslint-plugin-security/blob/master/rules/detect-non-literal-regexp.js


### PR DESCRIPTION
Some rules are mislabeled as CWE-185, while they really are looking for CWE-1333.