### PR TITLE
adding case to unverified ssl context

### DIFF
--- a/python/lang/security/unverified-ssl-context.py
+++ b/python/lang/security/unverified-ssl-context.py
@@ -11,3 +11,7 @@ conn = httplib.client.HTTPSConnection("123.123.21.21", context=context)
 
 # ruleid:unverified-ssl-context
 conn = httplib.client.HTTPSConnection("123.123.21.21", context=ssl._create_unverified_context())
+
+# ruleid:unverified-ssl-context
+ssl._create_default_https_context = ssl._create_unverified_context
+urllib2.urlopen("https://google.com").read()

--- a/python/lang/security/unverified-ssl-context.yaml
+++ b/python/lang/security/unverified-ssl-context.yaml
@@ -1,13 +1,16 @@
 rules:
 - id: unverified-ssl-context
-  pattern: ssl._create_unverified_context(...)
+  patterns:
+  - pattern-either:
+    - pattern: ssl._create_unverified_context(...)
+    - pattern: ssl._create_default_https_context = ssl._create_unverified_context
   fix-regex:
     regex: _create_unverified_context
     replacement: create_default_context
   message: >-
     Unverified SSL context detected. This will permit insecure connections without
     verifying
-    SSL certificates. Use 'ssl.create_default_context()' instead.
+    SSL certificates. Use 'ssl.create_default_context' instead.
   metadata:
     owasp:
     - A03:2017 - Sensitive Data Exposure


### PR DESCRIPTION
For https://github.com/returntocorp/semgrep-rules/issues/2487.

We want to detect cases where default https context is set to unverified.