### PR TITLE
Allow a template variable in the nonce attribute of a script tag.

### DIFF
--- a/generic/html-templates/security/var-in-script-src.html
+++ b/generic/html-templates/security/var-in-script-src.html
@@ -43,4 +43,8 @@
 <!-- ruleid: var-in-script-src -->
 <script src="./{{ reactDemoIndexBundleJs }}" crossOrigin="anonymous" integrity="{{ sri.reactDemoIndexBundleJs }}"></script>
 
+<script nonce="{{ request.csp_nonce }}">
+  console.log('inline script running');
+</script>
+
 </html>

--- a/generic/html-templates/security/var-in-script-src.yaml
+++ b/generic/html-templates/security/var-in-script-src.yaml
@@ -40,4 +40,6 @@ rules:
   - pattern-inside: <script ...>
   - pattern-not-inside: src = '...'
   - pattern-not-inside: src = "..."
+  - pattern-not-inside: nonce = '...'
+  - pattern-not-inside: nonce = "..."
   - pattern: '{{ ... }}'


### PR DESCRIPTION
On receiving a CSP, a compliant browser will refuse to execute inline scripts unless the server tags them with a nonce or hash.

The django-csp library handles generation and insertion of nonces. It requires however that we indicate the point in which it should place the nonce, using a template variable.

This PR modifies the var-in-script-src rule so that it will not flag a template variable inside a nonce attribute.

References:
https://content-security-policy.com/script-src/
https://django-csp.readthedocs.io/en/latest/nonce.html