### PR TITLE
fix failed tests from release PR

### DIFF
--- a/csharp/dotnet/security/use_deprecated_cipher_algorithm.yaml
+++ b/csharp/dotnet/security/use_deprecated_cipher_algorithm.yaml
@@ -14,7 +14,7 @@ rules:
     severity: ERROR
     metadata:
       cwe:
-        - CWE-327: Use of a Broken or Risky Cryptographic Algorithm
+        - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
       owasp:
         - A02:2021 - Cryptographic Failures
       technology:

--- a/csharp/dotnet/security/use_ecb_mode.yaml
+++ b/csharp/dotnet/security/use_ecb_mode.yaml
@@ -21,7 +21,7 @@ rules:
     severity: WARNING
     metadata:
       cwe:
-        - CWE-327: Use of a Broken or Risky Cryptographic Algorithm
+        - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
       owasp:
         - A02:2021 - Cryptographic Failures
       technology:

--- a/csharp/dotnet/security/use_weak_rng_for_keygeneration.yaml
+++ b/csharp/dotnet/security/use_weak_rng_for_keygeneration.yaml
@@ -30,7 +30,7 @@ rules:
     severity: ERROR
     metadata:
       cwe:
-        - CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
+        - 'CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)'
       owasp:
         - A02:2021 - Cryptographic Failures
       technology:

--- a/php/lang/security/php-ssrf.yaml
+++ b/php/lang/security/php-ssrf.yaml
@@ -29,6 +29,8 @@ rules:
       sufficiently ensure that the request is being sent to the expected
       destination. Dangerous function $FUNCS with payload $DATA
     metadata:
+      references: 
+        - https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
       license: Commons Clause License Condition v1.0[LGPL-2.1-only]
       cwe:
         - "CWE-918: Server-Side Request Forgery (SSRF)"


### PR DESCRIPTION
@returntocorp/security-research 

Fixes for failed jobs from https://github.com/returntocorp/semgrep-rules/actions/runs/3372782682/jobs/5596612867

to investigate - why these checks didn't fail on PRs to `develop`