### PR TITLE
Fix dompurify rule autofix

### DIFF
--- a/javascript/dompurify.fixed.jsx
+++ b/javascript/dompurify.fixed.jsx
@@ -23,5 +23,9 @@ var clean = DOMPurify.sanitize(dirty, {RETURN_DOM_FRAGMENT: true, RETURN_DOM_IMP
 document.body.appendChild(clean);
 
 // ruleid: harden-dompurify-usage
-var yikes = DOMPurify.sanitize(dirty, {RETURN_DOM: true});
+var yikes = DOMPurify.sanitize(dirty, {RETURN_DOM: true})
 document.body.innerHTML = yikes;
+
+
+// ruleid: harden-dompurify-usage
+dosomethingsketchy(DOMPurify.sanitize(dirty, {RETURN_DOM: true}));

--- a/javascript/dompurify.jsx
+++ b/javascript/dompurify.jsx
@@ -25,3 +25,7 @@ document.body.appendChild(clean);
 // ruleid: harden-dompurify-usage
 var yikes = DOMPurify.sanitize(dirty, {})
 document.body.innerHTML = yikes;
+
+
+// ruleid: harden-dompurify-usage
+dosomethingsketchy(DOMPurify.sanitize(dirty, {}));

--- a/javascript/dompurify.yaml
+++ b/javascript/dompurify.yaml
@@ -33,4 +33,4 @@ rules:
   - pattern-not: |
       DOMPurify.sanitize($X, {RETURN_DOM: true})
   fix: |
-    DOMPurify.sanitize($X, {RETURN_DOM: true});
+    DOMPurify.sanitize($X, {RETURN_DOM: true})


### PR DESCRIPTION
The pattern targets an expression, but the fix was a statement, since it is terminated by a semicolon. Removing the semicolon in the fix makes it consistent.

I've added a test case that illustrates the bad behavior that this leads to. Before this change, the new call was fixed to the following:

```
dosomethingsketchy(DOMPurify.sanitize(dirty, {RETURN_DOM: true}););
```

Note that this has an extra semicolon before the last close parenthesis.