### PR TITLE
Allow a template variable in the nonce attribute of a script tag.

### DIFF
--- a/python/django/security/audit/xss/var-in-script-tag.html
+++ b/python/django/security/audit/xss/var-in-script-tag.html
@@ -12,5 +12,10 @@
             <!-- ok: var-in-script-tag -->
             <p>{{ this_is_fine }}</p>
         </div>
+
+        <!-- ok: var-in-script-tag -->
+        <script nonce="{{ request.csp_nonce }}">
+            console.log('inline script running');
+        </script>
     </body>
 </html>

--- a/python/django/security/audit/xss/var-in-script-tag.yaml
+++ b/python/django/security/audit/xss/var-in-script-tag.yaml
@@ -16,6 +16,8 @@ rules:
   patterns:
   - pattern-inside: <script ...> ... </script>
   - pattern: '{{ ... }}'
+  - pattern-not-inside: nonce = '...'
+  - pattern-not-inside: nonce = "..."
   paths:
     include:
     - '*.html'


### PR DESCRIPTION
This updates the var-in-script-tag rule for Django templates to allow a variable in the nonce attribute of a script tag.

References:
https://content-security-policy.com/script-src/
https://django-csp.readthedocs.io/en/latest/nonce.html