### PR TITLE
support shebang contexts for finding dangerous execs

### DIFF
--- a/go/lang/security/audit/dangerous-exec-command.go
+++ b/go/lang/security/audit/dangerous-exec-command.go
@@ -79,7 +79,7 @@ func runcommand6(s string) (string, error) {
 
 	// might not have user context
 	// ruleid:dangerous-exec-command
-	cmd := exec.Command("/bin/env", "bash", "-c", s)
+	cmd := exec.CommandContext($CTX,"/bin/env", "bash", "-c", s)
 	stdoutStderr, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/go/lang/security/audit/dangerous-exec-command.go
+++ b/go/lang/security/audit/dangerous-exec-command.go
@@ -76,10 +76,10 @@ func runcommand5(s string) (string, error) {
 }
 
 func runcommand6(s string) (string, error) {
-
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	// might not have user context
 	// ruleid:dangerous-exec-command
-	cmd := exec.CommandContext($CTX,"/bin/env", "bash", "-c", s)
+	cmd := exec.CommandContext(ctx, "/bin/env", "bash", "-c", s)
 	stdoutStderr, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/go/lang/security/audit/dangerous-exec-command.go
+++ b/go/lang/security/audit/dangerous-exec-command.go
@@ -1,90 +1,133 @@
 package main
 
 import (
-    "fmt"
-    "os"
-    "os/exec"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
 )
 
 func runCommand1(userInput string) {
-  // ruleid:dangerous-exec-command
-  cmd := exec.Command( userInput, "foobar" )
+	// ruleid:dangerous-exec-command
+	cmd := exec.Command(userInput, "foobar")
 
-  cmd.Stdout = os.Stdout
-  cmd.Stderr = os.Stdout
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
 
-  if err := cmd.Run(); err != nil {
-      fmt.Println( "Error:", err )
-  }
+	if err := cmd.Run(); err != nil {
+		fmt.Println("Error:", err)
+	}
 
 }
 
 func runCommand2(userInput string) {
 
-    execPath,_ := exec.LookPath(userInput)
+	execPath, _ := exec.LookPath(userInput)
 
-    // ruleid:dangerous-exec-command
-    cmd := exec.Command( execPath, "foobar" )
+	// ruleid:dangerous-exec-command
+	cmd := exec.Command(execPath, "foobar")
 
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stdout
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
 
-    if err := cmd.Run(); err != nil {
-        fmt.Println( "Error:", err )
-    }
+	if err := cmd.Run(); err != nil {
+		fmt.Println("Error:", err)
+	}
 
 }
 
 func runCommand3(userInput string) {
-  ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-  defer cancel()
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
 
-  // ruleid:dangerous-exec-command
-  if err := exec.CommandContext(ctx, userInput, "5").Run(); err != nil {
-    fmt.Println( "Error:", err )
-  }
+	// ruleid:dangerous-exec-command
+	if err := exec.CommandContext(ctx, userInput, "5").Run(); err != nil {
+		fmt.Println("Error:", err)
+	}
 
 }
 
 func runCommand4(userInput string) {
 
-    // ruleid:dangerous-exec-command
-    cmd := exec.Command( "bash", "-c", userInput )
+	// ruleid:dangerous-exec-command
+	cmd := exec.Command("bash", "-c", userInput)
 
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stdout
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
 
-    if err := cmd.Run(); err != nil {
-        fmt.Println( "Error:", err )
-    }
+	if err := cmd.Run(); err != nil {
+		fmt.Println("Error:", err)
+	}
 
+}
+
+func runcommand5(s string) (string, error) {
+
+	// ruleid:dangerous-exec-command
+	cmd := exec.Command("/usr/bin/env", "bash", "-c", s)
+	stdoutStderr, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", fmt.Errorf("shellCommand: unexpected error: out = %s, error = %v", stdoutStderr, err)
+	}
+
+	return string(stdoutStderr), nil
+}
+
+func runcommand6(s string) (string, error) {
+
+	// might not have user context
+	// ruleid:dangerous-exec-command
+	cmd := exec.Command("/bin/env", "bash", "-c", s)
+	stdoutStderr, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", fmt.Errorf("shellCommand: unexpected error: out = %s, error = %v", stdoutStderr, err)
+	}
+
+	return string(stdoutStderr), nil
 }
 
 func okCommand1(userInput string) {
 
-    goExec,_ := exec.LookPath("go")
+	goExec, _ := exec.LookPath("go")
 
-    // ok:dangerous-exec-command
-    cmd := exec.Command( goExec, "version" )
+	// ok:dangerous-exec-command
+	cmd := exec.Command(goExec, "version")
 
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stdout
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
 
-    if err := cmd.Run(); err != nil {
-        fmt.Println( "Error:", err )
-    }
+	if err := cmd.Run(); err != nil {
+		fmt.Println("Error:", err)
+	}
 
 }
 
 func okCommand2(userInput string) {
-    // ok:dangerous-exec-command
-    cmd := exec.Command( "go", "version" )
+	// ok:dangerous-exec-command
+	cmd := exec.Command("go", "version")
 
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stdout
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stdout
 
-    if err := cmd.Run(); err != nil {
-        fmt.Println( "Error:", err )
-    }
+	if err := cmd.Run(); err != nil {
+		fmt.Println("Error:", err)
+	}
 
+}
+
+func okCommand3(s string) (string, error) {
+
+	someCommand := "w"
+	// ok:dangerous-exec-command
+	cmd := exec.Command("/usr/bin/env", "bash", "-c", someCommand)
+	stdoutStderr, err := cmd.CombinedOutput()
+
+	if err != nil {
+		return "", fmt.Errorf("shellCommand: unexpected error: out = %s, error = %v", stdoutStderr, err)
+	}
+
+	return string(stdoutStderr), nil
 }

--- a/go/lang/security/audit/dangerous-exec-command.yaml
+++ b/go/lang/security/audit/dangerous-exec-command.yaml
@@ -22,6 +22,11 @@ rules:
           exec.Command("...","...","...",...)
       - pattern-not: |
           exec.CommandContext($CTX,"...","...","...",...)
+    - pattern-either:
+        - pattern: |
+            exec.Command("=~/\/bin\/env/","=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$CMD,...)
+        - pattern: |
+            exec.CommandContext($CTX,"=~/bin/env","=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$CMD,...)
   - pattern-inside: |
       import "os/exec"
       ...

--- a/go/lang/security/audit/dangerous-exec-command.yaml
+++ b/go/lang/security/audit/dangerous-exec-command.yaml
@@ -26,7 +26,7 @@ rules:
         - pattern: |
             exec.Command("=~/\/bin\/env/","=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$CMD,...)
         - pattern: |
-            exec.CommandContext($CTX,"=~/bin/env","=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$CMD,...)
+            exec.CommandContext($CTX,"=~/\/bin\/env/","=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$CMD,...)
   - pattern-inside: |
       import "os/exec"
       ...


### PR DESCRIPTION
Go's `exec.Command` and `exec.CommandContext` support shebang-style command invocation which the existing command injection rule did not correctly handle.