### PR TITLE
Updated `use-filepath-join`

### DIFF
--- a/go/lang/correctness/use-filepath-join.go
+++ b/go/lang/correctness/use-filepath-join.go
@@ -13,3 +13,26 @@ func main() {
 	// ok: use-filepath-join
 	var fpath = filepath.Join(getDir())
 }
+
+func main() {
+	url, err := url.Parse("http://foo:666/bar")
+	if err != nil {
+		panic(err)
+	}
+
+	// ok: use-filepath-join
+	fmt.Println(path.Join(url.Path, "baz"))
+}
+
+func main(a *http.Request) {
+	p, err := path.Parse("/opt/foo/bar")
+	if err != nil {
+		panic(err)
+	}
+
+	// ruleid: use-filepath-join
+	fmt.Println(path.Join(p.Path, "baz"))
+
+	// ok: use-filepath-join
+	fmt.Println(path.Join(a.Path, "baz"))
+}

--- a/go/lang/correctness/use-filepath-join.go
+++ b/go/lang/correctness/use-filepath-join.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"path"
-	"filepath"
+	"path/filepath"
 )
 
 func main() {
@@ -34,5 +34,5 @@ func main(a *http.Request) {
 	fmt.Println(path.Join(p.Path, "baz"))
 
 	// ok: use-filepath-join
-	fmt.Println(path.Join(a.Path, "baz"))
+	fmt.Println(filepath.Join(a.Path, "baz"))
 }

--- a/go/lang/correctness/use-filepath-join.go
+++ b/go/lang/correctness/use-filepath-join.go
@@ -1,20 +1,23 @@
 package main
 
 import (
+	"filepath"
 	"path"
-	"path/filepath"
 )
 
-func main() {
+func a() {
 	dir := getDir()
 
-	// ruleid: use-filepath-join
-	var path = path.Join(getDir())
+	// ok: use-filepath-join
+	var p = path.Join(getDir())
 	// ok: use-filepath-join
 	var fpath = filepath.Join(getDir())
+
+	// ruleid: use-filepath-join
+	path.Join("/", path.Base(p))
 }
 
-func main() {
+func a() {
 	url, err := url.Parse("http://foo:666/bar")
 	if err != nil {
 		panic(err)
@@ -24,15 +27,14 @@ func main() {
 	fmt.Println(path.Join(url.Path, "baz"))
 }
 
-func main(a *http.Request) {
-	p, err := path.Parse("/opt/foo/bar")
-	if err != nil {
-		panic(err)
-	}
-
+func a(p string) {
 	// ruleid: use-filepath-join
-	fmt.Println(path.Join(p.Path, "baz"))
+	fmt.Println(path.Join(p, "baz"))
+
+	// ok: use-filepath-join
+	fmt.Println(path.Join("asdf", "baz"))
 
 	// ok: use-filepath-join
 	fmt.Println(filepath.Join(a.Path, "baz"))
 }
+

--- a/go/lang/correctness/use-filepath-join.yaml
+++ b/go/lang/correctness/use-filepath-join.yaml
@@ -6,73 +6,33 @@ rules:
     message: "`path.Join(...)` always joins using a forward slash. This may cause
       issues on Windows or other systems using a different delimiter. Use
       `filepath.Join(...)` instead which uses OS-specific path separators."
-    patterns:
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: |
+              ($STR : string)
+          - pattern-not: |
+              "..."
+      - patterns:
+          - pattern-inside: |
+              import "path"
+              ...
+          - pattern: path.$FUNC(...)
+          - metavariable-regex:
+              metavariable: $FUNC
+              regex: ^(Base|Clean|Dir|Split)$
+      - patterns:
+          - pattern-inside: |
+              import "path/filepath"
+              ...
+          - pattern: filepath.$FUNC(...)
+          - metavariable-regex:
+              metavariable: $FUNC
+              regex: ^(Base|Clean|Dir|FromSlash|Glob|Rel|Split|SplitList|ToSlash|VolumeName)$
+    pattern-sinks:
       - pattern: path.Join(...)
-      - pattern-not-inside: |
-          $URL, $ERR := url. ... .$ANTYHING(...)
+    pattern-sanitizers:
+      - pattern: |
+          url.Parse(...)
           ...
-          $URL = <... path.Join(...) ...>
-      - pattern-not-inside: |
-          $URL, $ERR := url. ... .$ANTYHING(...)
-          ...
-          path.Join(...,<... $URL ...>,...)
-      - pattern-not-inside: |
-          $URL, $ERR := url. ... .$ANTYHING(...)
-          ...
-          path.Join(...,<... $URL ...>,...)
-      - pattern-not-inside: |
-          path.Join(...,<... ($REQ *http.Request) ...>,...)
-      - pattern-not-inside: |
-          path.Join(...,<... ($RES *http.Response) ...>,...)
-      - pattern-not-inside: |
-          path.Join(...,<... route. ... .$ANYTHING(...) ...>,...)
-      - pattern-not-inside: |
-          path.Join(...,<... http. ... .$ANYTHING(...) ...>,...)
-      - pattern-not-inside: |
-          path.Join(...,<... http. ... .$ANYTHING ...>,...)
-      - pattern-not-inside: |
-          http.$ANYTHING(...,<... path.Join(...) ...>,...)
-      - pattern-not-inside: |
-          func ($L $ANTYHING) $R(...) *http.Request {
-            ...
-            path.Join(...)
-          }
-      - pattern-not-inside: |
-          func (...) *http.Request {
-            ...
-            path.Join(...)
-          }
-      - pattern-not-inside: |
-          func $SOMETHING(...) *http.Request {
-            ...
-            path.Join(...)
-          }
-      - pattern-not-inside: |
-          func ($L $ANTYHING) $R(...) *url.URL {
-            ...
-            path.Join(...)
-          }
-      - pattern-not-inside: |
-          func $SOMETHING(...) *url.URL {
-            ...
-            path.Join(...)
-          }
-      - pattern-not-inside: |
-          func (...) *url.URL {
-            ...
-            path.Join(...)
-          }
-    metadata:
-      category: correctness
-      references:
-        - https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
-        - https://go.dev/src/path/path.go?s=4034:4066#L145
-      technology:
-        - go
-      likelihood: LOW
-      impact: HIGH
-      confidence: LOW
-      subcategory:
-        - audit
-      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
 

--- a/go/lang/correctness/use-filepath-join.yaml
+++ b/go/lang/correctness/use-filepath-join.yaml
@@ -1,5 +1,5 @@
 rules:
-  - id: use-filepath-join-copy
+  - id: use-filepath-join
     languages:
       - go
     severity: WARNING

--- a/go/lang/correctness/use-filepath-join.yaml
+++ b/go/lang/correctness/use-filepath-join.yaml
@@ -6,6 +6,18 @@ rules:
     message: "`path.Join(...)` always joins using a forward slash. This may cause
       issues on Windows or other systems using a different delimiter. Use
       `filepath.Join(...)` instead which uses OS-specific path separators."
+    metadata:
+      category: correctness
+      references:
+      - https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
+      - https://go.dev/src/path/path.go?s=4034:4066#L145
+      likelihood: LOW
+      impact: HIGH
+      confidence: LOW
+      subcategory:
+        - audit
+      technology:
+      - go
     mode: taint
     pattern-sources:
       - patterns:

--- a/go/lang/correctness/use-filepath-join.yaml
+++ b/go/lang/correctness/use-filepath-join.yaml
@@ -1,16 +1,78 @@
 rules:
-- id: use-filepath-join
-  languages: [go]
-  severity: WARNING
-  message: >-
-    `path.Join(...)` always joins using a forward slash. This may cause
-    issues on Windows or other systems using a different delimiter. Use
-    `filepath.Join(...)` instead which uses OS-specific path separators.
-  pattern: path.Join(...)
-  metadata:
-    category: correctness
-    references:
-    - https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
-    - https://go.dev/src/path/path.go?s=4034:4066#L145
-    technology:
-    - go
+  - id: use-filepath-join-copy
+    languages:
+      - go
+    severity: WARNING
+    message: "`path.Join(...)` always joins using a forward slash. This may cause
+      issues on Windows or other systems using a different delimiter. Use
+      `filepath.Join(...)` instead which uses OS-specific path separators."
+    patterns:
+      - pattern: path.Join(...)
+      - pattern-not-inside: |
+          $URL, $ERR := url. ... .$ANTYHING(...)
+          ...
+          $URL = <... path.Join(...) ...>
+      - pattern-not-inside: |
+          $URL, $ERR := url. ... .$ANTYHING(...)
+          ...
+          path.Join(...,<... $URL ...>,...)
+      - pattern-not-inside: |
+          $URL, $ERR := url. ... .$ANTYHING(...)
+          ...
+          path.Join(...,<... $URL ...>,...)
+      - pattern-not-inside: |
+          path.Join(...,<... ($REQ *http.Request) ...>,...)
+      - pattern-not-inside: |
+          path.Join(...,<... ($RES *http.Response) ...>,...)
+      - pattern-not-inside: |
+          path.Join(...,<... route. ... .$ANYTHING(...) ...>,...)
+      - pattern-not-inside: |
+          path.Join(...,<... http. ... .$ANYTHING(...) ...>,...)
+      - pattern-not-inside: |
+          path.Join(...,<... http. ... .$ANYTHING ...>,...)
+      - pattern-not-inside: |
+          http.$ANYTHING(...,<... path.Join(...) ...>,...)
+      - pattern-not-inside: |
+          func ($L $ANTYHING) $R(...) *http.Request {
+            ...
+            path.Join(...)
+          }
+      - pattern-not-inside: |
+          func (...) *http.Request {
+            ...
+            path.Join(...)
+          }
+      - pattern-not-inside: |
+          func $SOMETHING(...) *http.Request {
+            ...
+            path.Join(...)
+          }
+      - pattern-not-inside: |
+          func ($L $ANTYHING) $R(...) *url.URL {
+            ...
+            path.Join(...)
+          }
+      - pattern-not-inside: |
+          func $SOMETHING(...) *url.URL {
+            ...
+            path.Join(...)
+          }
+      - pattern-not-inside: |
+          func (...) *url.URL {
+            ...
+            path.Join(...)
+          }
+    metadata:
+      category: correctness
+      references:
+        - https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
+        - https://go.dev/src/path/path.go?s=4034:4066#L145
+      technology:
+        - go
+      likelihood: LOW
+      impact: HIGH
+      confidence: LOW
+      subcategory:
+        - audit
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+


### PR DESCRIPTION
Updates the rule to be less noisy, w.r.t https://github.com/returntocorp/semgrep-rules/issues/2426