### PR TITLE
Update missing-integrity rule to handle newlines properly

### DIFF
--- a/html/security/audit/missing-integrity.html
+++ b/html/security/audit/missing-integrity.html
@@ -20,9 +20,10 @@
     <!-- ruleid: missing-integrity -->
     <link rel="stylesheet" href="https://somewhere-external.com/something-external.css">
     <!-- ok: missing-integrity -->
-    <link href="https://somewhere-external.com/something-external.css" rel="stylesheet" integrity="sha512-blahblah">
+    <link href="https://somewhere-external.com/something-external.css" rel="stylesheet"
+        integrity="sha512-blahblah">
     <!-- ok: missing-integrity -->
-    <link rel="stylesheet" type="text/css" href="./something-internal.css">
+    <link rel="stylesheet" type="text/css" href="./something-internal.css" />
     <!-- ok: missing-integrity -->
     <script src="https://www.googletagmanager.com/gtag/js?id=GA_TRACKING_ID"></script>
     <!-- ok: missing-integrity -->

--- a/html/security/audit/missing-integrity.yaml
+++ b/html/security/audit/missing-integrity.yaml
@@ -18,7 +18,7 @@ rules:
   patterns:
   - pattern-either:
     - pattern: <script $...A >...</script>
-    - pattern: <link $...A>
+    - pattern: <link $...A >
   - metavariable-pattern:
       metavariable: $...A
       patterns:
@@ -31,7 +31,7 @@ rules:
           - pattern: src="//..."
           - pattern: href='//...'
           - pattern: href="//..."
-        - pattern-not-regex: (.*integrity=)
+        - pattern-not-regex: (?is).*integrity=
         - pattern-not-regex: (google-analytics.com|fonts.googleapis.com|googletagmanager.com)
   paths:
     include:


### PR DESCRIPTION
Update missing-integrity rule to handle HTML tags with newlines properly to reduce false positives.