### PR TITLE
Fixing cookie-missing-samesite flagging 'null'

### DIFF
--- a/java/lang/security/audit/cookie-missing-samesite.java
+++ b/java/lang/security/audit/cookie-missing-samesite.java
@@ -28,4 +28,10 @@ public class CookieController {
         response.setHeader("Set-Cookie", "key=value; HttpOnly; Secure; SameSite=strict");
         response.addCookie(cookie);
     }
+
+    @RequestMapping(value = "/cookie4", method = "GET")
+    public void setEverything(@RequestParam String value, HttpServletResponse response) {
+        // ok:cookie-missing-samesite
+        response.setHeader("Set-Cookie", null);
+    }
 }

--- a/java/lang/security/audit/cookie-missing-samesite.yaml
+++ b/java/lang/security/audit/cookie-missing-samesite.yaml
@@ -36,3 +36,4 @@ rules:
   - pattern-either:
     - pattern: $RESP.addCookie(...);
     - pattern: $RESP.setHeader("Set-Cookie", ...);
+  - pattern-not: $RESP.setHeader("Set-Cookie", null);


### PR DESCRIPTION
Fix for https://github.com/returntocorp/semgrep-rules/issues/2533