### PR TITLE
adding deep metadata to java rules

### DIFF
--- a/c/lang/security/use-after-free.yaml
+++ b/c/lang/security/use-after-free.yaml
@@ -2,14 +2,16 @@ rules:
 - id: use-after-free
   mode: taint
   pattern-sources:
-    - patterns:
+    - by-side-effect: true
+      patterns:
         - pattern: free($VAR);
         - focus-metavariable: $VAR
   pattern-sinks:
     - pattern: |
         $VAR->$ACCESSOR
   pattern-sanitizers:
-      - patterns:
+      - by-side-effect: true
+        patterns:
         - pattern: |
             $VAR = NULL;
         - focus-metavariable: $VAR  

--- a/java/aws-lambda/security/tainted-sql-string.yaml
+++ b/java/aws-lambda/security/tainted-sql-string.yaml
@@ -27,7 +27,7 @@ rules:
     likelihood: MEDIUM
     impact: HIGH
     confidence: MEDIUM
-    deep: true
+    deepsemgrep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/aws-lambda/security/tainted-sql-string.yaml
+++ b/java/aws-lambda/security/tainted-sql-string.yaml
@@ -27,6 +27,7 @@ rules:
     likelihood: MEDIUM
     impact: HIGH
     confidence: MEDIUM
+    deep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/aws-lambda/security/tainted-sqli.yaml
+++ b/java/aws-lambda/security/tainted-sqli.yaml
@@ -67,4 +67,4 @@ rules:
     likelihood: MEDIUM
     impact: HIGH
     confidence: MEDIUM
-    deep: true
+    deepsemgrep: true

--- a/java/aws-lambda/security/tainted-sqli.yaml
+++ b/java/aws-lambda/security/tainted-sqli.yaml
@@ -67,3 +67,4 @@ rules:
     likelihood: MEDIUM
     impact: HIGH
     confidence: MEDIUM
+    deep: true

--- a/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.yaml
+++ b/java/lang/security/audit/xxe/documentbuilderfactory-disallow-doctype-decl-missing.yaml
@@ -35,7 +35,8 @@ rules:
       "http://xml.org/sax/features/external-parameter-entities" to false.
     mode: taint
     pattern-sources:
-      - patterns:
+      - by-side-effect: true
+        patterns:
           - pattern-either:
               - pattern: |
                   $FACTORY = DocumentBuilderFactory.newInstance();
@@ -88,7 +89,8 @@ rules:
       - patterns:
           - pattern: $FACTORY.newDocumentBuilder();
     pattern-sanitizers:
-      - pattern-either:
+      - by-side-effect: true
+        pattern-either:
           - patterns:
             - pattern-either:
               - pattern: >

--- a/java/spring/security/injection/tainted-file-path.yaml
+++ b/java/spring/security/injection/tainted-file-path.yaml
@@ -23,6 +23,7 @@ rules:
     impact: MEDIUM
     likelihood: MEDIUM
     confidence: MEDIUM
+    deep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/spring/security/injection/tainted-file-path.yaml
+++ b/java/spring/security/injection/tainted-file-path.yaml
@@ -23,7 +23,7 @@ rules:
     impact: MEDIUM
     likelihood: MEDIUM
     confidence: MEDIUM
-    deep: true
+    deepsemgrep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/spring/security/injection/tainted-html-string.yaml
+++ b/java/spring/security/injection/tainted-html-string.yaml
@@ -29,6 +29,7 @@ rules:
     likelihood: HIGH
     impact: MEDIUM
     confidence: MEDIUM
+    deep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/spring/security/injection/tainted-html-string.yaml
+++ b/java/spring/security/injection/tainted-html-string.yaml
@@ -29,7 +29,7 @@ rules:
     likelihood: HIGH
     impact: MEDIUM
     confidence: MEDIUM
-    deep: true
+    deepsemgrep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/spring/security/injection/tainted-sql-string.yaml
+++ b/java/spring/security/injection/tainted-sql-string.yaml
@@ -27,8 +27,8 @@ rules:
     likelihood: HIGH
     impact: MEDIUM
     confidence: MEDIUM
+    deep: true
   mode: taint
-  deep: true
   pattern-sources:
   - patterns:
     - pattern-either:

--- a/java/spring/security/injection/tainted-sql-string.yaml
+++ b/java/spring/security/injection/tainted-sql-string.yaml
@@ -27,7 +27,7 @@ rules:
     likelihood: HIGH
     impact: MEDIUM
     confidence: MEDIUM
-    deep: true
+    deepsemgrep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/spring/security/injection/tainted-sql-string.yaml
+++ b/java/spring/security/injection/tainted-sql-string.yaml
@@ -28,6 +28,7 @@ rules:
     impact: MEDIUM
     confidence: MEDIUM
   mode: taint
+  deep: true
   pattern-sources:
   - patterns:
     - pattern-either:

--- a/java/spring/security/injection/tainted-system-command.yaml
+++ b/java/spring/security/injection/tainted-system-command.yaml
@@ -58,4 +58,4 @@ rules:
     - vuln
     likelihood: HIGH
     impact: MEDIUM
-    deep: true
+    deepsemgrep: true

--- a/java/spring/security/injection/tainted-system-command.yaml
+++ b/java/spring/security/injection/tainted-system-command.yaml
@@ -58,3 +58,4 @@ rules:
     - vuln
     likelihood: HIGH
     impact: MEDIUM
+    deep: true

--- a/java/spring/security/injection/tainted-url-host.yaml
+++ b/java/spring/security/injection/tainted-url-host.yaml
@@ -30,7 +30,7 @@ rules:
     impact: MEDIUM
     likelihood: MEDIUM
     confidence: MEDIUM
-    deep: true
+    deepsemgrep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/java/spring/security/injection/tainted-url-host.yaml
+++ b/java/spring/security/injection/tainted-url-host.yaml
@@ -30,6 +30,7 @@ rules:
     impact: MEDIUM
     likelihood: MEDIUM
     confidence: MEDIUM
+    deep: true
   mode: taint
   pattern-sources:
   - patterns:

--- a/javascript/passport-jwt/security/passport-hardcode.yaml
+++ b/javascript/passport-jwt/security/passport-hardcode.yaml
@@ -36,7 +36,8 @@ rules:
   severity: WARNING
   mode: taint
   pattern-sources:
-  - patterns:
+  - by-side-effect: true
+    patterns:
     - pattern-either:
       - pattern: |
           {..., clientSecret: "...", ...}


### PR DESCRIPTION
Corresponding PR in semgrep rules as part of the project to add a java deepsemgrep rulepack to the registry that can be accessed via `semgrep -f p/deep <target>`. 

Please reference https://github.com/returntocorp/semgrep-rules-proprietary/pull/114 for more context.

What this PR does:
1. Adds the `deep: true` metadata to rules that would work well with deepsemgrep.