### PR TITLE
fixed: change yaml test regex

### DIFF
--- a/rust/lang/security/rustls-dangerous.rs
+++ b/rust/lang/security/rustls-dangerous.rs
@@ -6,7 +6,7 @@ let verifier = MyServerCertVerifie;
 let mut c1 = rustls::client::ClientConfig::new();
 
 // Remove todo when Rust supports direct module references
-// todoruleid: rustls-dangerous
+// ruleid: rustls-dangerous
 let mut c2 = rustls::client::DangerousClientConfig {cfg: &mut cfg};
 c2.set_certificate_verifier(verifier);
 

--- a/yaml/semgrep/slow-pattern-single-metavariable.yaml
+++ b/yaml/semgrep/slow-pattern-single-metavariable.yaml
@@ -19,7 +19,7 @@ rules:
               pattern-not: $PATTERN
       - metavariable-regex:
           metavariable: $PATTERN
-          regex: $[A-Z_]*
+          regex: \$[A-Z_]*
     severity: WARNING
     metadata:
       category: performance


### PR DESCRIPTION
## What:
This test doesn't actually work. The `$` at the beginning is a reserved symbol for end-of-match, and causes the regex to actually match the empty string.

## Why:
This wasn't uncovered before because before, it turns out that any metavariable in a YAML rule which captured the range of a metavariable in a YAML file (like `$FOO`) would actually just capture the empty string. Thus, regex like `$...` will actually match that, and make this test look like it succeeds when it doesn't. Kudos to @emjin for figuring this out.

This PR will fix the rule, and the corresponding change in Semgrep (https://github.com/returntocorp/semgrep/pull/6656) will make it so metavariables capture other metavariables properly, and thus this will produce a finding.

## How:
Changed the regex to properly escape the dollar sign so it's interpreted as a literal.