### PR TITLE
Deduplicate findings for javascript.express.security.injection.tainted-sql-string.tainted-sql-string

### DIFF
--- a/javascript/express/security/injection/tainted-sql-string.yaml
+++ b/javascript/express/security/injection/tainted-sql-string.yaml
@@ -37,13 +37,11 @@ rules:
     - pattern-either:
       - pattern-inside: function ... ($REQ, $RES) {...}
       - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
-      - patterns:
-        - pattern-either:
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})
-        - metavariable-regex:
-            metavariable: $METHOD
-            regex: ^(get|post|put|head|delete|options)$
+      - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
+      - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})
+    - metavariable-regex:
+        metavariable: $METHOD
+        regex: ^(get|post|put|head|delete|options)$
     - pattern-either:
       - pattern: $REQ.query
       - pattern: $REQ.body


### PR DESCRIPTION
Before, this rule reported every finding twice:
![image](https://user-images.githubusercontent.com/3809983/208048840-8b4a244b-a02d-495e-9f8d-11fd5addb394.png)

This fixes that:
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/3809983/208048938-08e0d13e-891d-49a4-b38a-3f7e24aea271.png">
