### PR TITLE
Improvements to SSRF

### DIFF
--- a/javascript/express/security/audit/express-ssrf.ts
+++ b/javascript/express/security/audit/express-ssrf.ts
@@ -7,16 +7,68 @@ module.exports = function badNormal () {
     const url = req.body.imageUrl
     // ruleid: express-ssrf
     request.get(url)
-
-}
-}
-module.exports = function goodNormal () {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const url = 'https://google.com'
+    
     // ok: express-ssrf
-     request.get(url)
-  }
+    request.get(`https://reddit.com/${req.query.url}/fooo`)
+    // ok: express-ssrf
+    request.get("https://google.com/"+req.query.url)
+    // ok: express-ssrf
+    request.get(config_value.foo+req.query.url)
+    // ok: express-ssrf
+    request.get(config_value.foo+req.body.shouldalsonotcatch)
+    // ok: express-ssrf
+    request.get(config_value.foo+req)
 
+    // ruleid: express-ssrf
+    request.get(req.body.url)
+    // ruleid: express-ssrf
+    request.get(`${req.query.url}/fooo`)
+    // ruleid: express-ssrf
+    request.get(req.query.url+config_value.url)
+
+    const a = req.body.url
+    // ruleid: express-ssrf
+    request.get(a)
+    // ruleid: express-ssrf
+    request.get(`${a}/fooo`)
+    // ruleid: express-ssrf
+    request.get(a+config_value.url)
+
+    // ok: express-ssrf
+    request.get(c+a)
+    // ok: express-ssrf
+    request.get(`${c}${a}/fooo`)
+    // ok: express-ssrf
+    request.get(c+a+config_value.url)
+
+    // ok: express-ssrf
+    request.get(c)
+    // ok: express-ssrf
+    request.get(`${c}`)
+    // ok: express-ssrf
+    request.get(c+config_value.url)
+
+    // ruleid: express-ssrf
+    request.get(req.body['url'])
+    // ruleid: express-ssrf
+    request.get(`${req.body['url']}/fooo`)
+    // ruleid: express-ssrf
+    request.get(req.body['url']+config_value.url)
+
+    // ruleid: express-ssrf
+    request.get("https://"+url)
+    // ruleid: express-ssrf
+    request.get(`https://${req.body['url']}/fooo`)
+    // ruleid: express-ssrf
+    request.get("https://"+req.body['url']+config_value.url)
+    // ruleid: express-ssrf
+    request.get("//"+req.body['url']+config_value.url)
+    // ok: express-ssrf
+    request.get("//"+c+req.body['url']+config_value.url)
+    // todo: express-ssrf
+    request.get("https://google.com"+req.query.url)
+
+}
 }
 
 

--- a/javascript/express/security/audit/express-ssrf.ts
+++ b/javascript/express/security/audit/express-ssrf.ts
@@ -4,10 +4,12 @@ const request = require('request')
 
 module.exports = function badNormal () {
   return (req: Request, res: Response, next: NextFunction) => {
-    const url = req.body.imageUrl
+    const url = "//"+req.body.imageUrl
+    const url1 = req.body['imageUrl'] + 123
     // ruleid: express-ssrf
     request.get(url)
-    
+    // ruleid: express-ssrf
+    request.get(url1+123)
     // ok: express-ssrf
     request.get(`https://reddit.com/${req.query.url}/fooo`)
     // ok: express-ssrf
@@ -24,13 +26,13 @@ module.exports = function badNormal () {
     // ruleid: express-ssrf
     request.get(`${req.query.url}/fooo`)
     // ruleid: express-ssrf
-    request.get(req.query.url+config_value.url)
+    request.get("//"+req.query.url+config_value.url)
 
     const a = req.body.url
     // ruleid: express-ssrf
     request.get(a)
     // ruleid: express-ssrf
-    request.get(`${a}/fooo`)
+    request.get(`${url1}/fooo`)
     // ruleid: express-ssrf
     request.get(a+config_value.url)
 
@@ -56,7 +58,7 @@ module.exports = function badNormal () {
     request.get(req.body['url']+config_value.url)
 
     // ruleid: express-ssrf
-    request.get("https://"+url)
+    request.get("https://"+url1)
     // ruleid: express-ssrf
     request.get(`https://${req.body['url']}/fooo`)
     // ruleid: express-ssrf

--- a/javascript/express/security/audit/express-ssrf.yaml
+++ b/javascript/express/security/audit/express-ssrf.yaml
@@ -1,83 +1,168 @@
 rules:
-- id: express-ssrf
-  message: >-
-    The following request $REQ1.$METHOD1($QUERY) was found to be crafted
-    from user-input which can lead to Server-Side Request Forgery (SSRF)
-    vulnerabilities. It is recommended where possible to not allow user-input
-    to craft the base request, but to be treated as part of the path or query
-    parameter. When user-input is necessary to craft the request, it is
-    recommeneded to follow OWASP best practices to prevent abuse. 
-  metadata:
-    deepsemgrep: true
-    references:
-    - https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
-    cwe:
-    - 'CWE-918: Server-Side Request Forgery (SSRF)'
-    technology:
-    - express
-    category: security
-    owasp:
-    - A10:2021 - Server-Side Request Forgery (SSRF)
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - vuln
-    likelihood: MEDIUM
-    impact: HIGH
-    confidence: MEDIUM
-  languages:
-  - javascript
-  - typescript
-  severity: WARNING
-  mode: taint
-  pattern-sources:
-  - patterns:
-    - pattern-either:
-      - pattern-inside: function ... ($REQ, $RES) {...}
-      - pattern-inside: function ... ($REQ, $RES, $NEXT) {...}
+  - id: express-ssrf
+    message: >-
+      The following request $REQUEST.$METHOD() was found to be crafted from
+      user-input `$REQ` which can lead to Server-Side Request Forgery (SSRF)
+      vulnerabilities. It is recommended where possible to not allow user-input
+      to craft the base request, but to be treated as part of the path or query
+      parameter. When user-input is necessary to craft the request, it is
+      recommeneded to follow OWASP best practices to prevent abuse. 
+    metadata:
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html
+      cwe:
+        - "CWE-918: Server-Side Request Forgery (SSRF)"
+      technology:
+        - express
+      category: security
+      owasp:
+        - A10:2021 - Server-Side Request Forgery (SSRF)
+      cwe2022-top25: true
+      cwe2021-top25: true
+      subcategory:
+        - vuln
+      likelihood: MEDIUM
+      impact: HIGH
+      confidence: MEDIUM
+    languages:
+      - javascript
+      - typescript
+    severity: WARNING
+    mode: taint
+    options:
+      taint_unify_mvars: true
+    pattern-sources:
       - patterns:
-        - pattern-either:
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES) {...})
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, $NEXT) {...})
-        - metavariable-regex:
-            metavariable: $METHOD
-            regex: ^(get|post|put|head|delete|options)$
-    - pattern-either:
-      - pattern: $REQ.query
-      - pattern: $REQ.body
-      - pattern: $REQ.params
-      - pattern: $REQ.cookies
-      - pattern: $REQ.headers
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          ({ $REQ }: Request,$RES: Response, $NEXT: NextFunction) =>
-          {...}
-      - pattern-inside: |
-          ({ $REQ }: Request,$RES: Response) => {...}
-    - focus-metavariable: $REQ
-    - pattern-either:
-      - pattern: params
-      - pattern: query
-      - pattern: cookies
-      - pattern: headers
-      - pattern: body
-  pattern-sinks:
-  - pattern-either:
-    - patterns:
-      - pattern-either:
-        - pattern-inside: |
-            $REQ1 = require('request')
-            ...
-        - pattern-inside: |
-            import * as $REQ1 from 'request'
-            ...
-        - pattern-inside: |
-            import $REQ1 from 'request'
-            ...
-      - pattern-either:
-        - pattern-inside: $REQ1.$METHOD1($QUERY)
-      - pattern: $QUERY
-      - metavariable-regex:
-          metavariable: $METHOD1
-          regex: ^(get|post|put|patch|del|head|delete)
+          - pattern-either:
+              - pattern-inside: function ... ($REQ, ...) {...}
+          - pattern-either:
+              - pattern: $REQ.query
+              - pattern: $REQ.body
+              - pattern: $REQ.params
+              - pattern: $REQ.cookies
+              - pattern: $REQ.headers
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  ({ $REQ }: Request,...) =>
+                  {...}
+              - pattern-inside: |
+                  ({ $REQ }: $EXPRESS.Request,...) => {...}
+          - focus-metavariable: $REQ
+          - pattern-either:
+              - pattern: params
+              - pattern: query
+              - pattern: cookies
+              - pattern: headers
+              - pattern: body
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $REQUEST = require('request')
+                  ...
+              - pattern-inside: |
+                  import * as $REQUEST from 'request'
+                  ...
+              - pattern-inside: |
+                  import $REQUEST from 'request'
+                  ...
+          - pattern-either:
+              - pattern: $REQUEST.$METHOD("$HTTP"+$REQ. ... .$VALUE)
+              - pattern: $REQUEST.$METHOD("$HTTP"+$REQ. ... .$VALUE + $...A)
+              - pattern: $REQUEST.$METHOD(`$HTTP${$REQ. ... .$VALUE}...`)
+              - pattern: $REQUEST.$METHOD("$HTTP"+$REQ.$VALUE[...])
+              - pattern: $REQUEST.$METHOD("$HTTP"+$REQ.$VALUE[...] + $...A)
+              - pattern: $REQUEST.$METHOD(`$HTTP${$REQ.$VALUE[...]}...`)
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(get|post|put|patch|del|head|delete)$
+          - metavariable-regex:
+              metavariable: $HTTP
+              regex: ^(https?:\/\/|//)$
+          - pattern-either:
+              - pattern: $REQ. ... .$VALUE
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $REQUEST = require('request')
+                  ...
+              - pattern-inside: |
+                  import * as $REQUEST from 'request'
+                  ...
+              - pattern-inside: |
+                  import $REQUEST from 'request'
+                  ...
+          - pattern-either:
+              - pattern: $REQUEST.$METHOD($REQ. ... .$VALUE,...)
+              - pattern: $REQUEST.$METHOD($REQ. ... .$VALUE + $...A,...)
+              - pattern: $REQUEST.$METHOD(`${$REQ. ... .$VALUE}...`,...)
+          - pattern: $REQ. ... .$VALUE
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(get|post|put|patch|del|head|delete)$
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $REQUEST = require('request')
+                  ...
+              - pattern-inside: |
+                  import * as $REQUEST from 'request'
+                  ...
+              - pattern-inside: |
+                  import $REQUEST from 'request'
+                  ...
+          - pattern-either:
+              - pattern: $REQUEST.$METHOD($REQ.$VALUE['...'],...)
+              - pattern: $REQUEST.$METHOD($REQ.$VALUE['...'] + $...A,...)
+              - pattern: $REQUEST.$METHOD(`${$REQ.$VALUE['...']}...`,...)
+          - pattern: $REQ.$VALUE
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(get|post|put|patch|del|head|delete)$
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $REQUEST = require('request')
+                  ...
+              - pattern-inside: |
+                  import * as $REQUEST from 'request'
+                  ...
+              - pattern-inside: |
+                  import $REQUEST from 'request'
+                  ...
+          - pattern-either:
+              - pattern-inside: |
+                  $ASSIGN = $REQ. ... .$VALUE
+                  ...
+              - pattern-inside: |
+                  $ASSIGN = $REQ.$VALUE['...']
+                  ...
+              - pattern-inside: |
+                  $ASSIGN = $REQ. ... .$VALUE + $...A
+                  ...
+              - pattern-inside: |
+                  $ASSIGN = $REQ.$VALUE['...'] + $...A
+                  ...     
+              - pattern-inside: |
+                  $ASSIGN = `${$REQ. ... .$VALUE}...`
+                  ...
+              - pattern-inside: |
+                  $ASSIGN = `${$REQ.$VALUE['...']}...`
+                  ...                    
+          - pattern-either:
+              - pattern: $REQUEST.$METHOD($ASSIGN,...)
+              - pattern: $REQUEST.$METHOD($ASSIGN + $...FOO,...)
+              - pattern: $REQUEST.$METHOD(`${$ASSIGN}...`,...)
+              - patterns:
+                - pattern-either:
+                  - pattern: $REQUEST.$METHOD("$HTTP"+$ASSIGN,...)
+                  - pattern: $REQUEST.$METHOD("$HTTP"+$ASSIGN + $...A,...)
+                  - pattern: $REQUEST.$METHOD(`$HTTP${$ASSIGN}...`,...)
+                - metavariable-regex:
+                    metavariable: $HTTP
+                    regex: ^(https?:\/\/|//)$
+          - pattern: $ASSIGN
+          - metavariable-regex:
+              metavariable: $METHOD
+              regex: ^(get|post|put|patch|del|head|delete)$

--- a/javascript/express/security/audit/express-ssrf.yaml
+++ b/javascript/express/security/audit/express-ssrf.yaml
@@ -55,6 +55,7 @@ rules:
               - pattern: cookies
               - pattern: headers
               - pattern: body
+    # we have a deepsemgrep rule which will make this 10x smaller.          
     pattern-sinks:
       - patterns:
           - pattern-either:
@@ -67,6 +68,7 @@ rules:
               - pattern-inside: |
                   import $REQUEST from 'request'
                   ...
+          # Direct usage with http:// https:// and //
           - pattern-either:
               - pattern: $REQUEST.$METHOD("$HTTP"+$REQ. ... .$VALUE)
               - pattern: $REQUEST.$METHOD("$HTTP"+$REQ. ... .$VALUE + $...A)
@@ -93,6 +95,7 @@ rules:
               - pattern-inside: |
                   import $REQUEST from 'request'
                   ...
+          # Direct usage with req.body at start
           - pattern-either:
               - pattern: $REQUEST.$METHOD($REQ. ... .$VALUE,...)
               - pattern: $REQUEST.$METHOD($REQ. ... .$VALUE + $...A,...)
@@ -112,6 +115,7 @@ rules:
               - pattern-inside: |
                   import $REQUEST from 'request'
                   ...
+          # Direct usage with req.body['value'] at start
           - pattern-either:
               - pattern: $REQUEST.$METHOD($REQ.$VALUE['...'],...)
               - pattern: $REQUEST.$METHOD($REQ.$VALUE['...'] + $...A,...)
@@ -131,37 +135,59 @@ rules:
               - pattern-inside: |
                   import $REQUEST from 'request'
                   ...
+          # Direct usage with req.body from assign
           - pattern-either:
               - pattern-inside: |
                   $ASSIGN = $REQ. ... .$VALUE
                   ...
               - pattern-inside: |
-                  $ASSIGN = $REQ.$VALUE['...']
+                  $ASSIGN = $REQ. ... .$VALUE['...']
                   ...
               - pattern-inside: |
                   $ASSIGN = $REQ. ... .$VALUE + $...A
                   ...
               - pattern-inside: |
-                  $ASSIGN = $REQ.$VALUE['...'] + $...A
+                  $ASSIGN = $REQ. ... .$VALUE['...'] + $...A
                   ...     
               - pattern-inside: |
                   $ASSIGN = `${$REQ. ... .$VALUE}...`
                   ...
               - pattern-inside: |
-                  $ASSIGN = `${$REQ.$VALUE['...']}...`
-                  ...                    
+                  $ASSIGN = `${$REQ. ... .$VALUE['...']}...`
+                  ... 
+              # Direct usage with req.body with http|https|// from assign
+              - patterns:
+                - pattern-either:
+                    - pattern-inside: |
+                            $ASSIGN = "$HTTP"+ $REQ. ... .$VALUE
+                            ...
+                    - pattern-inside: |
+                            $ASSIGN = "$HTTP"+$REQ. ... .$VALUE + $...A
+                            ...
+                    - pattern-inside: |
+                            $ASSIGN = "$HTTP"+$REQ.$VALUE[...]
+                            ...
+                    - pattern-inside: |
+                            $ASSIGN = "$HTTP"+$REQ.$VALUE[...] + $...A
+                            ...
+                    - pattern-inside: |
+                            $ASSIGN = `$HTTP${$REQ.$VALUE[...]}...`
+                            ...
+                - metavariable-regex:
+                    metavariable: $HTTP
+                    regex: ^(https?:\/\/|//)$                   
           - pattern-either:
               - pattern: $REQUEST.$METHOD($ASSIGN,...)
               - pattern: $REQUEST.$METHOD($ASSIGN + $...FOO,...)
               - pattern: $REQUEST.$METHOD(`${$ASSIGN}...`,...)
               - patterns:
-                - pattern-either:
-                  - pattern: $REQUEST.$METHOD("$HTTP"+$ASSIGN,...)
-                  - pattern: $REQUEST.$METHOD("$HTTP"+$ASSIGN + $...A,...)
-                  - pattern: $REQUEST.$METHOD(`$HTTP${$ASSIGN}...`,...)
-                - metavariable-regex:
-                    metavariable: $HTTP
-                    regex: ^(https?:\/\/|//)$
+                  - pattern-either:
+                      - pattern: $REQUEST.$METHOD("$HTTP"+$ASSIGN,...)
+                      - pattern: $REQUEST.$METHOD("$HTTP"+$ASSIGN + $...A,...)
+                      - pattern: $REQUEST.$METHOD(`$HTTP${$ASSIGN}...`,...)
+                  - metavariable-regex:
+                      metavariable: $HTTP
+                      regex: ^(https?:\/\/|//)$
           - pattern: $ASSIGN
           - metavariable-regex:
               metavariable: $METHOD


### PR DESCRIPTION
Existing rule has a lot of false positives since it can be anywhere within the request, even a query parameter.

This rule leverages `taint_unify_mvars` to ensure the source enters the sink in the correct location, which works well for OSS Semgrep. 

Expanded examples to verify improvement 