### PR TITLE
adding spring command injection rule improvements

### DIFF
--- a/java/spring/security/injection/tainted-system-command.java
+++ b/java/spring/security/injection/tainted-system-command.java
@@ -222,8 +222,8 @@ public class CommandInjection {
     public static void test1(@RequestParam(IP_ADDRESS) String ipAddress) {
         String args = "ping -c 2 " + ipAddress + "test";
         Process process;
-        // ruleid: tainted-system-command
         process = new ProcessBuilder(new String[] {"sh", "-c", args});
+        // ruleid: tainted-system-command
         process.start();
     }
 

--- a/java/spring/security/injection/tainted-system-command.java
+++ b/java/spring/security/injection/tainted-system-command.java
@@ -73,14 +73,14 @@ public class CommandInjection {
         if (isValid) {
             Process process;
             if (!isWindows) {
+                // ruleid: tainted-system-command
                 process =
-                        // ruleid: tainted-system-command
                         new ProcessBuilder(new String[] {"sh", "-c", "ping -c 2 " + ipAddress})
                                 .redirectErrorStream(true)
                                 .start();
             } else {
+                // ruleid: tainted-system-command
                 process =
-                        // ruleid: tainted-system-command
                         new ProcessBuilder(new String[] {"cmd", "/c", "ping -n 2 " + ipAddress})
                                 .redirectErrorStream(true)
                                 .start();
@@ -217,5 +217,47 @@ public class CommandInjection {
                         this.getResponseFromPingCommand(ipAddress, validator.get()).toString(),
                         true),
                 HttpStatus.OK);
+    }
+
+    public static void test1(@RequestParam(IP_ADDRESS) String ipAddress) {
+        String args = "ping -c 2 " + ipAddress + "test";
+        Process process;
+        // ruleid: tainted-system-command
+        process = new ProcessBuilder(new String[] {"sh", "-c", args});
+        process.start();
+    }
+
+    public static void test2(@RequestParam String input) {
+        String latlonCoords = input;
+        Runtime rt = Runtime.getRuntime();
+        // ok: tainted-system-command
+        Process exec = rt.exec(new String[] {
+                "c:\\path\to\latlon2utm.exe",
+                latlonCoords }); // safe bc args are seperated
+    }
+
+    public static void test3(@RequestParam String input) {
+        StringBuilder stringBuilder = new StringBuilder(100);
+        stringBuilder.append(input);
+        stringBuilder.append("test2");
+        Runtime rt = Runtime.getRuntime();
+        // ruleid: tainted-system-command
+        Process exec = rt.exec(stringBuilder);
+    }
+
+    public static void test4(@RequestParam String input) {
+        String test1 = "test";
+        String comb = test1.concat(input);
+        Runtime rt = Runtime.getRuntime();
+        // ruleid: tainted-system-command
+        Process exec = rt.exec(comb);
+    }
+
+    public static void test5(@RequestParam String input) {
+        String test1 = "test";
+        String comb = String.format("%s%s", test1, input);
+        Runtime rt = Runtime.getRuntime();
+        // ruleid: tainted-system-command
+        Process exec = rt.exec(comb);
     }
 }

--- a/java/spring/security/injection/tainted-system-command.yaml
+++ b/java/spring/security/injection/tainted-system-command.yaml
@@ -41,8 +41,6 @@ rules:
   - patterns:
     - pattern-either:
       - pattern: |
-          (ProcessBuilder $PB) = new ProcessBuilder(...);
-      - pattern: |
           (Process $P) = new Process(...);
       - pattern: |
           (ProcessBuilder $PB).command(...);

--- a/java/spring/security/injection/tainted-system-command.yaml
+++ b/java/spring/security/injection/tainted-system-command.yaml
@@ -4,6 +4,10 @@ rules:
   - java
   severity: ERROR
   mode: taint
+  pattern-propagators:
+  - pattern: (StringBuilder $STRB).append($INPUT)
+    from: $INPUT
+    to: $STRB
   pattern-sources:
   - patterns:
     - pattern-either:
@@ -17,18 +21,55 @@ rules:
           }
     - metavariable-regex:
         metavariable: $REQ
-        regex: (RequestBody|PathVariable|RequestParam|RequestHeader|CookieValue)
+        regex: (RequestBody|PathVariable|RequestParam|RequestHeader|CookieValue|ModelAttribute)
     - pattern: $SOURCE
+    label: INPUT
+  - patterns:
+    - pattern-either:
+      - pattern: $X + $SOURCE
+      - pattern: $SOURCE + $Y
+      - pattern: (StringBuilder $STRB).append($SOURCE)
+      - pattern: String.format("...", ..., $SOURCE, ...)
+      - pattern: String.join("...", ..., $SOURCE, ...)
+      - pattern: (String $STR).concat($SOURCE)
+      - pattern: $SOURCE.concat(...)
+      - pattern: $X += SOURCE
+      - pattern: $SOURCE += $X
+    label: CONCAT
+    requires: INPUT
   pattern-sinks:
-  - pattern-either:
-    - pattern: (Runtime $RUNTIME).exec(...)
-    - pattern: (Runtime $RUNTIME).loadLibrary(...)
-    - pattern: Runtime.getRuntime(...).exec(...)
-    - pattern: Runtime.getRuntime(...).loadLibrary(...)
-    - pattern: new ProcessBuilder($ONEARG)
-    - patterns:
-      - pattern: new ProcessBuilder(...)
-      - pattern-not: new ProcessBuilder("...", ...)
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          (ProcessBuilder $PB) = new ProcessBuilder(...);
+      - pattern: |
+          (Process $P) = new Process(...);
+      - pattern: |
+          (ProcessBuilder $PB).command(...);
+      - patterns:
+        - pattern-either:
+          - pattern: |
+              (Runtime $R).$EXEC(...);
+          - pattern: |
+               Runtime.getRuntime(...).$EXEC(...);
+        - metavariable-regex:
+            metavariable: $EXEC
+            regex: (exec|loadLibrary|load)
+      - patterns:
+        - pattern: |
+            (ProcessBuilder $PB).command(...).$ADD(...);
+        - metavariable-regex:
+            metavariable: $ADD
+            regex: (add|addAll)
+      - patterns:
+        - pattern-either:
+          - pattern: |
+              $BUILDER = new ProcessBuilder(...);
+              ...
+              $BUILDER.start(...);
+          - pattern: |
+              new ProcessBuilder(...). ... .start(...);
+    requires: CONCAT
   message: >-
     Detected user input entering a method which executes a system command.
     This could result in a command injection vulnerability, which allows an
@@ -51,7 +92,7 @@ rules:
     references:
     - https://www.stackhawk.com/blog/command-injection-java/
     - https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html
-
+    - https://github.com/github/codeql/blob/main/java/ql/src/Security/CWE/CWE-078/ExecUnescaped.java
     cwe2022-top25: true
     cwe2021-top25: true
     subcategory:

--- a/java/spring/security/injection/tainted-system-command.yaml
+++ b/java/spring/security/injection/tainted-system-command.yaml
@@ -63,10 +63,11 @@ rules:
             regex: (add|addAll)
       - patterns:
         - pattern-either:
-          - pattern: |
-              $BUILDER = new ProcessBuilder(...);
-              ...
-              $BUILDER.start(...);
+          - patterns:
+            - pattern-inside: |
+                $BUILDER = new ProcessBuilder(...);
+                ...
+            - pattern: $BUILDER.start(...)
           - pattern: |
               new ProcessBuilder(...). ... .start(...);
     requires: CONCAT
@@ -98,5 +99,5 @@ rules:
     subcategory:
     - vuln
     likelihood: HIGH
-    impact: MEDIUM
+    impact: HIGH
     deepsemgrep: true


### PR DESCRIPTION
Improvements to the spring command injection rule (adding taint labels, more sinks). This will reduce false positives. 

_To Test:_
Run `semgrep --test .` on the spring injection folder.