### PR TITLE
Handle Pod Security Context

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,31 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0
     hooks:
-      - id: check-yaml
-        exclude: semgrep-github-action-push-without-branches.test.yml
       - id: check-case-conflict
       - id: check-added-large-files
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: check-symlinks
+  # Normal case - single document YAML only
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-yaml
+        exclude: |
+          (?x)^(
+            # These are multi-document
+            semgrep-github-action-push-without-branches\.test\.yml|
+            yaml/kubernetes/security/.*\.test\.yaml
+          )$
+  # Exception case - multi-document YAML OK - still check YAML
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.5.0
+    hooks:
+      - id: check-yaml
+        args: [--allow-multiple-documents]
+        files: |
+          (?x)^(
+            # These are multi-document
+            semgrep-github-action-push-without-branches\.test\.yml|
+            yaml/kubernetes/security/.*\.test\.yaml
+          )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         exclude: |
           (?x)^(
             # These are multi-document
-            semgrep-github-action-push-without-branches\.test\.yml|
+            yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches\.test\.yml|
             yaml/kubernetes/security/.*\.test\.yaml
           )$
   # Exception case - multi-document YAML OK - still check YAML
@@ -27,6 +27,6 @@ repos:
         files: |
           (?x)^(
             # These are multi-document
-            semgrep-github-action-push-without-branches\.test\.yml|
+            yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches\.test\.yml|
             yaml/kubernetes/security/.*\.test\.yaml
           )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     rev: v2.5.0
     hooks:
       - id: check-yaml
-        name:  Check Yaml (Multi-documents)
+        name: Check Yaml (Multi-documents)
         args: [--allow-multiple-documents]
         files: |
           (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
     rev: v2.5.0
     hooks:
       - id: check-yaml
+        name:  Check Yaml (Multi-documents)
         args: [--allow-multiple-documents]
         files: |
           (?x)^(

--- a/yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches.test.yml
+++ b/yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches.test.yml
@@ -1,3 +1,4 @@
+---
 on:
   pull_request: {}
   push:
@@ -16,6 +17,7 @@ jobs:
         publishToken: abc
 
 
+---
 on:
   pull_request: {}
   push:

--- a/yaml/kubernetes/security/run-as-non-root-unsafe-value.test.yaml
+++ b/yaml/kubernetes/security/run-as-non-root-unsafe-value.test.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 spec:
@@ -12,3 +13,33 @@ spec:
       image: haproxy
       securityContext:
         runAsNonRoot: true
+---
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    # ruleid: run-as-non-root-unsafe-value
+    runAsNonRoot: false
+  containers:
+    - name: redis
+      image: redis
+    # ok: run-as-non-root-unsafe-value
+    - name: haproxy
+      image: haproxy
+      securityContext:
+        runAsNonRoot: true
+---
+apiVersion: v1
+kind: Pod
+spec:
+  securityContext:
+    # ok: run-as-non-root-unsafe-value
+    runAsNonRoot: true
+  containers:
+    - name: redis
+      image: redis
+    - name: haproxy
+      image: haproxy
+      securityContext:
+        # ruleid: run-as-non-root-unsafe-value
+        runAsNonRoot: false

--- a/yaml/kubernetes/security/run-as-non-root-unsafe-value.yaml
+++ b/yaml/kubernetes/security/run-as-non-root-unsafe-value.yaml
@@ -1,15 +1,25 @@
 rules:
 - id: run-as-non-root-unsafe-value
   patterns:
-  - pattern-inside: |
-      containers:
-        ...
-  - pattern: |
-      image: ...
-      ...
-      securityContext:
-        ...
-        runAsNonRoot: $VALUE
+  - pattern-either:
+      # Pod Security Context
+      - pattern: |
+          spec:
+            ...
+            securityContext:
+              ...
+              runAsNonRoot: $VALUE
+      # Container Security Context
+      - patterns:
+          - pattern-inside: |
+              containers:
+                ...
+          - pattern: |
+              image: ...
+              ...
+              securityContext:
+                ...
+                runAsNonRoot: $VALUE
   - pattern: |
       $VALUE
   - pattern: |

--- a/yaml/kubernetes/security/run-as-non-root.test.yaml
+++ b/yaml/kubernetes/security/run-as-non-root.test.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Pod
 spec:
@@ -17,3 +18,21 @@ spec:
       image: haproxy
       securityContext:
         runAsNonRoot: true
+---
+apiVersion: v1
+kind: Pod
+spec:
+  # ok: run-as-non-root
+  securityContext:
+    runAsNonRoot: true
+  containers:
+    - name: nginx
+      image: nginx
+    - name: postgres
+      image: postgres
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
+    - name: haproxy
+      image: haproxy

--- a/yaml/kubernetes/security/run-as-non-root.yaml
+++ b/yaml/kubernetes/security/run-as-non-root.yaml
@@ -1,6 +1,17 @@
 rules:
 - id: run-as-non-root
   patterns:
+  # Pod Security Context
+  - pattern-not-inside: |
+      spec:
+        ...
+        securityContext:
+          ...
+          runAsNonRoot: $VALUE
+        ...
+        containers:
+          ...
+  # Container Security Context
   - pattern-inside: |
       containers:
         ...


### PR DESCRIPTION
- Original rule only considered security context at container level, but security context can be applied at pod level as well.
- Updated the rules to handle both levels. This reduces false positives.
- Kubernetes gives precedence to container security context, test file includes positive/negative cases where both pod and container security context exist.