### PR TITLE
Path traversal rule edits

### DIFF
--- a/java/spring/security/injection/tainted-file-path.java
+++ b/java/spring/security/injection/tainted-file-path.java
@@ -13,6 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.core.io.Resource;
 
 /**
  * Preflight is the request which is executed to download the uploaded file. This controller is made
@@ -44,5 +47,28 @@ public class PreflightController {
         httpHeaders.add(HttpHeaders.CONTENT_DISPOSITION, "attachment");
         return new ResponseEntity<byte[]>(
                 IOUtils.toByteArray(inputStream), httpHeaders, HttpStatus.OK);
+    }
+
+    public static void test2(@RequestParam String filename)
+    {
+    	ApplicationContext appContext = 
+    	   new ClassPathXmlApplicationContext(new String[] {"If-you-have-any.xml"});
+
+    	Resource resource = 
+           appContext.getResource("classpath:com/" + filename);
+                
+        try {
+           InputStream is = resource.getInputStream();
+           BufferedReader br = new BufferedReader(new InputStreamReader(is));
+                
+           String line;
+           while ((line = br.readLine()) != null) {
+              System.out.println(line);
+           } 
+           br.close();
+                
+        } catch(IOException e){
+           e.printStackTrace();
+        }
     }
 }

--- a/java/spring/security/injection/tainted-file-path.yaml
+++ b/java/spring/security/injection/tainted-file-path.yaml
@@ -3,7 +3,8 @@ rules:
   languages:
   - java
   severity: ERROR
-  message: Detected user input controlling a file path. An attacker could control the location of this
+  message: >-
+    Detected user input controlling a file path. An attacker could control the location of this
     file, to include going backwards in the directory with '../'. To address this, ensure that user-controlled
     variables in file paths are sanitized. You may also consider using a utility method such as org.apache.commons.io.FilenameUtils.getName(...)
     to only retrieve the file name from the path.
@@ -20,9 +21,9 @@ rules:
     - spring
     subcategory:
     - vuln
-    impact: MEDIUM
+    impact: HIGH
     likelihood: MEDIUM
-    confidence: MEDIUM
+    confidence: HIGH
     deepsemgrep: true
   mode: taint
   pattern-sources:
@@ -38,15 +39,31 @@ rules:
           }
     - metavariable-regex:
         metavariable: $REQ
-        regex: (RequestBody|PathVariable|RequestParam|RequestHeader|CookieValue)
+        regex: (RequestBody|PathVariable|RequestParam|RequestHeader|CookieValue|ModelAttribute)
     - pattern: $SOURCE
   pattern-sinks:
-  - pattern-either:
+  - patterns:
     - pattern-either:
-      - pattern: new FileInputStream(...)
-      - pattern: new java.io.FileInputStream(...)
-      - pattern: new FileReader(...)
-      - pattern: new java.io.FileReader(...)
       - pattern: new File(...)
       - pattern: new java.io.File(...)
-      - pattern: $SOMETHING.getResourceAsStream(...)
+      - pattern: new FileReader(...)
+      - pattern: new java.io.FileReader(...)
+      - pattern: new FileInputStream(...)
+      - pattern: new java.io.FileInputStream(...)
+      - pattern: (Paths $PATHS).get(...)
+      - patterns:
+        - pattern: |
+            $CXT.$FUNC(...)
+        - metavariable-regex:
+            metavariable: $FUNC
+            regex: ^(getResourceAsStream|getResource)$
+      - patterns:
+        - pattern-either:
+          - pattern: new FileOutputStream($FILE, ...)
+          - pattern: new java.io.FileOutputStream($FILE, ...)
+          - pattern: new StreamSource($FILE, ...)
+          - pattern: new javax.xml.transform.StreamSource($FILE, ...)
+          - pattern: FileUtils.openOutputStream($FILE, ...)
+        - focus-metavariable: $FILE
+  pattern-sanitizers:
+  - pattern: org.apache.commons.io.FilenameUtils.getName(...)

--- a/java/spring/security/injection/tainted-file-path.yaml
+++ b/java/spring/security/injection/tainted-file-path.yaml
@@ -53,12 +53,14 @@ rules:
       - pattern: (Paths $PATHS).get(...)
       - patterns:
         - pattern: |
-            $CXT.$FUNC(...)
+            $CLASS.$FUNC(...)
         - metavariable-regex:
             metavariable: $FUNC
             regex: ^(getResourceAsStream|getResource)$
       - patterns:
         - pattern-either:
+          - pattern: new ClassPathResource($FILE, ...)
+          - pattern: ResourceUtils.getFile($FILE, ...)
           - pattern: new FileOutputStream($FILE, ...)
           - pattern: new java.io.FileOutputStream($FILE, ...)
           - pattern: new StreamSource($FILE, ...)


### PR DESCRIPTION
This change:
* Adds more sinks to the spring path-traversal rule and adds focus-metavariable to functions that can have 1+ args
* Adds a sanitizer
* Adds one more source annotation to the rule

To test:
Run `semgrep --test .` on the injection dir
