### PR TITLE
Updated 'ec2-imdsv1-optional' test to ensure default value isn't set

### DIFF
--- a/terraform/lang/security/ec2-imdsv1-optional.tf
+++ b/terraform/lang/security/ec2-imdsv1-optional.tf
@@ -1,16 +1,47 @@
-resource "aws_instance" "test-instance-bad" {
+resource "aws_instance" "test-instance-bad-http-tokens-optional" {
   ami = "ami-0d5eff06f840b45e9"
+
   metadata_options {
     http_endpoint = "enabled"
     # ruleid: ec2-imdsv1-optional
     http_tokens = "optional"
   }
 }
+
+# ruleid: ec2-imdsv1-optional
+resource "aws_instance" "test-instance-bad-no-metadata-options" {
+  ami = "ami-0d5eff06f840b45e9"
+}
+
+# ruleid: ec2-imdsv1-optional
+resource "aws_instance" "test-instance-bad-v3-http-tokens-default-optional" {
+  ami = "ami-0d5eff06f840b45e9"
+  metadata_options {
+    http_endpoint = "enabled"
+  }
+}
+
+resource "aws_instance" "test-instance-bad-http-tokens-optional-v2" {
+  ami = "ami-0d5eff06f840b45e9"
+  metadata_options {
+    # ruleid: ec2-imdsv1-optional
+    http_tokens = "optional"
+  }
+}
+
+# ruleid: ec2-imdsv1-optional
+resource "aws_instance" "test-instance-bad-all-default-values" {
+  ami = "ami-0d5eff06f840b45e9"
+  metadata_options {
+    instance_metadata_tags = "enabled"
+  }
+}
+
+# ok: ec2-imdsv1-optional
 resource "aws_instance" "test-instance-good" {
   ami = "ami-0d5eff06f840b45e9"
   metadata_options {
     http_endpoint = "enabled"
-    # ok: ec2-imdsv1-optional
     http_tokens = "required"
   }
 }

--- a/terraform/lang/security/ec2-imdsv1-optional.yaml
+++ b/terraform/lang/security/ec2-imdsv1-optional.yaml
@@ -23,8 +23,46 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: MEDIUM
-  patterns:
-  - pattern: http_tokens = "optional"
-  - pattern-inside: |
-      metadata_options { ... }
+  pattern-either:
+    # Legacy rule for backwards compatibility
+    - patterns:
+      - pattern: http_tokens = "optional"
+      - pattern-inside: |
+          metadata_options { ... }
+    - patterns:
+      - pattern: |
+          resource "aws_instance" "$NAME" {
+            ...
+          }
+      - pattern-not: |
+          resource "aws_instance" "$NAME" {
+            ...
+            metadata_options {
+              ...
+              http_tokens = "required"
+              ...
+            }
+            ...
+          }
+      # Don't match previous legacy rule
+      - pattern-not: |
+          resource "aws_instance" "$NAME" {
+            ...
+            metadata_options {
+              ...
+              http_tokens = "optional"
+              ...
+            }
+            ...
+          }
+      - pattern-not: |
+          resource "aws_instance" "$NAME" {
+            ...
+            metadata_options {
+              ...
+              http_endpoint = "disabled"
+              ...
+            }
+            ...
+          }
   severity: ERROR


### PR DESCRIPTION
The `ec2-imdsv1-optional` test ensures that the `http_tokens` value is not `optional` in the `metadata_options` block. However, by default this value is set to `optional`, so we also have to check for cases when it isn't explicitly defined. See the [Terraform Docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#http_tokens) for more information.