### PR TITLE
Update React Sources for Semgrep Open Source

### DIFF
--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
@@ -7,12 +7,13 @@ function TestComponent1() {
 }
 
 function TestComponent2(foo) {
-    // ok:react-dangerouslysetinnerhtml
+    // ruleid:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo.bar}};
     return React.createElement('div', params);
 }
 export default function AdDisplay(props) {
   const { ad, className, shape = 'auto' } = props;
+    // ruleid:react-dangerouslysetinnerhtml
     let f = {smth: 'test123', dangerouslySetInnerHTML: {__html: props.bar}}
 }
 

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
@@ -7,9 +7,13 @@ function TestComponent1() {
 }
 
 function TestComponent2(foo) {
-    // ruleid:react-dangerouslysetinnerhtml
-    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo.bar},a:b};
+    // ok:react-dangerouslysetinnerhtml
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo.bar}};
     return React.createElement('div', params);
+}
+export default function AdDisplay(props) {
+  const { ad, className, shape = 'auto' } = props;
+    let f = {smth: 'test123', dangerouslySetInnerHTML: {__html: props.bar}}
 }
 
 function TestComponent3() {
@@ -24,11 +28,16 @@ function OkComponent1() {
 }
 
 
+export default function AdDisplay(props) {
+  const { ad, className, shape = 'auto' } = props;
 
-function OkComponent2() {
-    // ok:react-dangerouslysetinnerhtml
-  return <li className={"foobar"} dangerouslySetInnerHTML={DOMPurify.sanitize(createMarkup())} />;
+  return (
+    // ok: react-dangerouslysetinnerhtml
+    <Root dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(props.description) }}>
+    </Root>
+  );
 }
+
 
 function OkComponent3() {
     // ok:react-dangerouslysetinnerhtml
@@ -52,3 +61,15 @@ function OkComponent6() {
     let params = {smth: "test123", style: {color: 'red'}};
     return React.createElement('div', params);
 }
+
+export default function AdDisplay(props) {
+  const { ad, className, shape = 'auto' } = props;
+
+  return (
+    // ruleid: react-dangerouslysetinnerhtml
+    <Root dangerouslySetInnerHTML={{ __html: props.description }}>
+    </Root>
+  );
+}
+
+

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -7,12 +7,13 @@ function TestComponent1() {
 }
 
 function TestComponent2(foo) {
-    // ok:react-dangerouslysetinnerhtml
+    // ruleid:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo.bar}};
     return React.createElement('div', params);
 }
 export default function AdDisplay(props) {
   const { ad, className, shape = 'auto' } = props;
+    // ruleid:react-dangerouslysetinnerhtml
     let f = {smth: 'test123', dangerouslySetInnerHTML: {__html: props.bar}}
 }
 

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -8,8 +8,12 @@ function TestComponent1() {
 
 function TestComponent2(foo) {
     // ruleid:react-dangerouslysetinnerhtml
-    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo.bar},a:b};
+    let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo.bar}};
     return React.createElement('div', params);
+}
+export default function AdDisplay(props) {
+  const { ad, className, shape = 'auto' } = props;
+    let f = {smth: 'test123', dangerouslySetInnerHTML: {__html: props.bar}}
 }
 
 function TestComponent3() {
@@ -24,11 +28,16 @@ function OkComponent1() {
 }
 
 
+export default function AdDisplay(props) {
+  const { ad, className, shape = 'auto' } = props;
 
-function OkComponent2() {
-    // ok:react-dangerouslysetinnerhtml
-  return <li className={"foobar"} dangerouslySetInnerHTML={DOMPurify.sanitize(createMarkup())} />;
+  return (
+    // ok: react-dangerouslysetinnerhtml
+    <Root dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(props.description) }}>
+    </Root>
+  );
 }
+
 
 function OkComponent3() {
     // ok:react-dangerouslysetinnerhtml
@@ -52,3 +61,15 @@ function OkComponent6() {
     let params = {smth: "test123", style: {color: 'red'}};
     return React.createElement('div', params);
 }
+
+export default function AdDisplay(props) {
+  const { ad, className, shape = 'auto' } = props;
+
+  return (
+    // ruleid: react-dangerouslysetinnerhtml
+    <Root dangerouslySetInnerHTML={{ __html: props.description }}>
+    </Root>
+  );
+}
+
+

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -7,7 +7,7 @@ function TestComponent1() {
 }
 
 function TestComponent2(foo) {
-    // ruleid:react-dangerouslysetinnerhtml
+    // ok:react-dangerouslysetinnerhtml
     let params = {smth: 'test123', dangerouslySetInnerHTML: {__html: foo.bar}};
     return React.createElement('div', params);
 }

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -32,13 +32,13 @@ rules:
     severity: WARNING
     mode: taint
     pattern-sources:
-      - patterns:
+     - patterns:
         - pattern-not-inside: |
             import $C from "..."
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            import * as $X from "..."
+            import * as $C from "..."
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
@@ -46,7 +46,7 @@ rules:
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            $X = require("...")
+            $C = require("...")
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
@@ -66,7 +66,7 @@ rules:
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$X,...} = require("...").$F
+            const {...,$C,...} = require("...").$F
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -1,6 +1,7 @@
 rules:
   - id: react-dangerouslysetinnerhtml
-    message: Detection of dangerouslySetInnerHTML from non-constant definition. This
+    message: >-
+      Detection of dangerouslySetInnerHTML from non-constant definition. This
       can inadvertently expose users to cross-site scripting (XSS) attacks if
       this comes  from user-provided input. If you have to use
       dangerouslySetInnerHTML, consider using a sanitization library such as
@@ -15,7 +16,7 @@ rules:
       references:
         - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
       category: security
-      confidence: MEDIUM
+      confidence: LOW
       technology:
         - react
       license: Commons Clause License Condition v1.0[LGPL-2.1-only]
@@ -23,7 +24,7 @@ rules:
       cwe2021-top25: true
       subcategory:
         - audit
-      likelihood: MEDIUM
+      likelihood: LOW
       impact: MEDIUM
     languages:
       - typescript

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -1,147 +1,196 @@
 rules:
-- id: react-dangerouslysetinnerhtml
-  message: >-
-    Detection of dangerouslySetInnerHTML from non-constant definition. This
-    can inadvertently expose users to cross-site scripting (XSS) attacks if
-    this comes  from user-provided input. If you have to use
-    dangerouslySetInnerHTML, consider using a sanitization library such as
-    DOMPurify to sanitize your HTML.
-  metadata:
-    cwe:
-    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp:
-    - A07:2017 - Cross-Site Scripting (XSS)
-    - A03:2021 - Injection
-    references:
-    - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
-    category: security
-    confidence: MEDIUM
-    technology:
-    - react
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - vuln
-    likelihood: MEDIUM
-    impact: MEDIUM
-  languages:
-  - typescript
-  - javascript
-  severity: WARNING
-  mode: taint
-  pattern-sources:
-    - patterns:
+  - id: react-dangerouslysetinnerhtml
+    message: Detection of dangerouslySetInnerHTML from non-constant definition. This
+      can inadvertently expose users to cross-site scripting (XSS) attacks if
+      this comes  from user-provided input. If you have to use
+      dangerouslySetInnerHTML, consider using a sanitization library such as
+      DOMPurify to sanitize your HTML.
+    metadata:
+      cwe:
+        - "CWE-79: Improper Neutralization of Input During Web Page Generation
+          ('Cross-site Scripting')"
+      owasp:
+        - A07:2017 - Cross-Site Scripting (XSS)
+        - A03:2021 - Injection
+      references:
+        - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+      category: security
+      confidence: MEDIUM
+      technology:
+        - react
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+      cwe2022-top25: true
+      cwe2021-top25: true
+      subcategory:
+        - vuln
+      likelihood: MEDIUM
+      impact: MEDIUM
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - patterns:
+        - pattern-not-inside: |
+            import $X from "..."
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            import * as $X from "..."
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            import { ..., $X,...} from "..."
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            $X = require("...")
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            $X = require("...").$F
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            const {...,$X,...} = require("...")
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            var {...,$X,...} = require("...")
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            let {...,$X,...} = require("...")
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            const {...,$X,...} = require("...").$F
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            var {...,$X,...} = require("...").$F
+            ...
+            $X. ... .$FUNC(...)
+        - pattern-not-inside: |
+            let {...,$X,...} = require("...").$F
+            ...
+            $X. ... .$FUNC(...)
         - pattern-either:
             - pattern-inside: |
                 function ...({..., $X, ...}) { ... }
             - pattern-inside: |
                 function ...(..., $X, ...) { ... }
         - focus-metavariable: $X
+    pattern-sinks:
+      - patterns:
+          - focus-metavariable: $X
+          - pattern-either:
+              - pattern: |
+                  {...,dangerouslySetInnerHTML: {__html: $X},...}
+              - pattern: |
+                  <$Y ... dangerouslySetInnerHTML={{__html: $X}} />
+          - pattern-not: |
+              <$Y ... dangerouslySetInnerHTML={{__html: "..."}} />
+          - pattern-not: |
+              {...,dangerouslySetInnerHTML:{__html: "..."},...}
+          - metavariable-pattern:
+              patterns:
+                - pattern-not: |
+                    {...}
+              metavariable: $X
+          - pattern-not: |
+              <... {__html: "..."} ...>
+          - pattern-not: |
+              <... {__html: `...`} ...>
+    pattern-sanitizers:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from "underscore.string"
+                  ...
+              - pattern-inside: |
+                  import * as $S from "underscore.string"
+                  ...
+              - pattern-inside: |
+                  import $S from "underscore.string"
+                  ...
+              - pattern-inside: |
+                  $S = require("underscore.string")
+                  ...
+          - pattern-either:
+              - pattern: $S.escapeHTML(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from "dompurify"
+                  ...
+              - pattern-inside: |
+                  import { ..., $S,... } from "dompurify"
+                  ...
+              - pattern-inside: |
+                  import * as $S from "dompurify"
+                  ...
+              - pattern-inside: |
+                  $S = require("dompurify")
+                  ...
+              - pattern-inside: |
+                  import $S from "isomorphic-dompurify"
+                  ...
+              - pattern-inside: |
+                  import * as $S from "isomorphic-dompurify"
+                  ...
+              - pattern-inside: |
+                  $S = require("isomorphic-dompurify")
+                  ...
+          - pattern-either:
+              - patterns:
+                  - pattern-inside: |
+                      $VALUE = $S(...)
+                      ...
+                  - pattern: $VALUE.sanitize(...)
+              - patterns:
+                  - pattern-inside: |
+                      $VALUE = $S.sanitize
+                      ...
+                  - pattern: $S(...)
+              - pattern: $S.sanitize(...)
+              - pattern: $S(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from 'xss';
+                  ...
+              - pattern-inside: |
+                  import * as $S from 'xss';
+                  ...
+              - pattern-inside: |
+                  $S = require("xss")
+                  ...
+          - pattern: $S(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from 'sanitize-html';
+                  ...
+              - pattern-inside: |
+                  import * as $S from "sanitize-html";
+                  ...
+              - pattern-inside: |
+                  $S = require("sanitize-html")
+                  ...
+          - pattern: $S(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $S = new Remarkable()
+                  ...
+          - pattern: $S.render(...)
+      - patterns:
         - pattern-either:
-            - pattern: $X.$Y
-            - pattern: $X[...]
-  pattern-sinks:
-  - patterns:
-    - focus-metavariable: $X
-    - pattern-either:
-      - pattern: |
-          {...,dangerouslySetInnerHTML: {__html: $X},...}
-      - pattern: |
-          <$Y ... dangerouslySetInnerHTML={{__html: $X}} />
-    - pattern-not: |
-        <$Y ... dangerouslySetInnerHTML={{__html: "..."}} />
-    - pattern-not: |
-        {...,dangerouslySetInnerHTML:{__html: "..."},...}
-    - metavariable-pattern:
-        patterns:
-        - pattern-not: |
-            {...}
-        metavariable: $X
-    - pattern-not: |
-        <... {__html: "..."} ...>
-    - pattern-not: |
-        <... {__html: `...`} ...>
-  pattern-sanitizers:
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from "underscore.string"
-          ...
-      - pattern-inside: |
-          import * as $S from "underscore.string"
-          ...
-      - pattern-inside: |
-          import $S from "underscore.string"
-          ...
-      - pattern-inside: |
-          $S = require("underscore.string")
-          ...
-    - pattern-either:
-      - pattern: $S.escapeHTML(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from "dompurify"
-          ...
-      - pattern-inside: |
-          import { ..., $S,... } from "dompurify"
-          ...
-      - pattern-inside: |
-          import * as $S from "dompurify"
-          ...
-      - pattern-inside: |
-          $S = require("dompurify")
-          ...
-      - pattern-inside: |
-          import $S from "isomorphic-dompurify"
-          ...
-      - pattern-inside: |
-          import * as $S from "isomorphic-dompurify"
-          ...
-      - pattern-inside: |
-          $S = require("isomorphic-dompurify")
-          ...
-    - pattern-either:
-      - patterns:
-        - pattern-inside: |
-            $VALUE = $S(...)
-            ...
-        - pattern: $VALUE.sanitize(...)
-      - patterns:
-        - pattern-inside: |
-            $VALUE = $S.sanitize
-            ...
-        - pattern: $S(...)
-      - pattern: $S.sanitize(...)
-      - pattern: $S(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from 'xss';
-          ...
-      - pattern-inside: |
-          import * as $S from 'xss';
-          ...
-      - pattern-inside: |
-          $S = require("xss")
-          ...
-    - pattern: $S(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from 'sanitize-html';
-          ...
-      - pattern-inside: |
-          import * as $S from "sanitize-html";
-          ...
-      - pattern-inside: |
-          $S = require("sanitize-html")
-          ...
-    - pattern: $S(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          $S = new Remarkable()
-          ...
-    - pattern: $S.render(...)
+            - pattern: $F(...)
+            - pattern: $X. ... .$F(...)
+            - pattern: $F. ... .$X(...)
+        - metavariable-regex:
+            metavariable: $F
+            regex: (?i)(.*sanitize|.*escape|.*encode)

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -34,49 +34,49 @@ rules:
     pattern-sources:
      - patterns:
         - pattern-not-inside: |
-            import $C from "..."
+            import $X from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            import * as $C from "..."
+            import * as $X from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            import { ..., $C,...} from "..."
+            import { ..., $X,...} from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            $C = require("...")
+            $X = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            $C = require("...").$F
+            $X = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$C,...} = require("...")
+            const {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$C,...} = require("...")
+            var {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$C,...} = require("...")
+            let {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$C,...} = require("...").$F
+            const {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$C,...} = require("...").$F
+            var {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$C,...} = require("...").$F
+            let {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-either:
             - pattern-inside: |
                 function ...({..., $X, ...}) { ... }

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -194,4 +194,4 @@ rules:
             - pattern: $F. ... .$X(...)
         - metavariable-regex:
             metavariable: $F
-            regex: (?i)(.*sanitize|.*escape|.*encode)
+            regex: (?i)(.*sanitiz|.*escape|.*encode)

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -34,49 +34,49 @@ rules:
     pattern-sources:
       - patterns:
         - pattern-not-inside: |
-            import $X from "..."
+            import $C from "..."
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
             import * as $X from "..."
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            import { ..., $X,...} from "..."
+            import { ..., $C,...} from "..."
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
             $X = require("...")
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            $X = require("...").$F
+            $C = require("...").$F
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$X,...} = require("...")
+            const {...,$C,...} = require("...")
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$X,...} = require("...")
+            var {...,$C,...} = require("...")
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$X,...} = require("...")
+            let {...,$C,...} = require("...")
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
             const {...,$X,...} = require("...").$F
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$X,...} = require("...").$F
+            var {...,$C,...} = require("...").$F
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$X,...} = require("...").$F
+            let {...,$C,...} = require("...").$F
             ...
-            $X. ... .$FUNC(...)
+            $C. ... .$FUNC(...)
         - pattern-either:
             - pattern-inside: |
                 function ...({..., $X, ...}) { ... }

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -22,7 +22,7 @@ rules:
       cwe2022-top25: true
       cwe2021-top25: true
       subcategory:
-        - vuln
+        - audit
       likelihood: MEDIUM
       impact: MEDIUM
     languages:

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -1,141 +1,188 @@
 rules:
-- id: react-href-var
-  message: Detected a variable used in an anchor tag with the 'href' attribute. A malicious actor may
-    be able to input the 'javascript:' URI, which could cause cross-site scripting (XSS). It is recommended
-    to disallow 'javascript:' URIs within your application.
-  metadata:
-    cwe:
-    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp:
-    - A07:2017 - Cross-Site Scripting (XSS)
-    - A03:2021 - Injection
-    references:
-    - https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls
-    - https://pragmaticwebsecurity.com/articles/spasecurity/react-xss-part1.html
-    category: security
-    confidence: LOW
-    technology:
-    - react
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-  languages:
-  - typescript
-  - javascript
-  severity: WARNING
-  mode: taint
-  pattern-sources:
-    - patterns:
-        - pattern-either:
-            - pattern-inside: |
-                function ...({..., $X, ...}) { ... }
-            - pattern-inside: |
-                function ...(..., $X, ...) { ... }
-        - focus-metavariable: $X
-        - pattern-either:
-            - pattern: $X.$Y
-            - pattern: $X[...]
-  pattern-sinks:
-  - patterns:
-    - pattern-either:
+  - id: react-href-var
+    message: Detected a variable used in an anchor tag with the 'href' attribute. A
+      malicious actor may be able to input the 'javascript:' URI, which could
+      cause cross-site scripting (XSS). It is recommended to disallow
+      'javascript:' URIs within your application.
+    metadata:
+      cwe:
+        - "CWE-79: Improper Neutralization of Input During Web Page Generation
+          ('Cross-site Scripting')"
+      owasp:
+        - A07:2017 - Cross-Site Scripting (XSS)
+        - A03:2021 - Injection
+      references:
+        - https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls
+        - https://pragmaticwebsecurity.com/articles/spasecurity/react-xss-part1.html
+      category: security
+      confidence: LOW
+      technology:
+        - react
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+      cwe2022-top25: true
+      cwe2021-top25: true
+      subcategory:
+        - audit
+      likelihood: LOW
+      impact: MEDIUM
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
       - patterns:
-        - focus-metavariable: $X
-        - pattern-not-inside: |
-            import {
-              ...,$X,...
-            } from "..."
-            ...
-        - pattern-not-inside: |
-            <Buttons .../>
-        - pattern-not-inside: |
-            <Button .../>
-        - pattern-not-inside: |
-            <AnchorButton .../>
-        - pattern-not-inside: |
-            <$EL ... href={$FUNC($X)}></$EL>
-        - pattern-not-inside: |
-            import $X from "..."
-            ...
-        - pattern-not-inside: |
-            import $X from "..."
-            ...
-        - pattern-not-inside: |
-            import * as $X from "..."
-            ...
-        - pattern-not-inside: |
-            $X = require(...)
-            ...
-        - pattern-either:
-          - pattern: |
-              <$EL href={$X} />
-          - pattern: |
-              <$EL href={`${$X}...`} />
-          - pattern: |
-              React.createElement($EL, {href: $X})
-          - pattern-inside: |
-              $PARAMS = {href: $X};
+          - pattern-not-inside: |
+              import $X from "..."
               ...
-              React.createElement($EL, $PARAMS);
-        - pattern-not: |
-            <$EL href="..." />
-        - pattern-not: |
-            <$EL href={"..."+$X} />
-        - pattern-not: |
-            React.createElement($EL, {href: "..."})        
-        - pattern-not: |
-            $PARAMS = {href: "..."};
-        - metavariable-pattern:
-            patterns:
-            - pattern-not: |
-                $FOO + $VALUE
-            - pattern-not: |
-                "..." + $F
-            - pattern-not: |
-                `...${$F}...`
-            metavariable: $X
-  pattern-sanitizers:
-  - patterns:
-    - pattern-either:
-      - pattern: |
-          $A ? $VAL1 : $VAL2
-      - pattern: |
-          $A ? $VAL2 : $VAL1
-    - metavariable-pattern:
-        patterns:
-        - pattern: |
-            `${...}...`
-        - pattern-not: |
-            "..."
-        - pattern-not: |
-            "..." + $V
-        - pattern-not: |
-            `...${...}...`
-        metavariable: $VAL1
-    - focus-metavariable: $VAL1
-  - patterns:
-    - pattern-either:
-      - pattern: validateUrl(...)
-      - pattern: getSanitizedUrl(...)
-  - patterns:
-    - pattern: |
-        `...${$X}...`
-    - pattern-not: |
-        `${$X}...`
-    - focus-metavariable: $X
-  - patterns:
-    - pattern: |
-        "..." + $VALUE
-  - patterns:
-    - pattern-inside: |
-        if (<... $SOURCE.startsWith("$REGEX") ...>) { 
-            ... 
-        }
-  - patterns:
-    - pattern-inside: |
-        $X = [{...}];
-        ...
-    - pattern: $X.map(...)
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              import * as $X from "..."
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              import { ..., $X,...} from "..."
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              $X = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              $X = require("...").$F
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              const {...,$X,...} = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              var {...,$X,...} = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              let {...,$X,...} = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              const {...,$X,...} = require("...").$F
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              var {...,$X,...} = require("...").$F
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              let {...,$X,...} = require("...").$F
+              ...
+              $X. ... .$FUNC(...)    
+          - pattern-either:
+              - pattern-inside: |
+                  function ...({..., $X, ...}) { ... }
+              - pattern-inside: |
+                  function ...(..., $X, ...) { ... }
+          - focus-metavariable: $X
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - patterns:
+                  - focus-metavariable: $X
+                  - pattern-not-inside: |
+                      import {
+                        ...,$X,...
+                      } from "..."
+                      ...
+                  - pattern-not-inside: |
+                      <Buttons .../>
+                  - pattern-not-inside: |
+                      <Button .../>
+                  - pattern-not-inside: |
+                      <AnchorButton .../>
+                  - pattern-not-inside: |
+                      <$EL ... href={$FUNC($X)}></$EL>
+                  - pattern-not-inside: |
+                      import $X from "..."
+                      ...
+                  - pattern-not-inside: |
+                      import $X from "..."
+                      ...
+                  - pattern-not-inside: |
+                      import * as $X from "..."
+                      ...
+                  - pattern-not-inside: |
+                      $X = require(...)
+                      ...
+                  - pattern-either:
+                      - pattern: |
+                          <$EL href={$X} />
+                      - pattern: |
+                          <$EL href={`${$X}...`} />
+                      - pattern: |
+                          React.createElement($EL, {href: $X})
+                      - pattern-inside: |
+                          $PARAMS = {href: $X};
+                          ...
+                          React.createElement($EL, $PARAMS);
+                  - pattern-not: |
+                      <$EL href="..." />
+                  - pattern-not: |
+                      <$EL href={"..."+$X} />
+                  - pattern-not: |
+                      React.createElement($EL, {href: "..."})        
+                  - pattern-not: |
+                      $PARAMS = {href: "..."};
+                  - metavariable-pattern:
+                      patterns:
+                        - pattern-not: |
+                            $FOO + $VALUE
+                        - pattern-not: |
+                            "..." + $F
+                        - pattern-not: |
+                            `...${$F}...`
+                      metavariable: $X
+    pattern-sanitizers:
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  $A ? $VAL1 : $VAL2
+              - pattern: |
+                  $A ? $VAL2 : $VAL1
+          - metavariable-pattern:
+              patterns:
+                - pattern: |
+                    `${...}...`
+                - pattern-not: |
+                    "..."
+                - pattern-not: |
+                    "..." + $V
+                - pattern-not: |
+                    `...${...}...`
+              metavariable: $VAL1
+          - focus-metavariable: $VAL1
+      - patterns:
+          - pattern-either:
+            - pattern: $F(...)
+            - pattern: $F. ... .$X(...)
+            - pattern: $X. ... .$F(...)
+          - metavariable-regex:
+                metavariable: $F
+                regex: (?i)(.*validate|sanitize)
+      - patterns:
+          - pattern: |
+              `...${$X}...`
+          - pattern-not: |
+              `${$X}...`
+          - focus-metavariable: $X
+      - patterns:
+          - pattern: |
+              "..." + $VALUE
+      - patterns:
+          - pattern-inside: |
+              if (<... $SOURCE.startsWith("$REGEX") ...>) { 
+                  ... 
+              }
+      - patterns:
+          - pattern-inside: |
+              $X = [{...}];
+              ...
+          - pattern: $X.map(...)

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -33,56 +33,56 @@ rules:
     mode: taint
     pattern-sources:
       - patterns:
-          - pattern-not-inside: |
-              import $X from "..."
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              import * as $X from "..."
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              import { ..., $X,...} from "..."
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              $X = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              $X = require("...").$F
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              const {...,$X,...} = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              var {...,$X,...} = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              let {...,$X,...} = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              const {...,$X,...} = require("...").$F
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              var {...,$X,...} = require("...").$F
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              let {...,$X,...} = require("...").$F
-              ...
-              $X. ... .$FUNC(...)    
-          - pattern-either:
-              - pattern-inside: |
-                  function ...({..., $X, ...}) { ... }
-              - pattern-inside: |
-                  function ...(..., $X, ...) { ... }
-          - focus-metavariable: $X
+        - pattern-not-inside: |
+            import $C from "..."
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            import * as $X from "..."
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            import { ..., $C,...} from "..."
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            $X = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            $C = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            const {...,$C,...} = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            var {...,$C,...} = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            let {...,$C,...} = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            const {...,$X,...} = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            var {...,$C,...} = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            let {...,$C,...} = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-either:
+            - pattern-inside: |
+                function ...({..., $X, ...}) { ... }
+            - pattern-inside: |
+                function ...(..., $X, ...) { ... }
+        - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -32,13 +32,13 @@ rules:
     severity: WARNING
     mode: taint
     pattern-sources:
-      - patterns:
+     - patterns:
         - pattern-not-inside: |
             import $C from "..."
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            import * as $X from "..."
+            import * as $C from "..."
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
@@ -46,7 +46,7 @@ rules:
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            $X = require("...")
+            $C = require("...")
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
@@ -66,7 +66,7 @@ rules:
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$X,...} = require("...").$F
+            const {...,$C,...} = require("...").$F
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -167,7 +167,7 @@ rules:
             - pattern: $X. ... .$F(...)
           - metavariable-regex:
                 metavariable: $F
-                regex: (?i)(.*validate|sanitize)
+                regex: (?i)(.*validate|sanitiz)
       - patterns:
           - pattern: |
               `...${$X}...`

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -34,49 +34,49 @@ rules:
     pattern-sources:
      - patterns:
         - pattern-not-inside: |
-            import $C from "..."
+            import $X from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            import * as $C from "..."
+            import * as $X from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            import { ..., $C,...} from "..."
+            import { ..., $X,...} from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            $C = require("...")
+            $X = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            $C = require("...").$F
+            $X = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$C,...} = require("...")
+            const {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$C,...} = require("...")
+            var {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$C,...} = require("...")
+            let {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$C,...} = require("...").$F
+            const {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$C,...} = require("...").$F
+            var {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$C,...} = require("...").$F
+            let {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-either:
             - pattern-inside: |
                 function ...({..., $X, ...}) { ... }

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -1,6 +1,7 @@
 rules:
   - id: react-href-var
-    message: Detected a variable used in an anchor tag with the 'href' attribute. A
+    message: >-
+      Detected a variable used in an anchor tag with the 'href' attribute. A
       malicious actor may be able to input the 'javascript:' URI, which could
       cause cross-site scripting (XSS). It is recommended to disallow
       'javascript:' URIs within your application.

--- a/typescript/react/security/audit/react-unsanitized-method.yaml
+++ b/typescript/react/security/audit/react-unsanitized-method.yaml
@@ -38,7 +38,7 @@ rules:
           ...
           $C. ... .$FUNC(...)
       - pattern-not-inside: |
-          import * as $X from "..."
+          import * as $C from "..."
           ...
           $C. ... .$FUNC(...)
       - pattern-not-inside: |
@@ -46,7 +46,7 @@ rules:
           ...
           $C. ... .$FUNC(...)
       - pattern-not-inside: |
-          $X = require("...")
+          $C = require("...")
           ...
           $C. ... .$FUNC(...)
       - pattern-not-inside: |
@@ -66,7 +66,7 @@ rules:
           ...
           $C. ... .$FUNC(...)
       - pattern-not-inside: |
-          const {...,$X,...} = require("...").$F
+          const {...,$C,...} = require("...").$F
           ...
           $C. ... .$FUNC(...)
       - pattern-not-inside: |
@@ -194,4 +194,4 @@ rules:
           - pattern: $F. ... .$X(...)
       - metavariable-regex:
           metavariable: $F
-          regex: (?i)(.*sanitize|.*escape|.*encode)
+          regex: (?i)(.*sanitiz|.*escape|.*encode)

--- a/typescript/react/security/audit/react-unsanitized-method.yaml
+++ b/typescript/react/security/audit/react-unsanitized-method.yaml
@@ -34,49 +34,49 @@ rules:
   pattern-sources:
     - patterns:
       - pattern-not-inside: |
-          import $C from "..."
+          import $X from "..."
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          import * as $C from "..."
+          import * as $X from "..."
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          import { ..., $C,...} from "..."
+          import { ..., $X,...} from "..."
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          $C = require("...")
+          $X = require("...")
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          $C = require("...").$F
+          $X = require("...").$F
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          const {...,$C,...} = require("...")
+          const {...,$X,...} = require("...")
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          var {...,$C,...} = require("...")
+          var {...,$X,...} = require("...")
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          let {...,$C,...} = require("...")
+          let {...,$X,...} = require("...")
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          const {...,$C,...} = require("...").$F
+          const {...,$X,...} = require("...").$F
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          var {...,$C,...} = require("...").$F
+          var {...,$X,...} = require("...").$F
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-not-inside: |
-          let {...,$C,...} = require("...").$F
+          let {...,$X,...} = require("...").$F
           ...
-          $C. ... .$FUNC(...)
+          $X. ... .$FUNC(...)
       - pattern-either:
           - pattern-inside: |
               function ...({..., $X, ...}) { ... }

--- a/typescript/react/security/audit/react-unsanitized-method.yaml
+++ b/typescript/react/security/audit/react-unsanitized-method.yaml
@@ -33,15 +33,56 @@ rules:
   mode: taint
   pattern-sources:
     - patterns:
-        - pattern-either:
-            - pattern-inside: |
-                function ...({..., $X, ...}) { ... }
-            - pattern-inside: |
-                function ...(..., $X, ...) { ... }
-        - focus-metavariable: $X
-        - pattern-either:
-            - pattern: $X.$Y
-            - pattern: $X[...]
+      - pattern-not-inside: |
+          import $C from "..."
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          import * as $X from "..."
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          import { ..., $C,...} from "..."
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          $X = require("...")
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          $C = require("...").$F
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          const {...,$C,...} = require("...")
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          var {...,$C,...} = require("...")
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          let {...,$C,...} = require("...")
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          const {...,$X,...} = require("...").$F
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          var {...,$C,...} = require("...").$F
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-not-inside: |
+          let {...,$C,...} = require("...").$F
+          ...
+          $C. ... .$FUNC(...)
+      - pattern-either:
+          - pattern-inside: |
+              function ...({..., $X, ...}) { ... }
+          - pattern-inside: |
+              function ...(..., $X, ...) { ... }
+      - focus-metavariable: $X
   pattern-sinks:
   - patterns:
     - pattern-either:
@@ -146,3 +187,11 @@ rules:
           $S = new Remarkable()
           ...
     - pattern: $S.render(...)
+  - patterns:
+      - pattern-either:
+          - pattern: $F(...)
+          - pattern: $X. ... .$F(...)
+          - pattern: $F. ... .$X(...)
+      - metavariable-regex:
+          metavariable: $F
+          regex: (?i)(.*sanitize|.*escape|.*encode)

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -1,162 +1,211 @@
 rules:
-- id: react-unsanitized-property
-  message: >-
-    Detection of $HTML from non-constant definition. This
-    can inadvertently expose users to cross-site scripting (XSS) attacks if this
-    comes from user-provided input. If you have to use $HTML, consider using
-    a sanitization library such as DOMPurify to sanitize your HTML.
-  metadata:
-    cwe:
-    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp:
-    - A07:2017 - Cross-Site Scripting (XSS)
-    - A03:2021 - Injection
-    references:
-    - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
-    category: security
-    confidence: MEDIUM
-    technology:
-    - react
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - vuln
-    likelihood: MEDIUM
-    impact: MEDIUM
-  languages:
-  - typescript
-  - javascript
-  severity: WARNING
-  mode: taint
-  pattern-sources:
-    - patterns:
-        - pattern-either:
-            - pattern-inside: |
-                function ...({..., $X, ...}) { ... }
-            - pattern-inside: |
-                function ...(..., $X, ...) { ... }
-        - focus-metavariable: $X
-        - pattern-either:
-            - pattern: $X.$Y
-            - pattern: $X[...]
-  pattern-sinks:
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          $BODY = $REACT.useRef(...)
-          ...
-      - pattern-inside: |
-          $BODY = useRef(...)
-          ...
-      - pattern-inside: |
-          $BODY = findDOMNode(...)
-          ...
-      - pattern-inside: |
-          $BODY = createRef(...)
-          ...
-      - pattern-inside: |
-          $BODY = $REACT.findDOMNode(...)
-          ...
-      - pattern-inside: |
-          $BODY = $REACT.createRef(...)
-          ...
-    - pattern-either:
-      - pattern: |
-          $BODY. ... .$HTML = $SINK 
-      - pattern: |
-          $BODY.$HTML = $SINK  
-    - metavariable-regex:
-        metavariable: $HTML
-        regex: (innerHTML|outerHTML)
-    - focus-metavariable: $SINK
-  - patterns:
-    - pattern-either:
-      - pattern: ReactDOM.findDOMNode(...).$HTML = $SINK
-    - metavariable-regex:
-        metavariable: $HTML
-        regex: (innerHTML|outerHTML)
-    - focus-metavariable: $SINK
-  pattern-sanitizers:
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from "underscore.string"
-          ...
-      - pattern-inside: |
-          import * as $S from "underscore.string"
-          ...
-      - pattern-inside: |
-          import $S from "underscore.string"
-          ...
-      - pattern-inside: |
-          $S = require("underscore.string")
-          ...
-    - pattern-either:
-      - pattern: $S.escapeHTML(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from "dompurify"
-          ...
-      - pattern-inside: |
-          import { ..., $S,... } from "dompurify"
-          ...
-      - pattern-inside: |
-          import * as $S from "dompurify"
-          ...
-      - pattern-inside: |
-          $S = require("dompurify")
-          ...
-      - pattern-inside: |
-          import $S from "isomorphic-dompurify"
-          ...
-      - pattern-inside: |
-          import * as $S from "isomorphic-dompurify"
-          ...
-      - pattern-inside: |
-          $S = require("isomorphic-dompurify")
-          ...
-    - pattern-either:
+  - id: react-unsanitized-property
+    message: Detection of $HTML from non-constant definition. This can inadvertently
+      expose users to cross-site scripting (XSS) attacks if this comes from
+      user-provided input. If you have to use $HTML, consider using a
+      sanitization library such as DOMPurify to sanitize your HTML.
+    metadata:
+      cwe:
+        - "CWE-79: Improper Neutralization of Input During Web Page Generation
+          ('Cross-site Scripting')"
+      owasp:
+        - A07:2017 - Cross-Site Scripting (XSS)
+        - A03:2021 - Injection
+      references:
+        - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+      category: security
+      confidence: LOW
+      technology:
+        - react
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+      cwe2022-top25: true
+      cwe2021-top25: true
+      subcategory:
+        - vuln
+      likelihood: MEDIUM
+      impact: MEDIUM
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
       - patterns:
-        - pattern-inside: |
-            $VALUE = $S(...)
-            ...
-        - pattern: $VALUE.sanitize(...)
+          - pattern-not-inside: |
+              import $X from "..."
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              import * as $X from "..."
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              import { ..., $X,...} from "..."
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              $X = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              $X = require("...").$F
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              const {...,$X,...} = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              var {...,$X,...} = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              let {...,$X,...} = require("...")
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              const {...,$X,...} = require("...").$F
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              var {...,$X,...} = require("...").$F
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-not-inside: |
+              let {...,$X,...} = require("...").$F
+              ...
+              $X. ... .$FUNC(...)
+          - pattern-either:
+              - pattern-inside: |
+                  function ...({..., $X, ...}) { ... }
+              - pattern-inside: |
+                  function ...(..., $X, ...) { ... }
+          - focus-metavariable: $X
+    pattern-sinks:
       - patterns:
-        - pattern-inside: |
-            $VALUE = $S.sanitize
-            ...
-        - pattern: $S(...)
-      - pattern: $S.sanitize(...)
-      - pattern: $S(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from 'xss';
-          ...
-      - pattern-inside: |
-          import * as $S from 'xss';
-          ...
-      - pattern-inside: |
-          $S = require("xss")
-          ...
-    - pattern: $S(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          import $S from 'sanitize-html';
-          ...
-      - pattern-inside: |
-          import * as $S from "sanitize-html";
-          ...
-      - pattern-inside: |
-          $S = require("sanitize-html")
-          ...
-    - pattern: $S(...)
-  - patterns:
-    - pattern-either:
-      - pattern-inside: |
-          $S = new Remarkable()
-          ...
-    - pattern: $S.render(...)
+          - pattern-either:
+              - pattern-inside: |
+                  $BODY = $REACT.useRef(...)
+                  ...
+              - pattern-inside: |
+                  $BODY = useRef(...)
+                  ...
+              - pattern-inside: |
+                  $BODY = findDOMNode(...)
+                  ...
+              - pattern-inside: |
+                  $BODY = createRef(...)
+                  ...
+              - pattern-inside: |
+                  $BODY = $REACT.findDOMNode(...)
+                  ...
+              - pattern-inside: |
+                  $BODY = $REACT.createRef(...)
+                  ...
+          - pattern-either:
+              - pattern: |
+                  $BODY. ... .$HTML = $SINK 
+              - pattern: |
+                  $BODY.$HTML = $SINK  
+          - metavariable-regex:
+              metavariable: $HTML
+              regex: (innerHTML|outerHTML)
+          - focus-metavariable: $SINK
+      - patterns:
+          - pattern-either:
+              - pattern: ReactDOM.findDOMNode(...).$HTML = $SINK
+          - metavariable-regex:
+              metavariable: $HTML
+              regex: (innerHTML|outerHTML)
+          - focus-metavariable: $SINK
+    pattern-sanitizers:
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from "underscore.string"
+                  ...
+              - pattern-inside: |
+                  import * as $S from "underscore.string"
+                  ...
+              - pattern-inside: |
+                  import $S from "underscore.string"
+                  ...
+              - pattern-inside: |
+                  $S = require("underscore.string")
+                  ...
+          - pattern-either:
+              - pattern: $S.escapeHTML(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from "dompurify"
+                  ...
+              - pattern-inside: |
+                  import { ..., $S,... } from "dompurify"
+                  ...
+              - pattern-inside: |
+                  import * as $S from "dompurify"
+                  ...
+              - pattern-inside: |
+                  $S = require("dompurify")
+                  ...
+              - pattern-inside: |
+                  import $S from "isomorphic-dompurify"
+                  ...
+              - pattern-inside: |
+                  import * as $S from "isomorphic-dompurify"
+                  ...
+              - pattern-inside: |
+                  $S = require("isomorphic-dompurify")
+                  ...
+          - pattern-either:
+              - patterns:
+                  - pattern-inside: |
+                      $VALUE = $S(...)
+                      ...
+                  - pattern: $VALUE.sanitize(...)
+              - patterns:
+                  - pattern-inside: |
+                      $VALUE = $S.sanitize
+                      ...
+                  - pattern: $S(...)
+              - pattern: $S.sanitize(...)
+              - pattern: $S(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from 'xss';
+                  ...
+              - pattern-inside: |
+                  import * as $S from 'xss';
+                  ...
+              - pattern-inside: |
+                  $S = require("xss")
+                  ...
+          - pattern: $S(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  import $S from 'sanitize-html';
+                  ...
+              - pattern-inside: |
+                  import * as $S from "sanitize-html";
+                  ...
+              - pattern-inside: |
+                  $S = require("sanitize-html")
+                  ...
+          - pattern: $S(...)
+      - patterns:
+          - pattern-either:
+              - pattern-inside: |
+                  $S = new Remarkable()
+                  ...
+          - pattern: $S.render(...)
+      - patterns:
+          - pattern-either:
+              - pattern: $F(...)
+              - pattern: $X. ... .$F(...)
+              - pattern: $F. ... .$X(...)
+          - metavariable-regex:
+              metavariable: $F
+              regex: (?i)(.*sanitize|.*escape|.*encode)

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -21,7 +21,7 @@ rules:
       cwe2022-top25: true
       cwe2021-top25: true
       subcategory:
-        - vuln
+        - audit
       likelihood: MEDIUM
       impact: MEDIUM
     languages:

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -32,56 +32,56 @@ rules:
     mode: taint
     pattern-sources:
       - patterns:
-          - pattern-not-inside: |
-              import $X from "..."
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              import * as $X from "..."
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              import { ..., $X,...} from "..."
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              $X = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              $X = require("...").$F
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              const {...,$X,...} = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              var {...,$X,...} = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              let {...,$X,...} = require("...")
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              const {...,$X,...} = require("...").$F
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              var {...,$X,...} = require("...").$F
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-not-inside: |
-              let {...,$X,...} = require("...").$F
-              ...
-              $X. ... .$FUNC(...)
-          - pattern-either:
-              - pattern-inside: |
-                  function ...({..., $X, ...}) { ... }
-              - pattern-inside: |
-                  function ...(..., $X, ...) { ... }
-          - focus-metavariable: $X
+        - pattern-not-inside: |
+            import $C from "..."
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            import * as $X from "..."
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            import { ..., $C,...} from "..."
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            $X = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            $C = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            const {...,$C,...} = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            var {...,$C,...} = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            let {...,$C,...} = require("...")
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            const {...,$X,...} = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            var {...,$C,...} = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-not-inside: |
+            let {...,$C,...} = require("...").$F
+            ...
+            $C. ... .$FUNC(...)
+        - pattern-either:
+            - pattern-inside: |
+                function ...({..., $X, ...}) { ... }
+            - pattern-inside: |
+                function ...(..., $X, ...) { ... }
+        - focus-metavariable: $X
     pattern-sinks:
       - patterns:
           - pattern-either:

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -1,6 +1,7 @@
 rules:
   - id: react-unsanitized-property
-    message: Detection of $HTML from non-constant definition. This can inadvertently
+    message: >-
+      Detection of $HTML from non-constant definition. This can inadvertently
       expose users to cross-site scripting (XSS) attacks if this comes from
       user-provided input. If you have to use $HTML, consider using a
       sanitization library such as DOMPurify to sanitize your HTML.
@@ -22,7 +23,7 @@ rules:
       cwe2021-top25: true
       subcategory:
         - audit
-      likelihood: MEDIUM
+      likelihood: LOW
       impact: MEDIUM
     languages:
       - typescript

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -31,13 +31,13 @@ rules:
     severity: WARNING
     mode: taint
     pattern-sources:
-      - patterns:
+     - patterns:
         - pattern-not-inside: |
             import $C from "..."
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            import * as $X from "..."
+            import * as $C from "..."
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
@@ -45,7 +45,7 @@ rules:
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            $X = require("...")
+            $C = require("...")
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
@@ -65,7 +65,7 @@ rules:
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$X,...} = require("...").$F
+            const {...,$C,...} = require("...").$F
             ...
             $C. ... .$FUNC(...)
         - pattern-not-inside: |
@@ -209,4 +209,4 @@ rules:
               - pattern: $F. ... .$X(...)
           - metavariable-regex:
               metavariable: $F
-              regex: (?i)(.*sanitize|.*escape|.*encode)
+              regex: (?i)(.*sanitiz|.*escape|.*encode)

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -33,49 +33,49 @@ rules:
     pattern-sources:
      - patterns:
         - pattern-not-inside: |
-            import $C from "..."
+            import $X from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            import * as $C from "..."
+            import * as $X from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            import { ..., $C,...} from "..."
+            import { ..., $X,...} from "..."
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            $C = require("...")
+            $X = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            $C = require("...").$F
+            $X = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$C,...} = require("...")
+            const {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$C,...} = require("...")
+            var {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$C,...} = require("...")
+            let {...,$X,...} = require("...")
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            const {...,$C,...} = require("...").$F
+            const {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            var {...,$C,...} = require("...").$F
+            var {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-not-inside: |
-            let {...,$C,...} = require("...").$F
+            let {...,$X,...} = require("...").$F
             ...
-            $C. ... .$FUNC(...)
+            $X. ... .$FUNC(...)
         - pattern-either:
             - pattern-inside: |
                 function ...({..., $X, ...}) { ... }


### PR DESCRIPTION
Updates to react rules (LOW CONFIDENCE, AUDIT FINDINGS)

1. We remove imports as a source
2. We add a generic sanitizer for anything with the word encode,sanitize,etc in a function call
3. We update the sources to be a function call again, since lowering it down doesn't make sense 

All new react rules will come from sources of taint which can be validated e.g. History, react.router so users can trust the finding, these rules should in general only be used to identify code smells, not directly going to be a vulnerability. 