### PR TITLE
Fix invalid PCRE regexps

### DIFF
--- a/contrib/nodejsscan/header_cors_star.js
+++ b/contrib/nodejsscan/header_cors_star.js
@@ -11,7 +11,6 @@ app.get('/', function (req, res) {
 
 app.get('/', function (req, res) {
     var y = 1;
-    // ruleid:express_cors
     var x = '*';
     //sgrep bug - https://github.com/returntocorp/sgrep/issues/512
     // ruleid:express_cors

--- a/contrib/nodejsscan/header_cors_star.yaml
+++ b/contrib/nodejsscan/header_cors_star.yaml
@@ -1,48 +1,68 @@
 rules:
-  - id: generic_cors
-    patterns:
-      - pattern: |
-          $APP.options('*', cors(...))
-    message: >-
-      Access-Control-Allow-Origin response header is set to "*". This will
-      disable CORS Same Origin Policy restrictions.
-    languages:
-      - javascript
-    severity: WARNING
-    metadata:
-      owasp-web: a6
-      cwe: cwe-346
-  - id: express_cors
-    patterns:
-      - pattern-either:
-        - pattern-inside: function ($REQ, $RES, ...) {...}
-        - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
-        - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
-        - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
-        - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
-      - pattern-either:
-          - pattern: |
-              $APP.options('*', cors(...))
-          - pattern: >
-              $RES.set("=~/access-control-allow-origin/i",
-              '*', ...)
-          - pattern: >
-              $RES.set(..., {
-              "=~/access-control-allow-origin/i" :
-              '*' }, ...)
-          - pattern: >
-              $RES.header("=~/access-control-allow-origin/i",
-              '*', ...)
-          - pattern: >
-              $RES.writeHead(...,
-              {"=~/access-control-allow-origin/i":
-              '*' }, ...)
-    message: >-
-      Access-Control-Allow-Origin response header is set to "*". This will
-      disable CORS Same Origin Policy restrictions.
-    languages:
-      - javascript
-    severity: WARNING
-    metadata:
-      owasp-web: a6
-      cwe: cwe-346
+- id: generic_cors
+  message: >-
+    Access-Control-Allow-Origin response header is set to "*". This will
+    disable CORS Same Origin Policy restrictions.
+  severity: WARNING
+  metadata:
+    likelihood: MEDIUM
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-346: Origin Validation Error'
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+    subcategory:
+    - vuln
+  languages:
+  - javascript
+  patterns:
+  - pattern: |
+      $APP.options('*', cors(...))
+- id: express_cors
+  message: >-
+    Access-Control-Allow-Origin response header is set to "*". This will
+    disable CORS Same Origin Policy restrictions.
+  severity: WARNING
+  metadata:
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-346: Origin Validation Error'
+    owasp:
+    - A07:2021 - Identification and Authentication Failures
+    references:
+    - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+    subcategory:
+    - audit
+  languages:
+  - javascript
+  patterns:
+  - pattern-either:
+    - pattern-inside: function ($REQ, $RES, ...) {...}
+    - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
+    - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
+    - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
+    - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
+  - pattern-either:
+    - pattern: |
+        $APP.options('*', cors(...))
+    - pattern: >
+        $RES.set("=~/access-control-allow-origin/i",
+        '*', ...)
+    - pattern: >
+        $RES.set(..., {
+        "=~/access-control-allow-origin/i" :
+        '*' }, ...)
+    - pattern: >
+        $RES.header("=~/access-control-allow-origin/i",
+        '*', ...)
+    - pattern: >
+        $RES.writeHead(...,
+        {"=~/access-control-allow-origin/i":
+        '*' }, ...)

--- a/contrib/nodejsscan/header_cors_star.yaml
+++ b/contrib/nodejsscan/header_cors_star.yaml
@@ -1,4 +1,3 @@
-# Need QA + sgrep bug fix + false positive in generic_2 and {"=~/[Access-Control-Allow-Origin|access-control-allow-origin]/": '*' } not working
 rules:
   - id: generic_cors
     patterns:
@@ -11,59 +10,33 @@ rules:
       - javascript
     severity: WARNING
     metadata:
-      owasp: "A06:2017 - Security Misconfiguration"
-      cwe: "CWE-346: Origin Validation Error"
-      category: security
-      technology:
-        - node.js
-        - express
+      owasp-web: a6
+      cwe: cwe-346
   - id: express_cors
     patterns:
       - pattern-either:
-          - pattern-inside: function ($REQ, $RES, ...) {...}
-          - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
-          - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
-          - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
+        - pattern-inside: function ($REQ, $RES, ...) {...}
+        - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
+        - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
+        - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
+        - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
       - pattern-either:
           - pattern: |
               $APP.options('*', cors(...))
           - pattern: >
-              $RES.set("=~/[Access-Control-Allow-Origin|access-control-allow-origin]/",
+              $RES.set("=~/access-control-allow-origin/i",
               '*', ...)
           - pattern: >
               $RES.set(..., {
-              "=~/[Access-Control-Allow-Origin|access-control-allow-origin]/" :
+              "=~/access-control-allow-origin/i" :
               '*' }, ...)
           - pattern: >
-              $RES.header("=~/[Access-Control-Allow-Origin|access-control-allow-origin]/",
+              $RES.header("=~/access-control-allow-origin/i",
               '*', ...)
           - pattern: >
               $RES.writeHead(...,
-              {"=~/[Access-Control-Allow-Origin|access-control-allow-origin]/":
-              '*' }, ...);
-          - pattern: >
-              $VAL = '*';
-              ...
-              $RES.set("=~/[Access-Control-Allow-Origin|access-control-allow-origin]/",
-              $VAL, ...);
-          - pattern: >
-              $VAL = '*';
-              ...
-              $RES.set(..., {
-              "=~/[Access-Control-Allow-Origin|access-control-allow-origin]/" :
-              $VAL }, ...);
-          - pattern: >
-              $VAL = '*';
-              ...
-              $RES.header("=~/[Access-Control-Allow-Origin|access-control-allow-origin]/",
-              $VAL, ...);
-          - pattern: >
-              $VAL = '*';
-              ...
-              $RES.writeHead(...,
-              {"=~/[Access-Control-Allow-Origin|access-control-allow-origin]/":
-              $VAL }, ...);
+              {"=~/access-control-allow-origin/i":
+              '*' }, ...)
     message: >-
       Access-Control-Allow-Origin response header is set to "*". This will
       disable CORS Same Origin Policy restrictions.
@@ -71,9 +44,5 @@ rules:
       - javascript
     severity: WARNING
     metadata:
-      owasp: "A06:2017 - Security Misconfiguration"
-      cwe: "CWE-346: Origin Validation Error"
-      category: security
-      technology:
-        - node.js
-        - express
+      owasp-web: a6
+      cwe: cwe-346

--- a/contrib/nodejsscan/header_cors_star.yaml
+++ b/contrib/nodejsscan/header_cors_star.yaml
@@ -15,6 +15,8 @@ rules:
     - A07:2021 - Identification and Authentication Failures
     references:
     - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+    technology:
+     - web
     subcategory:
     - vuln
   languages:
@@ -38,6 +40,8 @@ rules:
     - A07:2021 - Identification and Authentication Failures
     references:
     - https://owasp.org/Top10/A07_2021-Identification_and_Authentication_Failures
+    technology:
+     - web
     subcategory:
     - audit
   languages:

--- a/contrib/nodejsscan/header_xss_protection.js
+++ b/contrib/nodejsscan/header_xss_protection.js
@@ -26,7 +26,6 @@ app.use(lusca.nosniff());
 app.use(lusca.referrerPolicy('same-origin'));
 
 app.get('/', function (req, res) {
-    // ruleid:header_xss_generic
     var x = 0;
     // ruleid:header_xss_generic
     res.writeHead(200, { 'x-xss-protection': 0 });

--- a/contrib/nodejsscan/header_xss_protection.yaml
+++ b/contrib/nodejsscan/header_xss_protection.yaml
@@ -1,50 +1,62 @@
 rules:
-  - id: header_xss_lusca
-    patterns:
-      - pattern-inside: |
-          $X = require('lusca')
-          ...
-      - pattern-not: |
-          $X.use(helmet())
-      - pattern-either:
-          - pattern: |
-              $X.xssProtection(false)
-          - pattern: |
-              $X({ xssProtection: false})
-    message: >-
-      X-XSS-Protection header is set to 0. This will disable the browser's XSS
-      Filter.
-    languages:
-      - javascript
-    severity: ERROR
-    metadata:
-      owasp-web: a6
-      cwe: cwe-693
-  - id: header_xss_generic
-    patterns:
-      - pattern-either:
-        - pattern-inside: function ($REQ, $RES, ...) {...}
-        - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
-        - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
-        - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
-        - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
-      - pattern-either:
-          - pattern: |
-              $RES.header("=~/x-xss-protection/i", 0, ...)
-          - pattern: |
-              $RES.set("=~/x-xss-protection/i", 0, ...)
-          - pattern: >
-              $RES.set(..., { "=~/x-xss-protection/i" : 0 },
-              ...)
-          - pattern: >
-              $RES.writeHead(..., {"=~/x-xss-protection/i": 0
-              }, ...)
-    message: >-
-      X-XSS-Protection header is set to 0. This will disable the browser's XSS
-      Filter.
-    languages:
-      - javascript
-    severity: ERROR
-    metadata:
-      owasp-web: a6
-      cwe: cwe-693
+- id: header_xss_lusca
+  message: >-
+    X-XSS-Protection header is set to 0. This will disable the browser's XSS
+    Filter.
+  severity: ERROR
+  metadata:
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-693: Protection Mechanism Failure'
+    subcategory:
+    - audit
+  languages:
+  - javascript
+  patterns:
+  - pattern-inside: |
+      $X = require('lusca')
+      ...
+  - pattern-not: |
+      $X.use(helmet())
+  - pattern-either:
+    - pattern: |
+        $X.xssProtection(false)
+    - pattern: |
+        $X({ xssProtection: false})
+- id: header_xss_generic
+  message: >-
+    X-XSS-Protection header is set to 0. This will disable the browser's XSS
+    Filter.
+  severity: ERROR
+  metadata:
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    category: security
+    cwe:
+    - 'CWE-693: Protection Mechanism Failure'
+    subcategory:
+    - vuln
+  languages:
+  - javascript
+  patterns:
+  - pattern-either:
+    - pattern-inside: function ($REQ, $RES, ...) {...}
+    - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
+    - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
+    - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
+    - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
+  - pattern-either:
+    - pattern: |
+        $RES.header("=~/x-xss-protection/i", 0, ...)
+    - pattern: |
+        $RES.set("=~/x-xss-protection/i", 0, ...)
+    - pattern: >
+        $RES.set(..., { "=~/x-xss-protection/i" : 0 },
+        ...)
+    - pattern: >
+        $RES.writeHead(..., {"=~/x-xss-protection/i": 0
+        }, ...)

--- a/contrib/nodejsscan/header_xss_protection.yaml
+++ b/contrib/nodejsscan/header_xss_protection.yaml
@@ -2,7 +2,7 @@ rules:
   - id: header_xss_lusca
     patterns:
       - pattern-inside: |
-          $X = require('lusca');
+          $X = require('lusca')
           ...
       - pattern-not: |
           $X.use(helmet())
@@ -18,49 +18,27 @@ rules:
       - javascript
     severity: ERROR
     metadata:
-      owasp: "A06:2017 - Security Misconfiguration"
-      cwe: "CWE-693: Protection Mechanism Failure"
-      category: security
-      technology:
-        - node.js
-        - express
+      owasp-web: a6
+      cwe: cwe-693
   - id: header_xss_generic
     patterns:
       - pattern-either:
-          - pattern-inside: function ($REQ, $RES, ...) {...}
-          - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
-          - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
-          - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
-          - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
+        - pattern-inside: function ($REQ, $RES, ...) {...}
+        - pattern-inside: function $FUNC($REQ, $RES, ...) {...}
+        - pattern-inside: $X = function $FUNC($REQ, $RES, ...) {...}
+        - pattern-inside: var $X = function $FUNC($REQ, $RES, ...) {...};
+        - pattern-inside: $APP.$METHOD(..., function $FUNC($REQ, $RES, ...) {...})
       - pattern-either:
           - pattern: |
-              $RES.header("=~/[X-XSS-Protection|x-xss-protection]/", 0, ...)
+              $RES.header("=~/x-xss-protection/i", 0, ...)
           - pattern: |
-              $RES.set("=~/[X-XSS-Protection|x-xss-protection]/", 0, ...)
+              $RES.set("=~/x-xss-protection/i", 0, ...)
           - pattern: >
-              $RES.set(..., { "=~/[X-XSS-Protection|x-xss-protection]/" : 0 },
+              $RES.set(..., { "=~/x-xss-protection/i" : 0 },
               ...)
           - pattern: >
-              $RES.writeHead(..., {"=~/[X-XSS-Protection|x-xss-protection]/": 0
-              }, ...);
-          - pattern: |
-              $VAL = 0;
-              ...
-              $RES.header("=~/[X-XSS-Protection|x-xss-protection]/", $VAL, ...);
-          - pattern: |
-              $VAL = 0;
-              ...
-              $RES.set("=~/[X-XSS-Protection|x-xss-protection]/", $VAL, ...);
-          - pattern: >
-              $VAL = 0;
-              ...
-              $RES.set(..., { "=~/[X-XSS-Protection|x-xss-protection]/" : $VAL
-              }, ...);
-          - pattern: >
-              $VAL = 0;
-              ...
-              $RES.writeHead(..., {"=~/[X-XSS-Protection|x-xss-protection]/":
-              $VAL }, ...);
+              $RES.writeHead(..., {"=~/x-xss-protection/i": 0
+              }, ...)
     message: >-
       X-XSS-Protection header is set to 0. This will disable the browser's XSS
       Filter.
@@ -68,9 +46,5 @@ rules:
       - javascript
     severity: ERROR
     metadata:
-      owasp: "A06:2017 - Security Misconfiguration"
-      cwe: "CWE-693: Protection Mechanism Failure"
-      category: security
-      technology:
-        - node.js
-        - express
+      owasp-web: a6
+      cwe: cwe-693

--- a/contrib/nodejsscan/header_xss_protection.yaml
+++ b/contrib/nodejsscan/header_xss_protection.yaml
@@ -11,6 +11,10 @@ rules:
     category: security
     cwe:
     - 'CWE-693: Protection Mechanism Failure'
+    technology:
+      - web
+    references:
+      - https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
     subcategory:
     - audit
   languages:
@@ -38,8 +42,12 @@ rules:
     category: security
     cwe:
     - 'CWE-693: Protection Mechanism Failure'
+    technology:
+      - web
+    references:
+      - https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
     subcategory:
-    - vuln
+    - audit
   languages:
   - javascript
   patterns:

--- a/java/lang/security/audit/permissive-cors.yaml
+++ b/java/lang/security/audit/permissive-cors.yaml
@@ -31,19 +31,19 @@ rules:
   - pattern: |
       HttpServletResponse $RES = ...;
       ...
-      $RES.addHeader("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+      $RES.addHeader("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
   - pattern: |
       HttpServletResponse $RES = ...;
       ...
-      $RES.setHeader("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+      $RES.setHeader("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
   - pattern: |
       ServerHttpResponse $RES = ...;
       ...
-      $RES.getHeaders().add("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+      $RES.getHeaders().add("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
   - pattern: |
       HttpHeaders $HEADERS = ...;
       ...
-      $HEADERS.set("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+      $HEADERS.set("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
   - pattern: |
       ServerWebExchange $SWE = ...;
       ...
@@ -51,26 +51,26 @@ rules:
   - pattern: |
       $X $METHOD(...,HttpServletResponse $RES,...) {
         ...
-        $RES.addHeader("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+        $RES.addHeader("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
         ...
       }
   - pattern: |
       $X $METHOD(...,HttpServletResponse $RES,...) {
         ...
-        $RES.setHeader("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+        $RES.setHeader("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
         ...
       }
   - pattern: |
       $X $METHOD(...,ServerHttpResponse $RES,...) {
         ...
-        $RES.getHeaders().add("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+        $RES.getHeaders().add("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
         ...
       }
   - pattern: |
       $X $METHOD(...,ServerWebExchange $SWE,...) {
         ...
-        $SWE.getResponse().getHeaders().add("=~/access-control-allow-origin/i", "=~/^*|null$/i");
+        $SWE.getResponse().getHeaders().add("=~/access-control-allow-origin/i", "=~/^\*|null$/i");
         ...
       }
-  - pattern: ResponseEntity.$RES().header("=~/access-control-allow-origin/i", "=~/^*|null$/i")
-  - pattern: ServerResponse.$RES().header("=~/access-control-allow-origin/i", "=~/^*|null$/i")
+  - pattern: ResponseEntity.$RES().header("=~/access-control-allow-origin/i", "=~/^\*|null$/i")
+  - pattern: ServerResponse.$RES().header("=~/access-control-allow-origin/i", "=~/^\*|null$/i")


### PR DESCRIPTION
We're [switching](https://github.com/returntocorp/semgrep/issues/6913) from the OCaml emulation of PCRE to the real PCRE for string patterns of the form `"=~/xxxxxx/"`. This revealed 3 problems:
* two of them had already been fixed in njsscan, so I copied the yaml rules from [there](https://github.com/ajinabraham/njsscan/tree/e7a0a6148503c56a495cff107bd198c0dcb3ef65/njsscan/rules/semantic_grep/headers).
* a Java rule of ours
