### PR TITLE
editing rule 

### DIFF
--- a/java/lang/security/audit/command-injection-formatted-runtime-call.java
+++ b/java/lang/security/audit/command-injection-formatted-runtime-call.java
@@ -40,5 +40,23 @@ class Cls {
         // ok: command-injection-formatted-runtime-call
         Runtime.getRuntime().loadLibrary("lib.dll");
     }
-}
 
+    public void test6(String input) {
+        String[] envp = new String[]{"-c"};
+        // ruleid: command-injection-formatted-runtime-call
+        Runtime.getRuntime().exec("bash", envp, input);
+    }
+
+    public void test6(String input) {
+        String[] command = new String[]{"bash"};
+        String[] envp = new String[]{"-c"};
+        // ruleid: command-injection-formatted-runtime-call
+        Runtime.getRuntime().exec(command, envp, input);
+    }
+
+        public void test6(String input) {
+        String[] command = new String[]{"bash"};
+        // ruleid: command-injection-formatted-runtime-call
+        Runtime.getRuntime().exec(command, "-c", input);
+    }
+}

--- a/java/lang/security/audit/command-injection-formatted-runtime-call.yaml
+++ b/java/lang/security/audit/command-injection-formatted-runtime-call.yaml
@@ -14,8 +14,8 @@ rules:
     - pattern: $RUNTIME.loadLibrary(String.format(...));
     - patterns:
       - pattern-either:
-        - pattern: |
-            $RUNTIME.exec("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$ARG,...)
+        - pattern: | 
+            $RUNTIME.exec("=~/(sh|bash|ksh|csh|tcsh|zsh)/", "-c", $ARG,...)
         - pattern: |
             $RUNTIME.exec(Arrays.asList("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$ARG,...),...)
         - pattern: |
@@ -31,6 +31,24 @@ rules:
           - pattern-inside: |
               $CMD = "=~/(sh|bash|ksh|csh|tcsh|zsh)/";
               ...
+        - patterns:
+          - pattern-either:
+            - pattern: |
+                $RUNTIME.exec($CMD, $EXECUTE, $ARG, ...)
+          - pattern-inside: |
+              $CMD = new String[]{"=~/(sh|bash|ksh|csh|tcsh|zsh)/", ...};
+              ...
+        - patterns:
+            - pattern-either:
+                - pattern: | 
+                    $RUNTIME.exec("=~/(sh|bash|ksh|csh|tcsh|zsh)/", $BASH, $ARG,...)
+                - pattern: |
+                    $RUNTIME.exec(Arrays.asList("=~/(sh|bash|ksh|csh|tcsh|zsh)/",$BASH,$ARG,...),...)
+                - pattern: |
+                    $RUNTIME.exec(new String[]{"=~/(sh|bash|ksh|csh|tcsh|zsh)/",$BASH,$ARG,...},...)
+            - pattern-inside: |
+                $BASH = new String[]{"=~/(-c)/", ...};
+                ...
       - pattern-not-inside: |
           $ARG = "...";
           ...
@@ -69,4 +87,3 @@ rules:
   severity: ERROR
   languages:
   - java
-


### PR DESCRIPTION
For https://github.com/returntocorp/semgrep-rules/issues/2685

This does add options so we catch string arrays, but in reality it is hard to catch all of these examples without some version of constant propagation that is able to identify a string array with a certain constant inside of it as that constant. Otherwise, the number of cases we must add additional patterns to catch is too many.