### PR TITLE
Clarify that CSRF protection is disabled

### DIFF
--- a/java/spring/security/audit/spring-csrf-disabled.yaml
+++ b/java/spring/security/audit/spring-csrf-disabled.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: spring-csrf-disabled
   message: >-
-    CSRF is disabled for this configuration. This is a security risk.
+    CSRF protection is disabled for this configuration. This is a security risk.
   metadata:
     cwe:
     - 'CWE-352: Cross-Site Request Forgery (CSRF)'

--- a/php/symfony/security/audit/symfony-csrf-protection-disabled.yaml
+++ b/php/symfony/security/audit/symfony-csrf-protection-disabled.yaml
@@ -16,7 +16,7 @@ rules:
           $VAL = false;
           ...
   message: >-
-    CSRF is disabled for this configuration. This is a security risk.
+    CSRF protection is disabled for this configuration. This is a security risk.
     Make sure that it is safe or consider setting `csrf_protection` property to `true`.
   metadata:
     references:

--- a/python/pyramid/audit/csrf-check-disabled.yaml
+++ b/python/pyramid/audit/csrf-check-disabled.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: pyramid-csrf-check-disabled
-  message: CSRF is disabled for this view. This is a security risk.
+  message: CSRF protection is disabled for this view. This is a security risk.
   metadata:
     cwe:
     - 'CWE-352: Cross-Site Request Forgery (CSRF)'


### PR DESCRIPTION
Cross Site Request Forgery, or CSRF, is the name of the attack. Disabling that would be good. Here, the protection against that is disabled.