### PR TITLE
Fix test expectations for tainted-html-string

### DIFF
--- a/java/spring/security/injection/tainted-html-string.java
+++ b/java/spring/security/injection/tainted-html-string.java
@@ -421,7 +421,7 @@ public class SecurityQuestionAssignment extends AssignmentEndpoint {
     if (answer.isPresent()) {
       triedQuestions.incr(question);
       if (triedQuestions.isComplete()) {
-        //todook: tainted-html-string
+        //ok: tainted-html-string
         return success(this).output("<b>" + answer + "</b>").build();
       }
     }


### PR DESCRIPTION
This rule was rewritten using taint labels, and it seems that a todoook got fixed that way.