### PR TITLE
changing confidence to add some rules to default

### DIFF
--- a/contrib/owasp/java/xxe/xmlinputfactory.yaml
+++ b/contrib/owasp/java/xxe/xmlinputfactory.yaml
@@ -13,7 +13,8 @@ rules:
       likelihood: MEDIUM
       impact: MEDIUM
       confidence: MEDIUM
-      category: security
+      subcategory:
+      - guardrail
     message:
       XMLInputFactory being instantiated without calling the setProperty functions
       that are generally used for disabling entity processing

--- a/contrib/owasp/java/xxe/xmlinputfactory.yaml
+++ b/contrib/owasp/java/xxe/xmlinputfactory.yaml
@@ -10,6 +10,10 @@ rules:
       category: security
       license: Commons Clause License Condition v1.0[LGPL-2.1-only]
       technology: [java]
+      likelihood: MEDIUM
+      impact: MEDIUM
+      confidence: MEDIUM
+      category: security
     message:
       XMLInputFactory being instantiated without calling the setProperty functions
       that are generally used for disabling entity processing


### PR DESCRIPTION
Rules confidences changed:
* xmlinputfactory.yaml -> we don't have any coverage of this XML parser anywhere besides with this rule! We should add this to default for now