### PR TITLE
Deprecate npm rule, we have a better one

### DIFF
--- a/generic/secrets/security/detected-npm-token.txt
+++ b/generic/secrets/security/detected-npm-token.txt
@@ -1,4 +1,4 @@
-# ruleid: detected-npm-token
+
 //registry.npmjs.org/:_authToken=xxxxxxxxxxxxxxxxxxxx
 
 # ok: detected-npm-token

--- a/generic/secrets/security/detected-npm-token.yaml
+++ b/generic/secrets/security/detected-npm-token.yaml
@@ -1,8 +1,13 @@
 rules:
 - id: detected-npm-token
-  pattern-regex: |-
-    \/\/.+\/:_authToken=.+
-  languages: [regex]
+  patterns:
+    - pattern: $AUTHTOKEN = $VALUE
+    - metavariable-regex:
+        metavariable: $AUTHTOKEN
+        regex: _(authToken|auth|password)
+    - pattern-not: $AUTHTOKEN = ${...}
+  languages: 
+    - generic
   message: NPM token
   severity: ERROR
   metadata:

--- a/generic/secrets/security/detected-npm-token.yaml
+++ b/generic/secrets/security/detected-npm-token.yaml
@@ -1,14 +1,11 @@
 rules:
 - id: detected-npm-token
   patterns:
-    - pattern: $AUTHTOKEN = $VALUE
-    - metavariable-regex:
-        metavariable: $AUTHTOKEN
-        regex: _(authToken|auth|password)
-    - pattern-not: $AUTHTOKEN = ${...}
+    - pattern: a()
+    - pattern: b()
   languages: 
     - generic
-  message: NPM token
+  message: This rule has been deprecated, please use https://semgrep.dev/playground/r/generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token instead.
   severity: ERROR
   metadata:
     cwe:


### PR DESCRIPTION
People should be using generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token instead which is in default