### PR TITLE
Retire terraform encrypt with CMK rule

### DIFF
--- a/terraform/aws/security/aws-elasticache-replication-group-encrypted-with-cmk.tf
+++ b/terraform/aws/security/aws-elasticache-replication-group-encrypted-with-cmk.tf
@@ -12,7 +12,6 @@ resource "aws_elasticache_replication_group" "pass" {
   at_rest_encryption_enabled    = true
   kms_key_id                    = aws_kms_key.bar.arn
 }
-# ruleid: aws-elasticache-replication-group-encrypted-with-cmk
 resource "aws_elasticache_replication_group" "fail" {
   replication_group_id          = "tf-%s"
   replication_group_description = "test description"

--- a/terraform/aws/security/aws-elasticache-replication-group-encrypted-with-cmk.yaml
+++ b/terraform/aws/security/aws-elasticache-replication-group-encrypted-with-cmk.yaml
@@ -1,22 +1,10 @@
 rules:
 - id: aws-elasticache-replication-group-encrypted-with-cmk
   patterns:
-  - pattern: |
-      resource "aws_elasticache_replication_group" $ANYTHING {
-        ...
-        at_rest_encryption_enabled  = true
-        ...
-      }
-  - pattern-not-inside: |
-      resource "aws_elasticache_replication_group" $ANYTHING {
-        ...
-        at_rest_encryption_enabled  = true
-        kms_key_id = ...
-        ...
-      }
+  - pattern: a
+  - pattern: b
   message: >-
-    Ensure Elasticache Replication Group is encrypted at rest using KMS CMKs. CMKs gives you control over
-    the encryption key in terms of access and rotation.
+    This rule has been retired
   metadata:
     category: security
     technology:

--- a/terraform/aws/security/aws-elasticache-replication-group-encrypted-with-cmk.yaml
+++ b/terraform/aws/security/aws-elasticache-replication-group-encrypted-with-cmk.yaml
@@ -1,10 +1,10 @@
 rules:
 - id: aws-elasticache-replication-group-encrypted-with-cmk
   patterns:
-  - pattern: a
-  - pattern: b
+  - pattern: a()
+  - pattern: b()
   message: >-
-    This rule has been retired
+    This rule has been deprecated.
   metadata:
     category: security
     technology:


### PR DESCRIPTION
Retired because of: https://github.com/returntocorp/semgrep-rules/issues/2642