### PR TITLE
chore: change test for explicit regex introduction

### DIFF
--- a/generic/secrets/gitleaks/generic-api-key.yaml
+++ b/generic/secrets/gitleaks/generic-api-key.yaml
@@ -25,7 +25,7 @@ rules:
   patterns:
     - pattern-regex: (?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)
       metavars:
-        - $1: $A
+        - 1: $A
     - metavariable-analysis:
         metavariable: $A
         analyzer: entropy

--- a/generic/secrets/gitleaks/generic-api-key.yaml
+++ b/generic/secrets/gitleaks/generic-api-key.yaml
@@ -24,7 +24,8 @@ rules:
         - gitleaks
   patterns:
     - pattern-regex: (?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)
-      $1: $A
+      metavars:
+        - $1: $A
     - metavariable-analysis:
         metavariable: $A
         analyzer: entropy

--- a/generic/secrets/gitleaks/generic-api-key.yaml
+++ b/generic/secrets/gitleaks/generic-api-key.yaml
@@ -24,7 +24,8 @@ rules:
         - gitleaks
   patterns:
     - pattern-regex: (?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)
+      $1: $A
     - metavariable-analysis:
-        metavariable: $1
+        metavariable: $A
         analyzer: entropy
-    - focus-metavariable: $1
+    - focus-metavariable: $A


### PR DESCRIPTION
## What:
This is a companion to https://github.com/returntocorp/semgrep/pull/7227.

## Why:
Essentially, rule syntax has changed so we don't get implicit introduction of metavariables like `$1`, which aren't valid metavariables. We now require them to be explicitly introduced, which is what this PR changes.

## Test plan:
`make test` (although it won't work until the aforementioned PR is merged)