### PR TITLE
Fixup the check-render-local-file-include Ruby rule to be more specific about which parameters can cause LFI or other unintended effects

### DIFF
--- a/ruby/rails/security/brakeman/check-render-local-file-include.rb
+++ b/ruby/rails/security/brakeman/check-render-local-file-include.rb
@@ -10,6 +10,36 @@
     render :file => "/some/path/#{page}"
   end
 
+  def test_render_with_modern_param
+    page = params[:page]
+    #ruleid: check-render-local-file-include
+    render file: "/some/path/#{page}"
+  end
+
+  def test_render_with_modern_param_second_param
+    page = params[:page]
+    #ruleid: check-render-local-file-include
+    render status: 403, file: "/some/path/#{page}"
+  end
+
+  def test_render_with_old_param_second_param
+    page = params[:page]
+    #ruleid: check-render-local-file-include
+    render :status => 403, :file => "/some/path/#{page}"
+  end
+
+  def test_render_with_first_positional_argument
+    page = params[:page]
+    #ruleid: check-render-local-file-include
+    render page
+  end
+
+  def test_render_with_first_positional_argument_and_keyword
+    page = params[:page]
+    #ruleid: check-render-local-file-include
+    render page, status: 403
+  end
+
   def test_param_ok
     map = make_map
     thing = map[params.id]
@@ -17,3 +47,4 @@
     render :file => "/some/path/#{thing}"
   end
     
+

--- a/ruby/rails/security/brakeman/check-render-local-file-include.yaml
+++ b/ruby/rails/security/brakeman/check-render-local-file-include.yaml
@@ -1,45 +1,58 @@
 rules:
-- id: check-render-local-file-include
-  mode: taint
-  pattern-sources:
-  - patterns:
-    - pattern: params[...]
-  pattern-sinks:
-  - patterns:
-    - pattern: |
-        render ...
-  pattern-sanitizers:
-  - patterns:
-    - pattern: $MAP[...]
-    - metavariable-pattern:
-        metavariable: $MAP
-        patterns:
-        - pattern-not-regex: params 
-  message: Found request parameters in a call to `render`. This can allow end users to request arbitrary
-    local files which may result in leaking sensitive information persisted on disk. Where possible, avoid
-    letting users specify template paths for `render`. If you must allow user input, use an allow-list
-    of known templates or normalize the user-supplied value with `File.basename(...)`.
-  languages:
-  - ruby
-  severity: WARNING
-  metadata:
-    technology:
-    - ruby
-    - rails
-    category: security
-    cwe:
-    - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"
-    owasp:
-    - A05:2017 - Broken Access Control
-    - A01:2021 - Broken Access Control
-    source-rule-url: https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_render.rb
-    references:
-    - https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion
-    - https://github.com/presidentbeef/brakeman/blob/f74cb53/test/apps/rails2/app/controllers/home_controller.rb#L48-L60
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - vuln
-    likelihood: MEDIUM
-    impact: HIGH
-    confidence: MEDIUM
+  - id: check-render-local-file-include
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern: params[...]
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  render ..., file: ...
+              - pattern: |
+                  render ..., inline: ...
+              - pattern: |
+                  render ..., template: ...
+              - pattern: |
+                  render ..., action: ...
+              - pattern: |
+                  render $FILE, ...
+    pattern-sanitizers:
+      - patterns:
+          - pattern: $MAP[...]
+          - metavariable-pattern:
+              metavariable: $MAP
+              patterns:
+                - pattern-not-regex: params
+    message: Found request parameters in a call to `render`. This can allow end
+      users to request arbitrary local files which may result in leaking
+      sensitive information persisted on disk. Where possible, avoid letting
+      users specify template paths for `render`. If you must allow user input,
+      use an allow-list of known templates or normalize the user-supplied value
+      with `File.basename(...)`.
+    languages:
+      - ruby
+    severity: WARNING
+    metadata:
+      technology:
+        - ruby
+        - rails
+      category: security
+      cwe:
+        - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory
+          ('Path Traversal')"
+      owasp:
+        - A05:2017 - Broken Access Control
+        - A01:2021 - Broken Access Control
+      source-rule-url: https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_render.rb
+      references:
+        - https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/07-Input_Validation_Testing/11.1-Testing_for_Local_File_Inclusion
+        - https://github.com/presidentbeef/brakeman/blob/f74cb53/test/apps/rails2/app/controllers/home_controller.rb#L48-L60
+      cwe2022-top25: true
+      cwe2021-top25: true
+      subcategory:
+        - vuln
+      likelihood: MEDIUM
+      impact: HIGH
+      confidence: MEDIUM
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]


### PR DESCRIPTION
## Link to an issue, if relevant

Hey all! I’m hoping to contribute some noise-reducing fixes upstream for Semgrep Ruby. Specifically, [this rule](https://semgrep.dev/playground/r/ruby.rails.security.brakeman.check-render-local-file-include.check-render-local-file-include?editorMode=advanced) is pretty noisy when run against an example corpus like [Mastodon](https://github.com/mastodon/mastodon). The problem is that the rule looks for params[…] going into any argument to `render`, while most render arguments are harmless. An example would be [this line](https://github.com/mastodon/mastodon/blob/main/app/controllers/api/v2/filters/keywords_controller.rb#L18) which simply renders a user-input-derived value as JSON:

```ryby
@keyword = current_account.custom_filters.find(params[:filter_id]).keywords.create!(resource_params)

render json: @keyword, serializer: REST::FilterKeywordSerializer
```

This PR changes the rule to only match on specific dangerous parameters:

- `inline`: executes arbitrary ERB (RCE)
- `file`: renders the contents file from the filesystem
- `template`: renders a specific template by its descriptor (eg `users/edit`)
- first positional argument: similar to template

Open questions:

- [ ] Do all of these behaviours belong in one rule? 
- [ ] If so, how can we update the description to be more accurate?

### Adding a new rule? Look over this PR checklist

- The issue or PR has links, references, or examples.
- The rule has **true positive** and **true negative** test cases in a file that matches the rule name.

> If the rule is `my-rule`, the test file name should be `my-rule.js`.
>
> True positives are marked by comments with `ruleid: <my-rule>` and true negatives are marked by comments with `ok: <my-rule>`.

- The rule has a good message. A good message includes:

> 1. A description of the pattern (e.g., missing parameter, dangerous flag, out-of-order function calls).
> 1. A description of why this pattern was detected (e.g., logic bug, introduces a security vulnerability, bad practice).
> 1. An alternative that resolves the issue (e.g., use another function, validate data first, discard the dangerous flag).
