### PR TITLE
Update severity/likelihood/impact for CWE-79

### DIFF
--- a/contrib/nodejsscan/xss_node.yaml
+++ b/contrib/nodejsscan/xss_node.yaml
@@ -129,7 +129,7 @@ rules:
       Scripting Vulnerability.
     languages:
       - javascript
-    severity: ERROR
+    severity: WARNING
     metadata:
       owasp: "A01:2017 - Injection"
       cwe: >-

--- a/csharp/razor/security/html-raw-json.yaml
+++ b/csharp/razor/security/html-raw-json.yaml
@@ -24,10 +24,10 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   paths:
     include:
     - '*.cshtml'
-  severity: ERROR
+  severity: WARNING

--- a/generic/html-templates/security/unquoted-attribute-var.yaml
+++ b/generic/html-templates/security/unquoted-attribute-var.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - generic

--- a/generic/html-templates/security/var-in-href.yaml
+++ b/generic/html-templates/security/var-in-href.yaml
@@ -29,7 +29,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - generic

--- a/generic/html-templates/security/var-in-script-src.yaml
+++ b/generic/html-templates/security/var-in-script-src.yaml
@@ -26,7 +26,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - generic

--- a/generic/html-templates/security/var-in-script-tag.yaml
+++ b/generic/html-templates/security/var-in-script-tag.yaml
@@ -29,7 +29,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - generic

--- a/go/lang/security/audit/net/formatted-template-string.yaml
+++ b/go/lang/security/audit/net/formatted-template-string.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages: [go]
   severity: WARNING

--- a/go/lang/security/audit/net/unescaped-data-in-htmlattr.yaml
+++ b/go/lang/security/audit/net/unescaped-data-in-htmlattr.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages: [go]
   severity: WARNING

--- a/go/lang/security/audit/net/unescaped-data-in-js.yaml
+++ b/go/lang/security/audit/net/unescaped-data-in-js.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages: [go]
   severity: WARNING

--- a/go/lang/security/audit/net/unescaped-data-in-url.yaml
+++ b/go/lang/security/audit/net/unescaped-data-in-url.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages: [go]
   severity: WARNING

--- a/go/lang/security/audit/net/wip-xss-using-responsewriter-and-printf.yaml
+++ b/go/lang/security/audit/net/wip-xss-using-responsewriter-and-printf.yaml
@@ -65,7 +65,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   severity: WARNING
   languages:

--- a/go/lang/security/audit/xss/import-text-template.yaml
+++ b/go/lang/security/audit/xss/import-text-template.yaml
@@ -26,8 +26,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
   severity: WARNING
   patterns:
     - pattern: |

--- a/go/lang/security/audit/xss/no-direct-write-to-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-direct-write-to-responsewriter.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   patterns:
   - pattern-either:

--- a/go/lang/security/audit/xss/no-fprintf-to-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-fprintf-to-responsewriter.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   severity: WARNING
   patterns:

--- a/go/lang/security/audit/xss/no-interpolation-in-tag.yaml
+++ b/go/lang/security/audit/xss/no-interpolation-in-tag.yaml
@@ -23,7 +23,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - generic

--- a/go/lang/security/audit/xss/no-interpolation-js-template-string.yaml
+++ b/go/lang/security/audit/xss/no-interpolation-js-template-string.yaml
@@ -25,7 +25,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - generic

--- a/go/lang/security/audit/xss/no-io-writestring-to-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-io-writestring-to-responsewriter.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   severity: WARNING
   patterns:

--- a/go/lang/security/audit/xss/no-printf-in-responsewriter.yaml
+++ b/go/lang/security/audit/xss/no-printf-in-responsewriter.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   severity: WARNING
   patterns:

--- a/go/lang/security/audit/xss/template-html-does-not-escape.yaml
+++ b/go/lang/security/audit/xss/template-html-does-not-escape.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages: [go]
   severity: WARNING

--- a/go/lang/security/injection/raw-html-format.yaml
+++ b/go/lang/security/injection/raw-html-format.yaml
@@ -27,7 +27,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
   mode: taint
   pattern-sources:

--- a/go/template/security/insecure-types.yaml
+++ b/go/template/security/insecure-types.yaml
@@ -31,7 +31,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - go

--- a/html/security/audit/eval-detected.yaml
+++ b/html/security/audit/eval-detected.yaml
@@ -20,7 +20,7 @@ rules:
       cwe2021-top25: true
       subcategory:
       - audit
-      likelihood: LOW
+      likelihood: MEDIUM
       impact: MEDIUM
       confidence: LOW
       references:

--- a/html/security/audit/insecure-document-method.yaml
+++ b/html/security/audit/insecure-document-method.yaml
@@ -19,7 +19,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
     references:

--- a/java/lang/security/audit/xss/no-direct-response-writer.yaml
+++ b/java/lang/security/audit/xss/no-direct-response-writer.yaml
@@ -40,7 +40,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   severity: WARNING

--- a/java/lang/security/audit/xssrequestwrapper-is-insecure.yaml
+++ b/java/lang/security/audit/xssrequestwrapper-is-insecure.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/java/lang/security/servletresponse-writer-xss.yaml
+++ b/java/lang/security/servletresponse-writer-xss.yaml
@@ -25,7 +25,7 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
-  severity: ERROR
+  severity: WARNING
   patterns:
   - pattern-inside: $TYPE $FUNC(..., HttpServletResponse $RESP, ...) { ... }
   - pattern-inside: $VAR = $REQ.getParameter(...); ...

--- a/java/spring/security/injection/tainted-html-string.yaml
+++ b/java/spring/security/injection/tainted-html-string.yaml
@@ -2,7 +2,7 @@ rules:
 - id: tainted-html-string
   languages:
   - java
-  severity: ERROR
+  severity: WARNING
   message: >-
     Detected user input flowing into a manually constructed HTML string.
     You may be accidentally bypassing secure methods of rendering HTML by
@@ -26,7 +26,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
     interfile: true

--- a/javascript/angular/security/detect-angular-element-methods.yaml
+++ b/javascript/angular/security/detect-angular-element-methods.yaml
@@ -22,12 +22,12 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - javascript
   - typescript
-  severity: INFO
+  severity: WARNING
   mode: taint
   pattern-sources:
   - patterns:

--- a/javascript/angular/security/detect-angular-element-taint.yaml
+++ b/javascript/angular/security/detect-angular-element-taint.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - javascript

--- a/javascript/angular/security/detect-angular-open-redirect.yaml
+++ b/javascript/angular/security/detect-angular-open-redirect.yaml
@@ -23,13 +23,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:
   - javascript
   - typescript
-  severity: ERROR
+  severity: WARNING
   patterns:
   - pattern: |
       $window.location.href = ...

--- a/javascript/angular/security/detect-angular-resource-loading.yaml
+++ b/javascript/angular/security/detect-angular-resource-loading.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/angular/security/detect-angular-sce-disabled.yaml
+++ b/javascript/angular/security/detect-angular-sce-disabled.yaml
@@ -19,12 +19,12 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: HIGH
   languages:
   - javascript
   - typescript
-  severity: ERROR
+  severity: WARNING
   pattern: |
     $sceProvider.enabled(false);

--- a/javascript/angular/security/detect-angular-trust-as-css.yaml
+++ b/javascript/angular/security/detect-angular-trust-as-css.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/angular/security/detect-angular-trust-as-html-method.yaml
+++ b/javascript/angular/security/detect-angular-trust-as-html-method.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/angular/security/detect-angular-trust-as-js-method.yaml
+++ b/javascript/angular/security/detect-angular-trust-as-js-method.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/angular/security/detect-angular-trust-as-method.yaml
+++ b/javascript/angular/security/detect-angular-trust-as-method.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages:

--- a/javascript/angular/security/detect-angular-trust-as-resourceurl-method.yaml
+++ b/javascript/angular/security/detect-angular-trust-as-resourceurl-method.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/angular/security/detect-angular-trust-as-url-method.yaml
+++ b/javascript/angular/security/detect-angular-trust-as-url-method.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/angular/security/detect-third-party-angular-translate.yaml
+++ b/javascript/angular/security/detect-third-party-angular-translate.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/audit/detect-replaceall-sanitization.yaml
+++ b/javascript/audit/detect-replaceall-sanitization.yaml
@@ -22,13 +22,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - javascript
   - typescript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern-either:
     - pattern: $STR.$FUNC('<', '&lt;')

--- a/javascript/browser/security/dom-based-xss.yaml
+++ b/javascript/browser/security/dom-based-xss.yaml
@@ -21,13 +21,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - javascript
   - typescript
-  severity: ERROR
+  severity: WARNING
   pattern-either:
   - pattern: document.write(<... document.location.$W ...>)
   - pattern: document.write(<... location.$W ...>)

--- a/javascript/browser/security/insecure-document-method.yaml
+++ b/javascript/browser/security/insecure-document-method.yaml
@@ -16,15 +16,15 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
     references:
     - https://owasp.org/Top10/A03_2021-Injection
   languages:
   - javascript
   - typescript
-  severity: ERROR
+  severity: WARNING
   patterns:
   - pattern-either:
     - pattern: |

--- a/javascript/browser/security/insecure-innerhtml.yaml
+++ b/javascript/browser/security/insecure-innerhtml.yaml
@@ -15,15 +15,15 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
     references:
     - https://owasp.org/Top10/A03_2021-Injection
   languages:
   - javascript
   - typescript
-  severity: ERROR
+  severity: WARNING
   patterns:
   - pattern: |
       $EL.innerHTML = $HTML;

--- a/javascript/browser/security/raw-html-join.yaml
+++ b/javascript/browser/security/raw-html-join.yaml
@@ -17,8 +17,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - javascript

--- a/javascript/dompurify.yaml
+++ b/javascript/dompurify.yaml
@@ -19,13 +19,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages:
   - js
   - ts
-  severity: ERROR
+  severity: WARNING
   patterns:
   - pattern: DOMPurify.sanitize($X, ...)
   - pattern-not: |

--- a/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/ejs/explicit-unescape.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/ejs/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-href.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-src.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/ejs/var-in-script-tag.yaml
@@ -25,7 +25,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/mustache/escape-function-overwrite.yaml
+++ b/javascript/express/security/audit/xss/mustache/escape-function-overwrite.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/mustache/explicit-unescape.yaml
@@ -23,7 +23,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/mustache/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-href.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/mustache/var-in-script-tag.yaml
@@ -25,7 +25,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/pug/and-attributes.yaml
+++ b/javascript/express/security/audit/xss/pug/and-attributes.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
+++ b/javascript/express/security/audit/xss/pug/explicit-unescape.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/pug/var-in-href.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-href.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
+++ b/javascript/express/security/audit/xss/pug/var-in-script-tag.yaml
@@ -25,7 +25,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/express/security/injection/raw-html-format.yaml
+++ b/javascript/express/security/injection/raw-html-format.yaml
@@ -19,7 +19,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages:

--- a/javascript/express/security/injection/tainted-sql-string.yaml
+++ b/javascript/express/security/injection/tainted-sql-string.yaml
@@ -24,13 +24,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages:
   - javascript
   - typescript
-  severity: ERROR
+  severity: WARNING
   mode: taint
   pattern-sources:
   - patterns:

--- a/javascript/fbjs/security/audit/insecure-createnodesfrommarkup.yaml
+++ b/javascript/fbjs/security/audit/insecure-createnodesfrommarkup.yaml
@@ -15,7 +15,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
     references:

--- a/javascript/jquery/security/audit/jquery-insecure-method.yaml
+++ b/javascript/jquery/security/audit/jquery-insecure-method.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/jquery/security/audit/jquery-insecure-selector.yaml
+++ b/javascript/jquery/security/audit/jquery-insecure-selector.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/jquery/security/audit/prohibit-jquery-html.yaml
+++ b/javascript/jquery/security/audit/prohibit-jquery-html.yaml
@@ -29,7 +29,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/javascript/lang/security/audit/unknown-value-with-script-tag.yaml
+++ b/javascript/lang/security/audit/unknown-value-with-script-tag.yaml
@@ -20,8 +20,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - javascript

--- a/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.yaml
+++ b/javascript/monaco-editor/security/audit/monaco-hover-htmlsupport.yaml
@@ -20,8 +20,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript

--- a/javascript/vue/security/audit/xss/templates/avoid-v-html.yaml
+++ b/javascript/vue/security/audit/xss/templates/avoid-v-html.yaml
@@ -18,8 +18,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - regex

--- a/php/lang/security/injection/echoed-request.yaml
+++ b/php/lang/security/injection/echoed-request.yaml
@@ -5,7 +5,7 @@ rules:
     `Echo`ing user input risks cross-site scripting vulnerability.
     You should use `htmlentities()` when showing data to users.
   languages: [php]
-  severity: ERROR
+  severity: WARNING
   pattern-sources:
   - pattern: $_REQUEST
   - pattern: $_GET

--- a/python/aws-lambda/security/tainted-html-response.yaml
+++ b/python/aws-lambda/security/tainted-html-response.yaml
@@ -32,7 +32,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages:

--- a/python/aws-lambda/security/tainted-html-string.yaml
+++ b/python/aws-lambda/security/tainted-html-string.yaml
@@ -26,7 +26,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   mode: taint

--- a/python/django/security/audit/avoid-mark-safe.yaml
+++ b/python/django/security/audit/avoid-mark-safe.yaml
@@ -26,7 +26,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages: [python]

--- a/python/django/security/audit/xss/class-extends-safestring.yaml
+++ b/python/django/security/audit/xss/class-extends-safestring.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/context-autoescape-off.yaml
+++ b/python/django/security/audit/xss/context-autoescape-off.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
+++ b/python/django/security/audit/xss/direct-use-of-httpresponse.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/filter-with-is-safe.yaml
+++ b/python/django/security/audit/xss/filter-with-is-safe.yaml
@@ -25,7 +25,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/formathtml-fstring-parameter.yaml
+++ b/python/django/security/audit/xss/formathtml-fstring-parameter.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/global-autoescape-off.yaml
+++ b/python/django/security/audit/xss/global-autoescape-off.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/html-magic-method.yaml
+++ b/python/django/security/audit/xss/html-magic-method.yaml
@@ -23,7 +23,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/html-safe.yaml
+++ b/python/django/security/audit/xss/html-safe.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/template-autoescape-off.yaml
+++ b/python/django/security/audit/xss/template-autoescape-off.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/template-blocktranslate-no-escape.yaml
+++ b/python/django/security/audit/xss/template-blocktranslate-no-escape.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: template-blocktranslate-no-escape
   languages: [generic]
-  severity: INFO
+  severity: WARNING
   message: >-
     Translated strings will not be escaped when rendered in a template.
     This leads to a vulnerability where translators could include malicious script tags in their translations.
@@ -41,6 +41,6 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW

--- a/python/django/security/audit/xss/template-href-var.yaml
+++ b/python/django/security/audit/xss/template-href-var.yaml
@@ -24,8 +24,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: MEDIUM  
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - generic

--- a/python/django/security/audit/xss/template-translate-as-no-escape.yaml
+++ b/python/django/security/audit/xss/template-translate-as-no-escape.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: template-translate-as-no-escape
   languages: [generic]
-  severity: INFO
+  severity: WARNING
   message: >-
     Translated strings will not be escaped when rendered in a template.
     This leads to a vulnerability where translators could include malicious script tags in their translations.
@@ -124,6 +124,6 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW

--- a/python/django/security/audit/xss/template-translate-no-escape.yaml
+++ b/python/django/security/audit/xss/template-translate-no-escape.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: template-translate-no-escape
   languages: [generic]
-  severity: INFO
+  severity: WARNING
   message: >-
     This rule is deprecated. It will no longer produce findings.
   patterns:
@@ -24,6 +24,6 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW

--- a/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
+++ b/python/django/security/audit/xss/template-var-unescaped-with-safeseq.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/django/security/audit/xss/var-in-script-tag.yaml
+++ b/python/django/security/audit/xss/var-in-script-tag.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: var-in-script-tag
   languages: [generic]
-  severity: ERROR
+  severity: WARNING
   message: >-
     Detected a template variable used in a script tag.
     Although template variables are HTML escaped, HTML
@@ -38,6 +38,6 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW

--- a/python/django/security/injection/raw-html-format.yaml
+++ b/python/django/security/injection/raw-html-format.yaml
@@ -25,7 +25,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   mode: taint

--- a/python/django/security/injection/reflected-data-httpresponsebadrequest.yaml
+++ b/python/django/security/injection/reflected-data-httpresponsebadrequest.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages: [python]

--- a/python/flask/security/audit/directly-returned-format-string.yaml
+++ b/python/flask/security/audit/directly-returned-format-string.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages:

--- a/python/flask/security/audit/xss/make-response-with-unknown-content.yaml
+++ b/python/flask/security/audit/xss/make-response-with-unknown-content.yaml
@@ -46,7 +46,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/flask/security/unescaped-template-extension.yaml
+++ b/python/flask/security/unescaped-template-extension.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   patterns:

--- a/python/flask/security/unsanitized-input.yaml
+++ b/python/flask/security/unsanitized-input.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages: [python]

--- a/python/flask/security/xss/audit/direct-use-of-jinja2.yaml
+++ b/python/flask/security/xss/audit/direct-use-of-jinja2.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/flask/security/xss/audit/explicit-unescape-with-markup.yaml
+++ b/python/flask/security/xss/audit/explicit-unescape-with-markup.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/flask/security/xss/audit/template-autoescape-off.yaml
+++ b/python/flask/security/xss/audit/template-autoescape-off.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/flask/security/xss/audit/template-href-var.yaml
+++ b/python/flask/security/xss/audit/template-href-var.yaml
@@ -23,7 +23,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
+++ b/python/flask/security/xss/audit/template-unescaped-with-safe.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
+++ b/python/flask/security/xss/audit/template-unquoted-attribute-var.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/python/lang/security/audit/mako-templates-detected.yaml
+++ b/python/lang/security/audit/mako-templates-detected.yaml
@@ -24,8 +24,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages: [python]
-  severity: INFO
+  severity: WARNING

--- a/python/pyramid/security/direct-use-of-response.yaml
+++ b/python/pyramid/security/direct-use-of-response.yaml
@@ -20,12 +20,12 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   languages:
   - python
-  severity: ERROR
+  severity: WARNING
   mode: taint
   pattern-sources:
   - patterns:

--- a/ruby/lang/security/json-encoding.yaml
+++ b/ruby/lang/security/json-encoding.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/ruby/lang/security/json-entity-escape.yaml
+++ b/ruby/lang/security/json-entity-escape.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/ruby/rails/security/audit/mail-to-erb.yaml
+++ b/ruby/rails/security/audit/mail-to-erb.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/mail-to.yaml
+++ b/ruby/rails/security/audit/mail-to.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/number-to-currency-erb.yaml
+++ b/ruby/rails/security/audit/number-to-currency-erb.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/number-to-currency.yaml
+++ b/ruby/rails/security/audit/number-to-currency.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/xss/avoid-content-tag.yaml
+++ b/ruby/rails/security/audit/xss/avoid-content-tag.yaml
@@ -17,7 +17,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/xss/avoid-html-safe.yaml
+++ b/ruby/rails/security/audit/xss/avoid-html-safe.yaml
@@ -17,7 +17,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/xss/avoid-link-to.yaml
+++ b/ruby/rails/security/audit/xss/avoid-link-to.yaml
@@ -17,7 +17,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   message: >-

--- a/ruby/rails/security/audit/xss/avoid-raw.yaml
+++ b/ruby/rails/security/audit/xss/avoid-raw.yaml
@@ -17,7 +17,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/xss/avoid-render-inline.yaml
+++ b/ruby/rails/security/audit/xss/avoid-render-inline.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/xss/avoid-render-text.yaml
+++ b/ruby/rails/security/audit/xss/avoid-render-text.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/xss/manual-template-creation.yaml
+++ b/ruby/rails/security/audit/xss/manual-template-creation.yaml
@@ -16,7 +16,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   message: >-

--- a/ruby/rails/security/audit/xss/templates/alias-for-html-safe.yaml
+++ b/ruby/rails/security/audit/xss/templates/alias-for-html-safe.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages: [generic]

--- a/ruby/rails/security/audit/xss/templates/avoid-content-tag.yaml
+++ b/ruby/rails/security/audit/xss/templates/avoid-content-tag.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages: [generic]

--- a/ruby/rails/security/audit/xss/templates/avoid-html-safe.yaml
+++ b/ruby/rails/security/audit/xss/templates/avoid-html-safe.yaml
@@ -23,7 +23,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages: [generic]

--- a/ruby/rails/security/audit/xss/templates/avoid-raw.yaml
+++ b/ruby/rails/security/audit/xss/templates/avoid-raw.yaml
@@ -23,7 +23,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages: [generic]

--- a/ruby/rails/security/audit/xss/templates/dangerous-link-to.yaml
+++ b/ruby/rails/security/audit/xss/templates/dangerous-link-to.yaml
@@ -26,7 +26,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/ruby/rails/security/audit/xss/templates/unquoted-attribute.yaml
+++ b/ruby/rails/security/audit/xss/templates/unquoted-attribute.yaml
@@ -20,7 +20,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/ruby/rails/security/audit/xss/templates/var-in-href.yaml
+++ b/ruby/rails/security/audit/xss/templates/var-in-href.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/ruby/rails/security/audit/xss/templates/var-in-script-tag.yaml
+++ b/ruby/rails/security/audit/xss/templates/var-in-script-tag.yaml
@@ -26,7 +26,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
   languages:

--- a/ruby/rails/security/injection/raw-html-format.yaml
+++ b/ruby/rails/security/injection/raw-html-format.yaml
@@ -26,7 +26,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
   mode: taint

--- a/ruby/rails/security/injection/tainted-sql-string.yaml
+++ b/ruby/rails/security/injection/tainted-sql-string.yaml
@@ -2,7 +2,7 @@ rules:
 - id: tainted-sql-string
   languages:
   - ruby
-  severity: ERROR
+  severity: WARNING
   message: Detected user input used to manually construct a SQL string. This is usually bad practice because
     manual construction could accidentally result in a SQL injection. An attacker could use a SQL injection
     to steal or modify contents of the database. Instead, use a parameterized query which is available
@@ -25,7 +25,7 @@ rules:
     subcategory:
     - vuln
     likelihood: MEDIUM
-    impact: HIGH
+    impact: MEDIUM
     confidence: MEDIUM
   mode: taint
   pattern-sources:

--- a/ruby/rails/security/injection/tainted-url-host.yaml
+++ b/ruby/rails/security/injection/tainted-url-host.yaml
@@ -28,7 +28,7 @@ rules:
     subcategory:
     - vuln
     likelihood: MEDIUM
-    impact: HIGH
+    impact: MEDIUM
     confidence: MEDIUM
   mode: taint
   pattern-sanitizers:

--- a/scala/play/security/tainted-html-response.yaml
+++ b/scala/play/security/tainted-html-response.yaml
@@ -18,7 +18,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
   message: >-
     Detected a request with potential user-input going into an `Ok()` response.  This bypasses any view

--- a/scala/play/security/twirl-html-var.yaml
+++ b/scala/play/security/twirl-html-var.yaml
@@ -40,5 +40,5 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM

--- a/typescript/angular/security/audit/angular-domsanitizer.yaml
+++ b/typescript/angular/security/audit/angular-domsanitizer.yaml
@@ -25,7 +25,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - typescript

--- a/typescript/nestjs/security/audit/nestjs-header-xss-disabled.yaml
+++ b/typescript/nestjs/security/audit/nestjs-header-xss-disabled.yaml
@@ -17,8 +17,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript

--- a/typescript/react/security/audit/react-css-injection.yaml
+++ b/typescript/react/security/audit/react-css-injection.yaml
@@ -18,13 +18,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript
   - javascript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -21,7 +21,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - typescript

--- a/typescript/react/security/audit/react-html-element-spreading.yaml
+++ b/typescript/react/security/audit/react-html-element-spreading.yaml
@@ -18,13 +18,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript
   - javascript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/typescript/react/security/audit/react-no-refs.yaml
+++ b/typescript/react/security/audit/react-no-refs.yaml
@@ -18,13 +18,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript
   - javascript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/typescript/react/security/audit/react-props-injection.yaml
+++ b/typescript/react/security/audit/react-props-injection.yaml
@@ -18,13 +18,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript
   - javascript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/typescript/react/security/audit/react-router-redirect.yaml
+++ b/typescript/react/security/audit/react-router-redirect.yaml
@@ -20,13 +20,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript
   - javascript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/typescript/react/security/audit/react-styled-components-injection.yaml
+++ b/typescript/react/security/audit/react-styled-components-injection.yaml
@@ -18,13 +18,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript
   - javascript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/typescript/react/security/audit/react-unsanitized-method.yaml
+++ b/typescript/react/security/audit/react-unsanitized-method.yaml
@@ -24,7 +24,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: MEDIUM
     impact: MEDIUM
   languages:
   - typescript

--- a/typescript/react/security/react-controlled-component-password.yaml
+++ b/typescript/react/security/react-controlled-component-password.yaml
@@ -18,13 +18,13 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript
   - javascript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/typescript/react/security/react-markdown-insecure-html.yaml
+++ b/typescript/react/security/react-markdown-insecure-html.yaml
@@ -18,8 +18,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: LOW
-    impact: LOW
+    likelihood: MEDIUM
+    impact: MEDIUM
     confidence: LOW
   languages:
   - typescript


### PR DESCRIPTION
This PR updates likelihood/impact to match the default value defined in our jsonnet reference. Severity is computed from likelihood/impact.

NOTE TO REVIEWERS: please comment if you believe any of severity/impact/likelihood for a given rule should be overridden and not be the default.