### PR TITLE
Update metadata for the rule detect-no-csrf-before-method-override, add additional owasp number of the same vulnerability

### DIFF
--- a/javascript/lang/security/detect-no-csrf-before-method-override.yaml
+++ b/javascript/lang/security/detect-no-csrf-before-method-override.yaml
@@ -16,6 +16,7 @@ rules:
     - javascript
     owasp:
     - A01:2021 - Broken Access Control
+    - A05:2017 - Broken Access Control
     cwe2022-top25: true
     cwe2021-top25: true
     subcategory:


### PR DESCRIPTION
Small fix for documentation testing. The goal of this PR is to have hands-on experience in updating a rule as a user would.

The actual change in this PR: As suggested by @inkz - some customers may still use the older OWASP number for this vulnerability - https://owasp.org/www-project-top-ten/2017/A5_2017-Broken_Access_Control. This PR adds the older OWASP number. 

