### PR TITLE
Update severity/likelihood/impact for CWE-798

### DIFF
--- a/contrib/nodejsscan/jwt_hardcoded.yaml
+++ b/contrib/nodejsscan/jwt_hardcoded.yaml
@@ -67,7 +67,7 @@ rules:
     message: Hardcoded JWT secret was found. Store it properly in an environment variable.
     languages:
       - javascript
-    severity: ERROR
+    severity: WARNING
     metadata:
       owasp: "A03:2017 - Sensitive Data Exposure"
       cwe: "CWE-798: Use of Hard-coded Credentials"

--- a/generic/secrets/gitleaks/adafruit-api-key.yaml
+++ b/generic/secrets/gitleaks/adafruit-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks adafruit-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/adobe-client-id.yaml
+++ b/generic/secrets/gitleaks/adobe-client-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks adobe-client-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/adobe-client-secret.yaml
+++ b/generic/secrets/gitleaks/adobe-client-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks adobe-client-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/age-secret-key.yaml
+++ b/generic/secrets/gitleaks/age-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks age secret key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/airtable-api-key.yaml
+++ b/generic/secrets/gitleaks/airtable-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks airtable-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/algolia-api-key.yaml
+++ b/generic/secrets/gitleaks/algolia-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks algolia-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/alibaba-access-key-id.yaml
+++ b/generic/secrets/gitleaks/alibaba-access-key-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks alibaba-access-key-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/alibaba-secret-key.yaml
+++ b/generic/secrets/gitleaks/alibaba-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks alibaba-secret-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/asana-client-id.yaml
+++ b/generic/secrets/gitleaks/asana-client-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks asana-client-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/asana-client-secret.yaml
+++ b/generic/secrets/gitleaks/asana-client-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks asana-client-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/atlassian-api-token.yaml
+++ b/generic/secrets/gitleaks/atlassian-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks atlassian-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/aws-access-token.yaml
+++ b/generic/secrets/gitleaks/aws-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks aws-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/beamer-api-token.yaml
+++ b/generic/secrets/gitleaks/beamer-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks beamer-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/bitbucket-client-id.yaml
+++ b/generic/secrets/gitleaks/bitbucket-client-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks bitbucket-client-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/bitbucket-client-secret.yaml
+++ b/generic/secrets/gitleaks/bitbucket-client-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks bitbucket-client-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/bittrex-access-key.yaml
+++ b/generic/secrets/gitleaks/bittrex-access-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks bittrex-access-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/bittrex-secret-key.yaml
+++ b/generic/secrets/gitleaks/bittrex-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks bittrex-secret-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/clojars-api-token.yaml
+++ b/generic/secrets/gitleaks/clojars-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks clojars-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/codecov-access-token.yaml
+++ b/generic/secrets/gitleaks/codecov-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks codecov-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/coinbase-access-token.yaml
+++ b/generic/secrets/gitleaks/coinbase-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks coinbase-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/confluent-access-token.yaml
+++ b/generic/secrets/gitleaks/confluent-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks confluent-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/confluent-secret-key.yaml
+++ b/generic/secrets/gitleaks/confluent-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks confluent-secret-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/contentful-delivery-api-token.yaml
+++ b/generic/secrets/gitleaks/contentful-delivery-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks contentful-delivery-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/databricks-api-token.yaml
+++ b/generic/secrets/gitleaks/databricks-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks databricks-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/datadog-access-token.yaml
+++ b/generic/secrets/gitleaks/datadog-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks datadog-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/digitalocean-access-token.yaml
+++ b/generic/secrets/gitleaks/digitalocean-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks digitalocean-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/digitalocean-pat.yaml
+++ b/generic/secrets/gitleaks/digitalocean-pat.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks digitalocean-pat was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/digitalocean-refresh-token.yaml
+++ b/generic/secrets/gitleaks/digitalocean-refresh-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks digitalocean-refresh-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/discord-api-token.yaml
+++ b/generic/secrets/gitleaks/discord-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks discord-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/discord-client-id.yaml
+++ b/generic/secrets/gitleaks/discord-client-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks discord-client-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/discord-client-secret.yaml
+++ b/generic/secrets/gitleaks/discord-client-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks discord-client-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/doppler-api-token.yaml
+++ b/generic/secrets/gitleaks/doppler-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks doppler-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/droneci-access-token.yaml
+++ b/generic/secrets/gitleaks/droneci-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks droneci-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/dropbox-api-token.yaml
+++ b/generic/secrets/gitleaks/dropbox-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks dropbox-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/dropbox-long-lived-api-token.yaml
+++ b/generic/secrets/gitleaks/dropbox-long-lived-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks dropbox-long-lived-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/dropbox-short-lived-api-token.yaml
+++ b/generic/secrets/gitleaks/dropbox-short-lived-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks dropbox-short-lived-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/duffel-api-token.yaml
+++ b/generic/secrets/gitleaks/duffel-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks duffel-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/dynatrace-api-token.yaml
+++ b/generic/secrets/gitleaks/dynatrace-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks dynatrace-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/easypost-api-token.yaml
+++ b/generic/secrets/gitleaks/easypost-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks easypost-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/easypost-test-api-token.yaml
+++ b/generic/secrets/gitleaks/easypost-test-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks easypost-test-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/etsy-access-token.yaml
+++ b/generic/secrets/gitleaks/etsy-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks etsy-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/facebook.yaml
+++ b/generic/secrets/gitleaks/facebook.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks facebook was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/fastly-api-token.yaml
+++ b/generic/secrets/gitleaks/fastly-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks fastly-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/finicity-api-token.yaml
+++ b/generic/secrets/gitleaks/finicity-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks finicity-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/finicity-client-secret.yaml
+++ b/generic/secrets/gitleaks/finicity-client-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks finicity-client-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/finnhub-access-token.yaml
+++ b/generic/secrets/gitleaks/finnhub-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks finnhub-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/flickr-access-token.yaml
+++ b/generic/secrets/gitleaks/flickr-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks flickr-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/flutterwave-encryption-key.yaml
+++ b/generic/secrets/gitleaks/flutterwave-encryption-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks flutterwave-encryption-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/flutterwave-public-key.yaml
+++ b/generic/secrets/gitleaks/flutterwave-public-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks flutterwave-public-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/flutterwave-secret-key.yaml
+++ b/generic/secrets/gitleaks/flutterwave-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks flutterwave-secret-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/frameio-api-token.yaml
+++ b/generic/secrets/gitleaks/frameio-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks frameio-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/freshbooks-access-token.yaml
+++ b/generic/secrets/gitleaks/freshbooks-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks freshbooks-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/gcp-api-key.yaml
+++ b/generic/secrets/gitleaks/gcp-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks gcp-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/generic-api-key.yaml
+++ b/generic/secrets/gitleaks/generic-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks generic-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/github-app-token.yaml
+++ b/generic/secrets/gitleaks/github-app-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks github-app-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/github-fine-grained-pat.yaml
+++ b/generic/secrets/gitleaks/github-fine-grained-pat.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks github-fine-grained-pat was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/github-oauth.yaml
+++ b/generic/secrets/gitleaks/github-oauth.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks github-oauth was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/github-pat.yaml
+++ b/generic/secrets/gitleaks/github-pat.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks github-pat was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/github-refresh-token.yaml
+++ b/generic/secrets/gitleaks/github-refresh-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks github-refresh-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/gitlab-pat.yaml
+++ b/generic/secrets/gitleaks/gitlab-pat.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks gitlab-pat was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/gitlab-ptt.yaml
+++ b/generic/secrets/gitleaks/gitlab-ptt.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks gitlab-ptt was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/gitlab-rrt.yaml
+++ b/generic/secrets/gitleaks/gitlab-rrt.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks gitlab-rrt was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/gitter-access-token.yaml
+++ b/generic/secrets/gitleaks/gitter-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks gitter-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/gocardless-api-token.yaml
+++ b/generic/secrets/gitleaks/gocardless-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks gocardless-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/grafana-api-key.yaml
+++ b/generic/secrets/gitleaks/grafana-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks grafana-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/grafana-cloud-api-token.yaml
+++ b/generic/secrets/gitleaks/grafana-cloud-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks grafana-cloud-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/grafana-service-account-token.yaml
+++ b/generic/secrets/gitleaks/grafana-service-account-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks grafana-service-account-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/hashicorp-tf-api-token.yaml
+++ b/generic/secrets/gitleaks/hashicorp-tf-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks hashicorp-tf-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/heroku-api-key.yaml
+++ b/generic/secrets/gitleaks/heroku-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks heroku-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/hubspot-api-key.yaml
+++ b/generic/secrets/gitleaks/hubspot-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks hubspot-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/intercom-api-key.yaml
+++ b/generic/secrets/gitleaks/intercom-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks intercom-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/jwt.yaml
+++ b/generic/secrets/gitleaks/jwt.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks jwt was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/kraken-access-token.yaml
+++ b/generic/secrets/gitleaks/kraken-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks kraken-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/kucoin-access-token.yaml
+++ b/generic/secrets/gitleaks/kucoin-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks kucoin-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/kucoin-secret-key.yaml
+++ b/generic/secrets/gitleaks/kucoin-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks kucoin-secret-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/launchdarkly-access-token.yaml
+++ b/generic/secrets/gitleaks/launchdarkly-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks launchdarkly-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/linear-api-key.yaml
+++ b/generic/secrets/gitleaks/linear-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks linear-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/linear-client-secret.yaml
+++ b/generic/secrets/gitleaks/linear-client-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks linear-client-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/linkedin-client-id.yaml
+++ b/generic/secrets/gitleaks/linkedin-client-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks linkedin-client-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/linkedin-client-secret.yaml
+++ b/generic/secrets/gitleaks/linkedin-client-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks linkedin-client-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/lob-api-key.yaml
+++ b/generic/secrets/gitleaks/lob-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks lob-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/lob-pub-api-key.yaml
+++ b/generic/secrets/gitleaks/lob-pub-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks lob-pub-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/mailchimp-api-key.yaml
+++ b/generic/secrets/gitleaks/mailchimp-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks mailchimp-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/mailgun-private-api-token.yaml
+++ b/generic/secrets/gitleaks/mailgun-private-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks mailgun-private-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/mailgun-pub-key.yaml
+++ b/generic/secrets/gitleaks/mailgun-pub-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks mailgun-pub-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/mailgun-signing-key.yaml
+++ b/generic/secrets/gitleaks/mailgun-signing-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks mailgun-signing-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/mapbox-api-token.yaml
+++ b/generic/secrets/gitleaks/mapbox-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks mapbox-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/mattermost-access-token.yaml
+++ b/generic/secrets/gitleaks/mattermost-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks mattermost-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/messagebird-api-token.yaml
+++ b/generic/secrets/gitleaks/messagebird-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks messagebird-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/messagebird-client-id.yaml
+++ b/generic/secrets/gitleaks/messagebird-client-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks messagebird-client-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/microsoft-teams-webhook.yaml
+++ b/generic/secrets/gitleaks/microsoft-teams-webhook.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks microsoft-teams-webhook was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/netlify-access-token.yaml
+++ b/generic/secrets/gitleaks/netlify-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks netlify-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/new-relic-browser-api-token.yaml
+++ b/generic/secrets/gitleaks/new-relic-browser-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks new-relic-browser-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/new-relic-user-api-id.yaml
+++ b/generic/secrets/gitleaks/new-relic-user-api-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks new-relic-user-api-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/new-relic-user-api-key.yaml
+++ b/generic/secrets/gitleaks/new-relic-user-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks new-relic-user-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/npm-access-token.yaml
+++ b/generic/secrets/gitleaks/npm-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks npm-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/nytimes-access-token.yaml
+++ b/generic/secrets/gitleaks/nytimes-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks nytimes-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/okta-access-token.yaml
+++ b/generic/secrets/gitleaks/okta-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks okta-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/plaid-api-token.yaml
+++ b/generic/secrets/gitleaks/plaid-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks plaid-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/plaid-client-id.yaml
+++ b/generic/secrets/gitleaks/plaid-client-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks plaid-client-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/plaid-secret-key.yaml
+++ b/generic/secrets/gitleaks/plaid-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks plaid-secret-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/planetscale-api-token.yaml
+++ b/generic/secrets/gitleaks/planetscale-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks planetscale-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/planetscale-oauth-token.yaml
+++ b/generic/secrets/gitleaks/planetscale-oauth-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks planetscale-oauth-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/planetscale-password.yaml
+++ b/generic/secrets/gitleaks/planetscale-password.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks planetscale-password was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/postman-api-token.yaml
+++ b/generic/secrets/gitleaks/postman-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks postman-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/prefect-api-token.yaml
+++ b/generic/secrets/gitleaks/prefect-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks prefect-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/private-key.yaml
+++ b/generic/secrets/gitleaks/private-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks private-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/pulumi-api-token.yaml
+++ b/generic/secrets/gitleaks/pulumi-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks pulumi-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/pypi-upload-token.yaml
+++ b/generic/secrets/gitleaks/pypi-upload-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks pypi-upload-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/rapidapi-access-token.yaml
+++ b/generic/secrets/gitleaks/rapidapi-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks rapidapi-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/readme-api-token.yaml
+++ b/generic/secrets/gitleaks/readme-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks readme-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/rubygems-api-token.yaml
+++ b/generic/secrets/gitleaks/rubygems-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks rubygems-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sendbird-access-id.yaml
+++ b/generic/secrets/gitleaks/sendbird-access-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sendbird-access-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sendbird-access-token.yaml
+++ b/generic/secrets/gitleaks/sendbird-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sendbird-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sendgrid-api-token.yaml
+++ b/generic/secrets/gitleaks/sendgrid-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sendgrid-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sendinblue-api-token.yaml
+++ b/generic/secrets/gitleaks/sendinblue-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sendinblue-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sentry-access-token.yaml
+++ b/generic/secrets/gitleaks/sentry-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sentry-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/shippo-api-token.yaml
+++ b/generic/secrets/gitleaks/shippo-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks shippo-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/shopify-access-token.yaml
+++ b/generic/secrets/gitleaks/shopify-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks shopify-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/shopify-custom-access-token.yaml
+++ b/generic/secrets/gitleaks/shopify-custom-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks shopify-custom-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/shopify-private-app-access-token.yaml
+++ b/generic/secrets/gitleaks/shopify-private-app-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks shopify-private-app-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/shopify-shared-secret.yaml
+++ b/generic/secrets/gitleaks/shopify-shared-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks shopify-shared-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sidekiq-secret.yaml
+++ b/generic/secrets/gitleaks/sidekiq-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sidekiq-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sidekiq-sensitive-url.yaml
+++ b/generic/secrets/gitleaks/sidekiq-sensitive-url.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sidekiq-sensitive-url was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/slack-access-token.yaml
+++ b/generic/secrets/gitleaks/slack-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks slack-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/slack-web-hook.yaml
+++ b/generic/secrets/gitleaks/slack-web-hook.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks slack-web-hook was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/square-access-token.yaml
+++ b/generic/secrets/gitleaks/square-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks square-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/squarespace-access-token.yaml
+++ b/generic/secrets/gitleaks/squarespace-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks squarespace-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/stripe-access-token.yaml
+++ b/generic/secrets/gitleaks/stripe-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks stripe-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sumologic-access-id.yaml
+++ b/generic/secrets/gitleaks/sumologic-access-id.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sumologic-access-id was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/sumologic-access-token.yaml
+++ b/generic/secrets/gitleaks/sumologic-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks sumologic-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/telegram-bot-api-token.yaml
+++ b/generic/secrets/gitleaks/telegram-bot-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks telegram-bot-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/travisci-access-token.yaml
+++ b/generic/secrets/gitleaks/travisci-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks travisci-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/twilio-api-key.yaml
+++ b/generic/secrets/gitleaks/twilio-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks twilio-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/twitch-api-token.yaml
+++ b/generic/secrets/gitleaks/twitch-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks twitch-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/twitter-access-secret.yaml
+++ b/generic/secrets/gitleaks/twitter-access-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks twitter-access-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/twitter-access-token.yaml
+++ b/generic/secrets/gitleaks/twitter-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks twitter-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/twitter-api-key.yaml
+++ b/generic/secrets/gitleaks/twitter-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks twitter-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/twitter-api-secret.yaml
+++ b/generic/secrets/gitleaks/twitter-api-secret.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks twitter-api-secret was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/twitter-bearer-token.yaml
+++ b/generic/secrets/gitleaks/twitter-bearer-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks twitter-bearer-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/typeform-api-token.yaml
+++ b/generic/secrets/gitleaks/typeform-api-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks typeform-api-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/vault-batch-token.yaml
+++ b/generic/secrets/gitleaks/vault-batch-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks vault-batch-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/vault-service-token.yaml
+++ b/generic/secrets/gitleaks/vault-service-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks vault-service-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/yandex-access-token.yaml
+++ b/generic/secrets/gitleaks/yandex-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks yandex-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/yandex-api-key.yaml
+++ b/generic/secrets/gitleaks/yandex-api-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks yandex-api-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/yandex-aws-access-token.yaml
+++ b/generic/secrets/gitleaks/yandex-aws-access-token.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks yandex-aws-access-token was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/gitleaks/zendesk-secret-key.yaml
+++ b/generic/secrets/gitleaks/zendesk-secret-key.yaml
@@ -3,10 +3,10 @@ rules:
   message: A gitleaks zendesk-secret-key was detected which attempts to identify hard-coded credentials. It is not recommended to store credentials in source-code, as this risks secrets being leaked and used by either an internal or external malicious adversary. It is recommended to use environment variables to securely provide credentials or retrieve credentials from a secure vault or HSM (Hardware Security Module).
   languages:
     - regex
-  severity: INFO
+  severity: WARNING
   metadata:
       likelihood: LOW
-      impact: MEDIUM
+      impact: HIGH
       confidence: LOW
       category: security
       cwe:

--- a/generic/secrets/security/detected-amazon-mws-auth-token.yaml
+++ b/generic/secrets/security/detected-amazon-mws-auth-token.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
   languages: [regex]
   message: Amazon MWS Auth Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-artifactory-password.yaml
+++ b/generic/secrets/security/detected-artifactory-password.yaml
@@ -7,7 +7,7 @@ rules:
       sha(128|256|512).*
   languages: [regex]
   message: Artifactory token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-artifactory-token.yaml
+++ b/generic/secrets/security/detected-artifactory-token.yaml
@@ -7,7 +7,7 @@ rules:
       sha(128|256|512).*
   languages: [regex]
   message: Artifactory token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-aws-access-key-id-value.yaml
+++ b/generic/secrets/security/detected-aws-access-key-id-value.yaml
@@ -6,7 +6,7 @@ rules:
   languages: [regex]
   message: AWS Access Key ID Value detected. This is a sensitive credential and should not be hardcoded
     here. Instead, read this value from an environment variable or keep it in a separate, private file.
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-aws-account-id.yaml
+++ b/generic/secrets/security/detected-aws-account-id.yaml
@@ -32,7 +32,7 @@ rules:
   languages: [generic]
   message: AWS Account ID detected. This is a sensitive credential and should not be hardcoded here. Instead,
     read the value from an environment variable or keep the value in a separate, private file.
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-aws-appsync-graphql-key.yaml
+++ b/generic/secrets/security/detected-aws-appsync-graphql-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: da2-[a-z0-9]{26}
   languages: [regex]
   message: AWS AppSync GraphQL Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-aws-secret-access-key.yaml
+++ b/generic/secrets/security/detected-aws-secret-access-key.yaml
@@ -6,7 +6,7 @@ rules:
   - pattern-not-regex: (?i)example|sample|test|fake
   languages: [regex]
   message: AWS Secret Access Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-aws-session-token.yaml
+++ b/generic/secrets/security/detected-aws-session-token.yaml
@@ -6,7 +6,7 @@ rules:
   - pattern-not-regex: (?i)example|sample|test|fake
   languages: [regex]
   message: AWS Session Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-bcrypt-hash.yaml
+++ b/generic/secrets/security/detected-bcrypt-hash.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: \$2[aby]?\$[\d]+\$[./A-Za-z0-9]{53}
   languages: [regex]
   message: bcrypt hash detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-codeclimate.yaml
+++ b/generic/secrets/security/detected-codeclimate.yaml
@@ -4,7 +4,7 @@ rules:
     (?i)codeclima.{0,50}["|'|`]?[0-9a-f]{64}["|'|`]?
   languages: [regex]
   message: CodeClimate detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/generic/secrets/security/detected-etc-shadow.yaml
+++ b/generic/secrets/security/detected-etc-shadow.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: root:[x!*]*:[0-9]*:[0-9]*
   languages: [regex]
   message: linux shadow file detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -20,5 +20,5 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH
 

--- a/generic/secrets/security/detected-facebook-access-token.yaml
+++ b/generic/secrets/security/detected-facebook-access-token.yaml
@@ -6,7 +6,7 @@ rules:
   - pattern-regex: EAAAAZAw4[0-9A-Za-z]+
   languages: [regex]
   message: Facebook Access Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -25,4 +25,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-facebook-oauth.yaml
+++ b/generic/secrets/security/detected-facebook-oauth.yaml
@@ -4,7 +4,7 @@ rules:
     [fF][aA][cC][eE][bB][oO][oO][kK].*[tT][oO][kK][eE][nN].*['|"]?[0-9a-f]{32}['|"]?
   languages: [regex]
   message: Facebook OAuth detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-generic-api-key.yaml
+++ b/generic/secrets/security/detected-generic-api-key.yaml
@@ -4,7 +4,7 @@ rules:
     [aA][pP][iI]_?[kK][eE][yY][=_:\s-]+['|"]?[0-9a-zA-Z]{32,45}['|"]?
   languages: [regex]
   message: Generic API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
     category: security
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-generic-secret.yaml
+++ b/generic/secrets/security/detected-generic-secret.yaml
@@ -4,7 +4,7 @@ rules:
     [sS][eE][cC][rR][eE][tT][:= \t]*['|\"]?[0-9a-zA-Z]{32,45}['|\"]?
   languages: [regex]
   message: Generic Secret detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-github-token.yaml
+++ b/generic/secrets/security/detected-github-token.yaml
@@ -24,7 +24,7 @@ rules:
       metavariable: $SECRET
   languages: [generic]
   message: GitHub Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -43,4 +43,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-google-api-key.yaml
+++ b/generic/secrets/security/detected-google-api-key.yaml
@@ -6,7 +6,7 @@ rules:
   languages:
   - regex
   message: Google API Key Detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -26,4 +26,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-google-cloud-api-key.yaml
+++ b/generic/secrets/security/detected-google-cloud-api-key.yaml
@@ -4,7 +4,7 @@ rules:
     AIza[0-9A-Za-z\\-_]{35}
   languages: [regex]
   message: Google Cloud API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-google-gcm-service-account.yaml
+++ b/generic/secrets/security/detected-google-gcm-service-account.yaml
@@ -4,7 +4,7 @@ rules:
     (("|'|`)?type("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?service_account("|'|`)?,?)
   languages: [regex]
   message: Google (GCM) Service account detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-google-oauth-access-token.yaml
+++ b/generic/secrets/security/detected-google-oauth-access-token.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: ya29\.[0-9A-Za-z\-_]+
   languages: [regex]
   message: Google OAuth Access Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-google-oauth.yaml
+++ b/generic/secrets/security/detected-google-oauth.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: '[0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com'
   languages: [regex]
   message: Google OAuth url detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-heroku-api-key.yaml
+++ b/generic/secrets/security/detected-heroku-api-key.yaml
@@ -4,7 +4,7 @@ rules:
     [hH][eE][rR][oO][kK][uU].*[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}
   languages: [regex]
   message: Heroku API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-hockeyapp.yaml
+++ b/generic/secrets/security/detected-hockeyapp.yaml
@@ -4,7 +4,7 @@ rules:
     (?i)hockey.{0,50}(\\\"|'|`)?[0-9a-f]{32}(\\\"|'|`)?
   languages: [regex]
   message: HockeyApp detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-kolide-api-key.yaml
+++ b/generic/secrets/security/detected-kolide-api-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: k2sk_v[0-9]_[0-9a-zA-Z]{24}
   languages: [regex]
   message: Kolide API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -21,4 +21,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-mailchimp-api-key.yaml
+++ b/generic/secrets/security/detected-mailchimp-api-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: '[0-9a-f]{32}-us[0-9]{1,2}'
   languages: [regex]
   message: MailChimp API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     source-rule-url: https://github.com/dxa4481/truffleHogRegexes/blob/master/truffleHogRegexes/regexes.json
     category: security
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-mailgun-api-key.yaml
+++ b/generic/secrets/security/detected-mailgun-api-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: key-[0-9a-zA-Z]{32}
   languages: [regex]
   message: Mailgun API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-npm-registry-auth-token.yaml
+++ b/generic/secrets/security/detected-npm-registry-auth-token.yaml
@@ -11,7 +11,7 @@ rules:
   paths:
     include:
     - '*npmrc*'
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -29,4 +29,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-npm-token.yaml
+++ b/generic/secrets/security/detected-npm-token.yaml
@@ -6,7 +6,7 @@ rules:
   languages: 
     - generic
   message: This rule has been deprecated, please use https://semgrep.dev/playground/r/generic.secrets.security.detected-npm-registry-auth-token.detected-npm-registry-auth-token instead.
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -25,4 +25,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-outlook-team.yaml
+++ b/generic/secrets/security/detected-outlook-team.yaml
@@ -4,7 +4,7 @@ rules:
     https://outlook\.office\.com/webhook/[0-9a-f-]{36}
   languages: [regex]
   message: Outlook Team detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-paypal-braintree-access-token.yaml
+++ b/generic/secrets/security/detected-paypal-braintree-access-token.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: access_token\$production\$[0-9a-z]{16}\$[0-9a-z]{32}
   languages: [regex]
   message: PayPal Braintree Access Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-pgp-private-key-block.yaml
+++ b/generic/secrets/security/detected-pgp-private-key-block.yaml
@@ -6,7 +6,7 @@ rules:
     Something that looks like a PGP private key block is detected. This is a potential
     hardcoded secret that could be leaked if this code is committed.
     Instead, remove this code block from the commit.
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -24,4 +24,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-picatic-api-key.yaml
+++ b/generic/secrets/security/detected-picatic-api-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: sk_live_[0-9a-z]{32}
   languages: [regex]
   message: Picatic API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-private-key.yaml
+++ b/generic/secrets/security/detected-private-key.yaml
@@ -17,7 +17,7 @@ rules:
   languages: [generic]
   message: Private Key detected. This is a sensitive credential and should not be hardcoded here. Instead,
     store this in a separate, private file.
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -35,4 +35,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-sauce-token.yaml
+++ b/generic/secrets/security/detected-sauce-token.yaml
@@ -4,7 +4,7 @@ rules:
     (?i)sauce.{0,50}(\\\"|'|`)?[0-9a-f-]{36}(\\\"|'|`)?
   languages: [regex]
   message: Sauce Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-sendgrid-api-key.yaml
+++ b/generic/secrets/security/detected-sendgrid-api-key.yaml
@@ -4,7 +4,7 @@ rules:
     SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9-]{43}\b
   languages: [regex]
   message: SendGrid API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-slack-token.yaml
+++ b/generic/secrets/security/detected-slack-token.yaml
@@ -5,7 +5,7 @@ rules:
   - pattern-regex: xox.-[0-9]{12}-[0-9]{12}-[0-9a-zA-Z]{24}
   languages: [regex]
   message: Slack Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -24,4 +24,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-slack-webhook.yaml
+++ b/generic/secrets/security/detected-slack-webhook.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: https://hooks\.slack\.com/services/T[a-zA-Z0-9_]{8,10}/B[a-zA-Z0-9_]{8,10}/[a-zA-Z0-9_]{24}
   languages: [regex]
   message: Slack Webhook detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     references:
     - https://api.slack.com/messaging/webhooks
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-snyk-api-key.yaml
+++ b/generic/secrets/security/detected-snyk-api-key.yaml
@@ -4,7 +4,7 @@ rules:
     (?i)snyk.{0,50}['|"|`]?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['"\s]?
   languages: [regex]
   message: Snyk API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-softlayer-api-key.yaml
+++ b/generic/secrets/security/detected-softlayer-api-key.yaml
@@ -4,7 +4,7 @@ rules:
     (?i)softlayer.{0,50}["|'|`]?[a-z0-9]{64}["|'|`]?
   languages: [regex]
   message: SoftLayer API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-sonarqube-docs-api-key.yaml
+++ b/generic/secrets/security/detected-sonarqube-docs-api-key.yaml
@@ -4,7 +4,7 @@ rules:
     (?i)sonar.{0,50}(\\\"|'|`)?[0-9a-f]{40}(\\\"|'|`)?
   languages: [regex]
   message: SonarQube Docs API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-square-access-token.yaml
+++ b/generic/secrets/security/detected-square-access-token.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: sq0atp-[0-9A-Za-z\-_]{22}
   languages: [regex]
   message: Square Access Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-square-oauth-secret.yaml
+++ b/generic/secrets/security/detected-square-oauth-secret.yaml
@@ -4,7 +4,7 @@ rules:
     sq0csp-[0-9A-Za-z\\\-_]{43}
   languages: [regex]
   message: Square OAuth Secret detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-ssh-password.yaml
+++ b/generic/secrets/security/detected-ssh-password.yaml
@@ -4,7 +4,7 @@ rules:
     sshpass -p.*['|\\\"]
   languages: [regex]
   message: SSH Password detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -23,4 +23,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-stripe-api-key.yaml
+++ b/generic/secrets/security/detected-stripe-api-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: sk_live_[0-9a-zA-Z]{24}
   languages: [regex]
   message: Stripe API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-stripe-restricted-api-key.yaml
+++ b/generic/secrets/security/detected-stripe-restricted-api-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: rk_live_[0-9a-zA-Z]{24}
   languages: [regex]
   message: Stripe Restricted API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: LOW
+    impact: HIGH

--- a/generic/secrets/security/detected-telegram-bot-api-key.yaml
+++ b/generic/secrets/security/detected-telegram-bot-api-key.yaml
@@ -7,7 +7,7 @@ rules:
   languages:
   - regex
   message: Telegram Bot API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -27,4 +27,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-twilio-api-key.yaml
+++ b/generic/secrets/security/detected-twilio-api-key.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: SK[0-9a-fA-F]{32}
   languages: [regex]
   message: Twilio API Key detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-twitter-access-token.yaml
+++ b/generic/secrets/security/detected-twitter-access-token.yaml
@@ -3,7 +3,7 @@ rules:
   pattern-regex: '[tT][wW][iI][tT][tT][eE][rR].*[1-9][0-9]+-[0-9a-zA-Z]{40}'
   languages: [regex]
   message: Twitter Access Token detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -22,4 +22,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-twitter-oauth.yaml
+++ b/generic/secrets/security/detected-twitter-oauth.yaml
@@ -7,7 +7,7 @@ rules:
         [tT][wW][iI][tT][tT][eE][rR].*hash.*=.*['|"]?[0-9a-zA-Z]{35,44}['|"]?
   languages: [regex]
   message: Twitter OAuth detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'
@@ -26,4 +26,4 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH

--- a/generic/secrets/security/detected-username-and-password-in-uri.yaml
+++ b/generic/secrets/security/detected-username-and-password-in-uri.yaml
@@ -14,7 +14,7 @@ rules:
   languages:
   - generic
   message: Username and password in URI detected
-  severity: ERROR
+  severity: WARNING
   metadata:
     owasp:
     - A07:2021 - Identification and Authentication Failures
@@ -31,5 +31,5 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: MEDIUM
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH

--- a/go/jwt-go/security/jwt.yaml
+++ b/go/jwt-go/security/jwt.yaml
@@ -22,8 +22,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
   severity: WARNING
   languages: [go]
   mode: taint

--- a/java/java-jwt/security/jwt-hardcode.yaml
+++ b/java/java-jwt/security/jwt-hardcode.yaml
@@ -23,7 +23,7 @@ rules:
     subcategory:
     - vuln
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH
     confidence: HIGH
   languages: [java]
   severity: WARNING

--- a/javascript/express/security/audit/express-session-hardcoded-secret.yaml
+++ b/javascript/express/security/audit/express-session-hardcoded-secret.yaml
@@ -22,7 +22,7 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
+    likelihood: LOW
     impact: HIGH
     confidence: HIGH
   languages:

--- a/javascript/express/security/express-jwt-hardcoded-secret.yaml
+++ b/javascript/express/security/express-jwt-hardcoded-secret.yaml
@@ -22,8 +22,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: HIGH
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: HIGH
   languages:
   - javascript

--- a/javascript/jose/security/jwt-exposed-credentials.yaml
+++ b/javascript/jose/security/jwt-exposed-credentials.yaml
@@ -18,12 +18,12 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: LOW
+    impact: HIGH
     confidence: LOW
   languages:
   - javascript
   - typescript
-  severity: INFO
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/javascript/jose/security/jwt-hardcode.yaml
+++ b/javascript/jose/security/jwt-hardcode.yaml
@@ -28,8 +28,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: HIGH
   languages:
   - javascript

--- a/javascript/jsonwebtoken/security/jwt-exposed-credentials.yaml
+++ b/javascript/jsonwebtoken/security/jwt-exposed-credentials.yaml
@@ -23,12 +23,12 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: LOW
+    impact: HIGH
     confidence: LOW
   languages:
   - javascript
   - typescript
-  severity: ERROR
+  severity: WARNING
   patterns:
   - pattern: a()
   - pattern: b()

--- a/javascript/jsonwebtoken/security/jwt-hardcode.yaml
+++ b/javascript/jsonwebtoken/security/jwt-hardcode.yaml
@@ -27,8 +27,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: HIGH
   languages:
   - javascript

--- a/javascript/lang/security/audit/hardcoded-hmac-key.yaml
+++ b/javascript/lang/security/audit/hardcoded-hmac-key.yaml
@@ -21,7 +21,7 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: LOW
+    impact: HIGH
     confidence: LOW
   languages:
   - javascript

--- a/javascript/passport-jwt/security/passport-hardcode.yaml
+++ b/javascript/passport-jwt/security/passport-hardcode.yaml
@@ -27,8 +27,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: HIGH
   languages:
   - javascript

--- a/python/boto3/security/hardcoded-token.yaml
+++ b/python/boto3/security/hardcoded-token.yaml
@@ -23,8 +23,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: HIGH
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: MEDIUM
   languages: [python]
   severity: WARNING

--- a/python/lang/security/audit/hardcoded-password-default-argument.yaml
+++ b/python/lang/security/audit/hardcoded-password-default-argument.yaml
@@ -24,5 +24,5 @@ rules:
     subcategory:
     - audit
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH
     confidence: LOW

--- a/ruby/lang/security/hardcoded-http-auth-in-controller.yaml
+++ b/ruby/lang/security/hardcoded-http-auth-in-controller.yaml
@@ -29,8 +29,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - audit
-    likelihood: MEDIUM
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: HIGH
   languages:
   - ruby

--- a/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
+++ b/ruby/lang/security/hardcoded-secret-rsa-passphrase.yaml
@@ -22,8 +22,8 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: MEDIUM
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: HIGH
   patterns:
   - pattern-either:

--- a/terraform/aws/security/aws-provider-static-credentials.yaml
+++ b/terraform/aws/security/aws-provider-static-credentials.yaml
@@ -32,6 +32,6 @@ rules:
     cwe2021-top25: true
     subcategory:
     - vuln
-    likelihood: MEDIUM
-    impact: MEDIUM
+    likelihood: LOW
+    impact: HIGH
     confidence: MEDIUM

--- a/yaml/kubernetes/security/secrets-in-config-file.yaml
+++ b/yaml/kubernetes/security/secrets-in-config-file.yaml
@@ -39,7 +39,7 @@ rules:
     subcategory:
     - vuln
     likelihood: LOW
-    impact: MEDIUM
+    impact: HIGH
     confidence: MEDIUM
   languages: [yaml]
   severity: WARNING


### PR DESCRIPTION
This PR updates likelihood/impact to match the default value defined in our jsonnet reference. Severity is computed from likelihood/impact.

NOTE TO REVIEWERS: please comment if you believe any of severity/impact/likelihood for a given rule should be overridden and not be the default.