### PR TITLE
Fix message formatMsgNoLookups disabled/enabled

### DIFF
--- a/java/log4j/security/log4j-message-lookup-injection.yaml
+++ b/java/log4j/security/log4j-message-lookup-injection.yaml
@@ -21,7 +21,7 @@ rules:
   message: Possible Lookup injection into Log4j messages. Lookups provide a way to add values to the Log4j
     messages at arbitrary places. If the message parameter contains an attacker controlled string, the
     attacker could inject arbitrary lookups, for instance '${java:runtime}'. This could lead to information
-    disclosure or even remote code execution if 'log4j2.formatMsgNoLookups' is enabled. This was enabled
+    disclosure or even remote code execution if 'log4j2.formatMsgNoLookups' is disabled. This was disabled
     by default until version 2.15.0.
   mode: taint
   pattern-sources:


### PR DESCRIPTION
- Enabling `formatMsgNoLookups` means lookups are disabled The variable has a negative in the name.