### PR TITLE
fix: fix terraform.aws.security.aws-ecr-mutable-image-tags message

### DIFF
--- a/terraform/aws/security/aws-ecr-mutable-image-tags.yaml
+++ b/terraform/aws/security/aws-ecr-mutable-image-tags.yaml
@@ -12,7 +12,7 @@ rules:
         ...
       }
   message: >- 
-    The ECR repository has image scans disabled. Image tags could be overwritten
+    The ECR repository allows tag mutability. Image tags could be overwritten
     with compromised images. ECR images should be set to IMMUTABLE to prevent code
     injection through image mutation. This can be done by setting image_tab_mutability
     to IMMUTABLE.


### PR DESCRIPTION
I added the `terraform.aws.security.aws-ecr-mutable-image-tags` rule in https://github.com/returntocorp/semgrep-rules/pull/2734, but made a mistake in the rule message (copy 🍝 )! This PR fixes that mistake.