### PR TITLE
ruby-jwt-decode-no-verify

### DIFF
--- a/ruby/jwt/security/jwt-decode-no-verify.rb
+++ b/ruby/jwt/security/jwt-decode-no-verify.rb
@@ -1,0 +1,21 @@
+require 'jwt'
+
+secret = "sampleSecret"
+payload = {}
+payload[:iat] = Time.now.to_i
+payload[:email] = "sample@mail.com"
+payload[:name] = "john doe"
+token = JWT.encode payload, secret, 'HS256'
+
+print token
+
+def bad(token, secret)
+    decoded_token = JWT.decode token, secret, false
+    print decoded_token    
+end
+
+
+def ok(token, secret)
+    decoded_token = JWT.decode token, secret, true
+    print decoded_token
+end

--- a/ruby/jwt/security/jwt-decode-no-verify.yaml
+++ b/ruby/jwt/security/jwt-decode-no-verify.yaml
@@ -1,0 +1,28 @@
+rules:
+  - id: ruby-jwt-decode-without-verify
+    message: Detected the decoding of a JWT token without a verify step. JWT tokens
+      must be verified before use, otherwise the token's integrity is unknown.
+      This means a malicious actor could forge a JWT token with any claims. Ensure verify=true in the JWT decode call
+    metadata:
+      cwe:
+        - "CWE-345: Insufficient Verification of Data Authenticity"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+      category: security
+      technology:
+        - jwt
+      confidence: MEDIUM
+      references:
+        - https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures
+      subcategory:
+        - vuln
+      likelihood: LOW
+      impact: HIGH
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+    languages:
+      - ruby
+    severity: WARNING
+    patterns:
+      - pattern: |
+          $JWT.decode $TOKEN, $SECRET, false

--- a/terraform/aws/security/aws-s3-not-using-approved-module.tf
+++ b/terraform/aws/security/aws-s3-not-using-approved-module.tf
@@ -1,0 +1,8 @@
+resource "aws_s3_bucket" "b" {
+  bucket = "my-tf-test-bucket"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+}

--- a/terraform/aws/security/aws-s3-not-using-approved-module.yaml
+++ b/terraform/aws/security/aws-s3-not-using-approved-module.yaml
@@ -1,0 +1,22 @@
+rules:
+- id: aws-s3-not-using-approved-module
+  patterns:
+  - pattern: |
+      resource "aws_s3_bucket" $ANYTHING {
+        ...
+      }
+  paths:
+    exclude:
+      - "*/tf-mod-s3*"
+  message: >-
+    Please use an approved internal module for creating an S3 bucket which automatically provision Cyral, encryption, and best practice public access blocks
+  metadata:
+    category: security
+    technology:
+    - terraform
+    - aws
+    likelihood: HIGH
+    impact: HIGH
+    confidence: HIGH
+  languages: [hcl]
+  severity: WARNING


### PR DESCRIPTION
Rule to catch the use of JWT tokens without verification of their signature. 