### PR TITLE
Fix USER root as last value

### DIFF
--- a/dockerfile/security/last-user-is-root.yaml
+++ b/dockerfile/security/last-user-is-root.yaml
@@ -13,7 +13,7 @@ rules:
     - focus-metavariable: $X
     - metavariable-regex:
         metavariable: $X
-        regex: root
+        regex: ^(root)$
     - metavariable-regex:
         metavariable: $F
         regex: (.*(?!root))

--- a/dockerfile/security/last-user-is-root.yaml
+++ b/dockerfile/security/last-user-is-root.yaml
@@ -6,13 +6,14 @@ rules:
         ...
         USER $X
     - pattern-not-inside: |
+        ...
         USER $X
         ...
         USER $F
     - focus-metavariable: $X
     - metavariable-regex:
         metavariable: $X
-        regex: ^(root)$
+        regex: root
     - metavariable-regex:
         metavariable: $F
         regex: (.*(?!root))


### PR DESCRIPTION
The missing `...` caused the rule to match mid range values. 

This should now only work if USER root is the last value