### PR TITLE
Update NodeJSScan Rules based on halo blog

### DIFF
--- a/contrib/nodejsscan/hardcoded_secrets.yaml
+++ b/contrib/nodejsscan/hardcoded_secrets.yaml
@@ -84,7 +84,7 @@ rules:
         - pattern: $F. ... .constant('$X','...')
       - metavariable-regex:
           metavariable: $X
-          regex: (?i)(.*api_key)
+          regex: (?i)(.*api_key|.*apikey)
     message: >-
       A hardcoded API Key is identified. Store it properly in an
       environment variable.

--- a/contrib/nodejsscan/hardcoded_secrets.yaml
+++ b/contrib/nodejsscan/hardcoded_secrets.yaml
@@ -22,6 +22,7 @@ rules:
       impact: MEDIUM
       confidence: LOW
       category: security
+      subcategory: audit
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"
       cwe2021-top25: true
@@ -59,6 +60,7 @@ rules:
         - "CWE-798: Use of Hard-coded Credentials"
       cwe2021-top25: true
       cwe2022-top25: true
+      subcategory: audit
       owasp:
         - A07:2021 - Identification and Authentication Failures
       references:
@@ -84,9 +86,19 @@ rules:
       - javascript
     severity: ERROR
     metadata:
-      owasp: "A03:2017 - Sensitive Data Exposure"
-      cwe: "CWE-798: Use of Hard-coded Credentials"
+      likelihood: LOW
+      impact: MEDIUM
+      confidence: LOW
       category: security
+      subcategory: audit
+      cwe:
+        - "CWE-798: Use of Hard-coded Credentials"
+      cwe2021-top25: true
+      cwe2022-top25: true
+      owasp:
+        - A07:2021 - Identification and Authentication Failures
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_CheatSheet.html
       source-rule-url: https://blogs.halodoc.io/streamlining-code-review-with-semgrep/
       technology:
         - node.js
@@ -115,6 +127,7 @@ rules:
       impact: MEDIUM
       confidence: LOW
       category: security
+      subcategory: audit
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"
       cwe2021-top25: true

--- a/contrib/nodejsscan/hardcoded_secrets.yaml
+++ b/contrib/nodejsscan/hardcoded_secrets.yaml
@@ -22,7 +22,8 @@ rules:
       impact: MEDIUM
       confidence: LOW
       category: security
-      subcategory: audit
+      subcategory: 
+        - audit
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"
       cwe2021-top25: true
@@ -60,7 +61,8 @@ rules:
         - "CWE-798: Use of Hard-coded Credentials"
       cwe2021-top25: true
       cwe2022-top25: true
-      subcategory: audit
+      subcategory: 
+        - audit
       owasp:
         - A07:2021 - Identification and Authentication Failures
       references:
@@ -90,7 +92,8 @@ rules:
       impact: MEDIUM
       confidence: LOW
       category: security
-      subcategory: audit
+      subcategory: 
+        - audit
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"
       cwe2021-top25: true
@@ -127,7 +130,8 @@ rules:
       impact: MEDIUM
       confidence: LOW
       category: security
-      subcategory: audit
+      subcategory: 
+        - audit
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"
       cwe2021-top25: true

--- a/contrib/nodejsscan/hardcoded_secrets.yaml
+++ b/contrib/nodejsscan/hardcoded_secrets.yaml
@@ -1,36 +1,16 @@
 rules:
   - id: node_password
     patterns:
-      - pattern-not: password = ''
-      - pattern-not: PASSWORD = ''
-      - pattern-not: PASS = ''
-      - pattern-not: pass = ''
-      - pattern-not: $X[...] = ''
+      - pattern-not: $X = ''
+      - pattern-not: $OBJ['$X'] = ''
+      - pattern-not: $OBJ. ... .$X = ''
       - pattern-either:
-          - pattern: |
-              password = '...';
-          - pattern: |
-              PASSWORD = '...';
-          - pattern: |
-              PASS = '...';
-          - pattern: |
-              pass = '...';
-          - pattern: |
-              $X['pass'] = '...';
-          - pattern: |
-              $X['password'] = '...';
-          - pattern: |
-              $X['PASS'] = '...';
-          - pattern: |
-              $X['PASSWORD'] = '...';
-          - pattern: |
-              $X.pass = '...';
-          - pattern: |
-              $X.password = '...';
-          - pattern: |
-              $X.PASS = '...';
-          - pattern: |
-              $X.PASSWORD = '...';
+        - pattern: $X = '...'
+        - pattern: $OBJ['$X'] = '...'
+        - pattern: $OBJ. ... .$X = '...'
+      - metavariable-regex:
+          metavariable: $X
+          regex: (?i)(^pass$|password)
     message: >-
       A hardcoded password in plain text is identified. Store it properly in an
       environment variable.
@@ -45,50 +25,16 @@ rules:
         - node.js
   - id: node_secret
     patterns:
-      - pattern-not: secret = ''
-      - pattern-not: SECRET = ''
-      - pattern-not: api_secret = ''
-      - pattern-not: API_SECRET = ''
-      - pattern-not: $X['...'] = ''
+      - pattern-not: $X = ''
+      - pattern-not: $OBJ[$X] = ''
+      - pattern-not: $OBJ. ... .$X = ''
       - pattern-either:
-          - pattern: |
-              secret = '...';
-          - pattern: |
-              SECRET = '...';
-          - pattern: |
-              api_secret = '...';
-          - pattern: |
-              API_SECRET = '...';
-          - pattern: |
-              $X['secret'] = '...';
-          - pattern: |
-              $X['SECRET'] = '...';
-          - pattern: |
-              $X['api_secret'] = '...';
-          - pattern: |
-              $X['apiSecret'] = '...';
-          - pattern: |
-              $X['API_SECRET'] = '...';
-          - pattern: |
-              $X.secret = '...';
-          - pattern: |
-              $X.SECRET = '...';
-          - pattern: |
-              $X.api_secret = '...';
-          - pattern: |
-              $X.apiSecret = '...';
-          - pattern: |
-              $X.API_SECRET = '...';
-          - pattern: |
-              $X('api_secret', '...')
-          - pattern: |
-              $X('apiSecret', '...')
-          - pattern: |
-              $X('API_SECRET', '...')
-          - pattern: |
-              $X('secret', '...')
-          - pattern: |
-              $X('SECRET', '...')
+        - pattern: $X = '...'
+        - pattern: $OBJ[$X] = '...'
+        - pattern: $OBJ. ... .$X = '...'
+      - metavariable-regex:
+          metavariable: $X
+          regex: (?i:(.*secret$))
     message: >-
       A hardcoded secret is identified. Store it properly in an
       environment variable.
@@ -103,43 +49,16 @@ rules:
         - node.js
   - id: node_username
     patterns:
-      - pattern-not: username = ''
-      - pattern-not: userName = ''
-      - pattern-not: USERNAME = ''
-      - pattern-not: user = ''
-      - pattern-not: USER = ''
-      - pattern-not: $X['...'] = ''
+      - pattern-not: $X = ''
+      - pattern-not: $OBJ[$X] = ''
+      - pattern-not: $OBJ. ... .$X = ''
       - pattern-either:
-          - pattern: |
-              username = '...';
-          - pattern: |
-              userName = '...';
-          - pattern: |
-              USERNAME = '...';
-          - pattern: |
-              user = '...';
-          - pattern: |
-              USER = '...';
-          - pattern: |
-              $X['username'] = '...';
-          - pattern: |
-              $X['userName'] = '...';
-          - pattern: |
-              $X['USERNAME'] = '...';
-          - pattern: |
-              $X['user'] = '...';
-          - pattern: |
-              $X['USER'] = '...';
-          - pattern: |
-              $X.username = '...';
-          - pattern: |
-              $X.userName = '...';
-          - pattern: |
-              $X.USERNAME = '...';
-          - pattern: |
-              $X.user = '...';
-          - pattern: |
-              $X.USER = '...';
+        - pattern: $X = '...'
+        - pattern: $OBJ[$X] = '...'
+        - pattern: $OBJ. ... .$X = '...'
+      - metavariable-regex:
+          metavariable: $X
+          regex: (?i:user(name$|_name|$))
     message: >-
       A hardcoded username in plain text is identified. Store it properly in an
       environment variable.
@@ -154,35 +73,18 @@ rules:
         - node.js
   - id: node_api_key
     patterns:
-      - pattern-not: api_key = ''
-      - pattern-not: apiKey = ''
-      - pattern-not: API_KEY = ''
-      - pattern-not: $X['...'] = ''
+      - pattern-not: $X = ''
+      - pattern-not: $OBJ[$X] = ''
+      - pattern-not: $OBJ. ... .$X = ''
       - pattern-either:
-          - pattern: |
-              api_key = '...';
-          - pattern: |
-              apiKey = '...';
-          - pattern: |
-              API_KEY = '...';
-          - pattern: |
-              $X['api_key'] = '...';
-          - pattern: |
-              $X['apiKey'] = '...';
-          - pattern: |
-              $X['API_KEY'] = '...';
-          - pattern: |
-              $X.api_key = '...';
-          - pattern: |
-              $X.apiKey = '...';
-          - pattern: |
-              $X.API_KEY = '...';
-          - pattern: |
-              $X('api_key', '...')
-          - pattern: |
-              $X('apiKey', '...')
-          - pattern: |
-              $X('API_KEY', '...')
+        - pattern: $X = '...'
+        - pattern: $OBJ[$X] = '...'
+        - pattern: $OBJ. ... .$X = '...'
+        # To keep in the angular example
+        - pattern: $F. ... .constant('$X','...')
+      - metavariable-regex:
+          metavariable: $X
+          regex: (?i)(.*api_key)
     message: >-
       A hardcoded API Key is identified. Store it properly in an
       environment variable.

--- a/contrib/nodejsscan/hardcoded_secrets.yaml
+++ b/contrib/nodejsscan/hardcoded_secrets.yaml
@@ -18,9 +18,18 @@ rules:
       - javascript
     severity: ERROR
     metadata:
-      owasp: "A03:2017 - Sensitive Data Exposure"
-      cwe: "CWE-798: Use of Hard-coded Credentials"
+      likelihood: LOW
+      impact: MEDIUM
+      confidence: LOW
       category: security
+      cwe:
+        - "CWE-798: Use of Hard-coded Credentials"
+      cwe2021-top25: true
+      cwe2022-top25: true
+      owasp:
+        - A07:2021 - Identification and Authentication Failures
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_CheatSheet.html
       technology:
         - node.js
   - id: node_secret
@@ -42,9 +51,18 @@ rules:
       - javascript
     severity: ERROR
     metadata:
-      owasp: "A03:2017 - Sensitive Data Exposure"
-      cwe: "CWE-798: Use of Hard-coded Credentials"
+      likelihood: LOW
+      impact: MEDIUM
+      confidence: LOW
       category: security
+      cwe:
+        - "CWE-798: Use of Hard-coded Credentials"
+      cwe2021-top25: true
+      cwe2022-top25: true
+      owasp:
+        - A07:2021 - Identification and Authentication Failures
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_CheatSheet.html
       technology:
         - node.js
   - id: node_username
@@ -69,6 +87,7 @@ rules:
       owasp: "A03:2017 - Sensitive Data Exposure"
       cwe: "CWE-798: Use of Hard-coded Credentials"
       category: security
+      source-rule-url: https://blogs.halodoc.io/streamlining-code-review-with-semgrep/
       technology:
         - node.js
   - id: node_api_key
@@ -92,8 +111,17 @@ rules:
       - javascript
     severity: ERROR
     metadata:
-      owasp: "A03:2017 - Sensitive Data Exposure"
-      cwe: "CWE-798: Use of Hard-coded Credentials"
+      likelihood: LOW
+      impact: MEDIUM
+      confidence: LOW
       category: security
+      cwe:
+        - "CWE-798: Use of Hard-coded Credentials"
+      cwe2021-top25: true
+      cwe2022-top25: true
+      owasp:
+        - A07:2021 - Identification and Authentication Failures
+      references:
+        - https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_CheatSheet.html
       technology:
         - node.js


### PR DESCRIPTION
Updates based on feedback from https://blogs.halodoc.io/streamlining-code-review-with-semgrep/

The NodeJSScan rules are not updatable by us by default so we created a 'contrib' folder originally to have a cloned version of the rules so we could update things when people had issues with the rules. 

This appears to be out of sync now with the original NodeJSScan rules https://github.com/ajinabraham/njsscan/blob/e7a0a6148503c56a495cff107bd198c0dcb3ef65/njsscan/rules/semantic_grep/generic/hardcoded_secrets.yaml#L22 so we'll need to investigate that

