### PR TITLE
Deprecated `s3-unencrypted-bucket`

### DIFF
--- a/terraform/lang/security/s3-unencrypted-bucket.tf
+++ b/terraform/lang/security/s3-unencrypted-bucket.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "unencrypted" {
-  # ruleid: s3-unencrypted-bucket
+  # ok: s3-unencrypted-bucket
   bucket = "my-unencrypted-bucket"
   acl    = "private"
 }

--- a/terraform/lang/security/s3-unencrypted-bucket.yaml
+++ b/terraform/lang/security/s3-unencrypted-bucket.yaml
@@ -1,23 +1,13 @@
 rules:
 - id: s3-unencrypted-bucket
   patterns:
-  - pattern: |
-      bucket = "..."
-  - pattern-inside: |
-      resource "aws_s3_bucket" "..." {
-        ...
-      }
-  - pattern-not-inside: |
-      resource "aws_s3_bucket" "..." {
-        ...
-        server_side_encryption_configuration {
-          ...
-        }
-      }
+  - pattern: a
+  - pattern: b
   languages:
   - hcl
   severity: INFO
-  message: S3 bucket without encryption at rest detected.
+  message: >-
+    This rule has been deprecated, as all s3 buckets are encrypted by default with no way to disable it
   metadata:
     references:
     - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#server_side_encryption_configuration
@@ -36,3 +26,4 @@ rules:
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: MEDIUM
+    deprecated: true


### PR DESCRIPTION
Deprecates rule because AWS S3 encrypts buckets by default now without a way to turn them off. Closes https://github.com/returntocorp/semgrep-rules/issues/2811