### PR TITLE
Remove includes array check false positive

### DIFF
--- a/javascript/express/security/audit/xss/direct-response-write.yaml
+++ b/javascript/express/security/audit/xss/direct-response-write.yaml
@@ -219,4 +219,14 @@ rules:
     - metavariable-regex:
         metavariable: $F
         regex: (?!.*text/html)
-        
+  - patterns: 
+    - pattern-inside: |
+        $X = [...];
+        ...
+    - pattern: |
+        if(<... !$X.includes($SOURCE)...>) {
+            ...
+            return ...
+        }
+        ...
+    - pattern: $SOURCE


### PR DESCRIPTION
Noticed generic code like:
```
		const types = ['read', 'write'];
		const { type } = req.params;
		if (!types.includes(type)) {
			return next();
		}
```
Would flag on this rule which leads to false positives since an array check includes wont be something that is vulnerable