### PR TITLE
Reduce FPs in Audit React rules

### DIFF
--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.jsx
@@ -12,6 +12,13 @@ function TestComponent2(foo) {
     return React.createElement('div', params);
 }
 
+// ok:react-dangerouslysetinnerhtml
+{collaborationSectionData.paragraphs.map((item, i) => (
+  <li key={`collaboration-p-${i}`} dangerouslySetInnerHTML={{
+    __html: item,}}>
+  </li>
+))}
+
 function TestComponent3() {
     // ok:react-dangerouslysetinnerhtml
   return <li className={"foobar"} dangerouslySetInnerHTML={{__html: params}} />;

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.tsx
@@ -12,6 +12,13 @@ function TestComponent2(foo) {
     return React.createElement('div', params);
 }
 
+// ok:react-dangerouslysetinnerhtml
+{collaborationSectionData.paragraphs.map((item, i) => (
+  <li key={`collaboration-p-${i}`} dangerouslySetInnerHTML={{
+    __html: item,}}>
+  </li>
+))}
+
 function TestComponent3() {
     // ok:react-dangerouslysetinnerhtml
   return <li className={"foobar"} dangerouslySetInnerHTML={{__html: params}} />;

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -40,7 +40,7 @@ rules:
         - focus-metavariable: $X
         # Added to remove value.map which causes a fair amount of false positives
         - pattern-not-inside: |
-              $X. ... .$SANITIZEUNC(...)
+              $F. ... .$SANITIZEUNC(...)
   pattern-sinks:
   - patterns:
     - focus-metavariable: $X

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -38,9 +38,9 @@ rules:
             - pattern-inside: |
                 function ...(..., $X, ...) { ... }
         - focus-metavariable: $X
-        - pattern-either:
-            - pattern: $X.$Y
-            - pattern: $X[...]
+        # Added to remove value.map which causes a fair amount of false positives
+        - pattern-not-inside: |
+              $X. ... .$SANITIZEUNC(...)
   pattern-sinks:
   - patterns:
     - focus-metavariable: $X

--- a/typescript/react/security/audit/react-href-var.jsx
+++ b/typescript/react/security/audit/react-href-var.jsx
@@ -14,6 +14,11 @@ function test1(input) {
 }
 
 // ok: react-href-var
+{collaborationSectionData.paragraphs.map((item, i) => (
+  <div>  <a href={item.value}>click</a></div>
+))}
+
+// ok: react-href-var
 let zzz = <Foo className={"foobar"} href={`${input}`} />;
 
 // ok: react-href-var

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -45,7 +45,7 @@ rules:
               - pattern: $X[...]
           # This removes function maps, which generally are from imported hardcoded values
           - pattern-not-inside: |
-              $X. ... .$SANITIZEUNC(...)
+              $F. ... .$SANITIZEUNC(...)
       - label: CONCAT
         requires: TAINTED
         patterns:

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -1,141 +1,152 @@
 rules:
-- id: react-href-var
-  message: Detected a variable used in an anchor tag with the 'href' attribute. A malicious actor may
-    be able to input the 'javascript:' URI, which could cause cross-site scripting (XSS). It is recommended
-    to disallow 'javascript:' URIs within your application.
-  metadata:
-    cwe:
-    - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
-    owasp:
-    - A07:2017 - Cross-Site Scripting (XSS)
-    - A03:2021 - Injection
-    references:
-    - https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls
-    - https://pragmaticwebsecurity.com/articles/spasecurity/react-xss-part1.html
-    category: security
-    confidence: LOW
-    technology:
-    - react
-    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
-    cwe2022-top25: true
-    cwe2021-top25: true
-    subcategory:
-    - audit
-    likelihood: LOW
-    impact: MEDIUM
-  languages:
-  - typescript
-  - javascript
-  severity: WARNING
-  mode: taint
-  pattern-sources:
-    - patterns:
-        - pattern-either:
-            - pattern-inside: |
-                function ...({..., $X, ...}) { ... }
-            - pattern-inside: |
-                function ...(..., $X, ...) { ... }
-        - focus-metavariable: $X
-        - pattern-either:
-            - pattern: $X.$Y
-            - pattern: $X[...]
-  pattern-sinks:
-  - patterns:
-    - pattern-either:
-      - patterns:
-        - focus-metavariable: $X
-        - pattern-not-inside: |
-            import {
-              ...,$X,...
-            } from "..."
-            ...
-        - pattern-not-inside: |
-            <Buttons .../>
-        - pattern-not-inside: |
-            <Button .../>
-        - pattern-not-inside: |
-            <AnchorButton .../>
-        - pattern-not-inside: |
-            <$EL ... href={$FUNC($X)}></$EL>
-        - pattern-not-inside: |
-            import $X from "..."
-            ...
-        - pattern-not-inside: |
-            import $X from "..."
-            ...
-        - pattern-not-inside: |
-            import * as $X from "..."
-            ...
-        - pattern-not-inside: |
-            $X = require(...)
-            ...
-        - pattern-either:
-          - pattern: |
-              <$EL href={$X} />
-          - pattern: |
-              <$EL href={`${$X}...`} />
-          - pattern: |
-              React.createElement($EL, {href: $X})
-          - pattern-inside: |
-              $PARAMS = {href: $X};
-              ...
-              React.createElement($EL, $PARAMS);
-        - pattern-not: |
-            <$EL href="..." />
-        - pattern-not: |
-            <$EL href={"..."+$X} />
-        - pattern-not: |
-            React.createElement($EL, {href: "..."})        
-        - pattern-not: |
-            $PARAMS = {href: "..."};
-        - metavariable-pattern:
-            patterns:
-            - pattern-not: |
-                $FOO + $VALUE
-            - pattern-not: |
-                "..." + $F
-            - pattern-not: |
-                `...${$F}...`
-            metavariable: $X
-  pattern-sanitizers:
-  - patterns:
-    - pattern-either:
-      - pattern: |
-          $A ? $VAL1 : $VAL2
-      - pattern: |
-          $A ? $VAL2 : $VAL1
-    - metavariable-pattern:
+  - id: react-href-var
+    message: >-
+      Detected a variable used in an anchor tag with the 'href' attribute. A
+      malicious actor may be able to input the 'javascript:' URI, which could
+      cause cross-site scripting (XSS). It is recommended to disallow
+      'javascript:' URIs within your application.
+    metadata:
+      cwe:
+        - "CWE-79: Improper Neutralization of Input During Web Page Generation
+          ('Cross-site Scripting')"
+      owasp:
+        - A07:2017 - Cross-Site Scripting (XSS)
+        - A03:2021 - Injection
+      references:
+        - https://reactjs.org/blog/2019/08/08/react-v16.9.0.html#deprecating-javascript-urls
+        - https://pragmaticwebsecurity.com/articles/spasecurity/react-xss-part1.html
+      category: security
+      confidence: LOW
+      technology:
+        - react
+      license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+      cwe2022-top25: true
+      cwe2021-top25: true
+      subcategory:
+        - audit
+      likelihood: LOW
+      impact: MEDIUM
+    languages:
+      - typescript
+      - javascript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - label: TAINTED
         patterns:
-        - pattern: |
-            `${...}...`
-        - pattern-not: |
-            "..."
-        - pattern-not: |
-            "..." + $V
-        - pattern-not: |
-            `...${...}...`
-        metavariable: $VAL1
-    - focus-metavariable: $VAL1
-  - patterns:
-    - pattern-either:
-      - pattern: validateUrl(...)
-      - pattern: getSanitizedUrl(...)
-  - patterns:
-    - pattern: |
-        `...${$X}...`
-    - pattern-not: |
-        `${$X}...`
-    - focus-metavariable: $X
-  - patterns:
-    - pattern: |
-        "..." + $VALUE
-  - patterns:
-    - pattern-inside: |
-        if (<... $SOURCE.startsWith("$REGEX") ...>) { 
-            ... 
-        }
-  - patterns:
-    - pattern-inside: |
-        $X = [{...}];
-        ...
-    - pattern: $X.map(...)
+          - pattern-either:
+              - pattern-inside: |
+                  function ...({..., $X, ...}) { ... }
+              - pattern-inside: |
+                  function ...(..., $X, ...) { ... }
+          - focus-metavariable: $X
+          - pattern-either:
+              - pattern: $X.$Y
+              - pattern: $X[...]
+          # This removes function maps, which generally are from imported hardcoded values
+          - pattern-not-inside: |
+              $X. ... .$SANITIZEUNC(...)
+      - label: CONCAT
+        requires: TAINTED
+        patterns:
+          - pattern-either:
+              - pattern: |
+                  `...${$X}...`
+              - pattern: |
+                  $SANITIZE + <... $X ...>
+          - pattern-not: |
+              `${$X}...`
+          - pattern-not: |
+              $X + ...
+          - focus-metavariable: $X
+    pattern-sinks:
+      - requires: TAINTED and not CONCAT
+        patterns:
+          - focus-metavariable: $X
+          - pattern-either:
+              - pattern: |
+                  <$EL href={$X} />
+              - pattern: |
+                  React.createElement($EL, {href: $X})
+              - pattern-inside: |
+                  $PARAMS = {href: $X};
+                  ...
+                  React.createElement($EL, $PARAMS);
+          # Removing any element which has buttons since it tends to be a fp
+          - metavariable-pattern:
+              patterns:
+                - pattern-not-regex: (?i)(button)
+              metavariable: $EL
+    pattern-sanitizers:
+      # Operators have been known to cause FPs, so removing any value which does not equal 
+      - patterns:
+          - pattern-either:
+              - pattern: |
+                  <... $A ...> ? $VAL1 : $VAL2
+              - pattern: |
+                  <... $A ...> ? $VAL2 : $VAL1
+          - metavariable-pattern:
+              patterns:
+                - pattern: |
+                    `${...}...`
+                - pattern-not: |
+                    "..."
+                - pattern-not: |
+                    "..." + $V
+                - pattern-not: |
+                    "..." + $V + ...
+                - pattern-not: |
+                    `...${...}...`
+              metavariable: $VAL1
+          - focus-metavariable: $VAL1
+      - patterns:
+          - pattern-either:
+              - patterns:
+                  - pattern-either:
+                      - pattern: |
+                          <... $A ...> ? $VAL1 : $VAL2
+                      - pattern: |
+                          <... $A ...> ? $VAL2 : $VAL1
+                  - pattern: $VAL1
+              - patterns:
+                  - pattern-either:
+                      - pattern-inside: |
+                          if (<... !$A($SOURCE) ...>) { 
+                              ... 
+                          }
+                          ...
+                      - pattern-inside: |
+                          if (<... !$SANITIZE. ... .$A($SOURCE) ...>) { 
+                              ... 
+                          } 
+                          ...
+                      - pattern-inside: |
+                          if (<... !$A. ... .$SANITIZE($SOURCE) ...>) { 
+                              ... 
+                          } 
+                          ...
+                      - pattern-inside: |
+                          if (<... $A. ... .$SANITIZE($SOURCE) ...>) { 
+                              ... 
+                          } 
+                      - pattern-inside: |
+                          if (<... $S. ... .$A($SOURCE) ...>) { 
+                              ... 
+                          } 
+                      - pattern-inside: |
+                          if (<... $A($SOURCE) ...>) { 
+                              ... 
+                          }
+                      - pattern: $A($SOURCE)
+                      - pattern: $SANITIZE. ... .$A($SOURCE)
+                      - pattern: $A. ... .$SANITIZE($SOURCE)
+                  - pattern: $SOURCE
+          - metavariable-regex:
+              metavariable: $A
+              regex: (?i)(.*valid|.*sanitiz)
+      - patterns:
+          - pattern-inside: |
+              if (<... $SOURCE.startsWith(...) ...>) { 
+                  ... 
+              }
+          - pattern: $SOURCE

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -40,10 +40,6 @@ rules:
               - pattern-inside: |
                   function ...(..., $X, ...) { ... }
           - focus-metavariable: $X
-          - pattern-either:
-              - pattern: $X.$Y
-              - pattern: $X[...]
-          # This removes function maps, which generally are from imported hardcoded values
           - pattern-not-inside: |
               $F. ... .$SANITIZEUNC(...)
       - label: CONCAT
@@ -59,8 +55,19 @@ rules:
           - pattern-not: |
               $X + ...
           - focus-metavariable: $X
+      - label: CLEAN
+        by-side-effect: true
+        patterns:
+          - pattern-either:
+              - pattern: $A($SOURCE)
+              - pattern: $SANITIZE. ... .$A($SOURCE)
+              - pattern: $A. ... .$SANITIZE($SOURCE)
+          - focus-metavariable: $SOURCE
+          - metavariable-regex:
+              metavariable: $A
+              regex: (?i)(.*valid|.*sanitiz)
     pattern-sinks:
-      - requires: TAINTED and not CONCAT
+      - requires: TAINTED and not CONCAT and not CLEAN
         patterns:
           - focus-metavariable: $X
           - pattern-either:
@@ -72,81 +79,7 @@ rules:
                   $PARAMS = {href: $X};
                   ...
                   React.createElement($EL, $PARAMS);
-          # Removing any element which has buttons since it tends to be a fp
           - metavariable-pattern:
               patterns:
                 - pattern-not-regex: (?i)(button)
               metavariable: $EL
-    pattern-sanitizers:
-      # Operators have been known to cause FPs, so removing any value which does not equal 
-      - patterns:
-          - pattern-either:
-              - pattern: |
-                  <... $A ...> ? $VAL1 : $VAL2
-              - pattern: |
-                  <... $A ...> ? $VAL2 : $VAL1
-          - metavariable-pattern:
-              patterns:
-                - pattern: |
-                    `${...}...`
-                - pattern-not: |
-                    "..."
-                - pattern-not: |
-                    "..." + $V
-                - pattern-not: |
-                    "..." + $V + ...
-                - pattern-not: |
-                    `...${...}...`
-              metavariable: $VAL1
-          - focus-metavariable: $VAL1
-      - patterns:
-          - pattern-either:
-              - patterns:
-                  - pattern-either:
-                      - pattern: |
-                          <... $A ...> ? $VAL1 : $VAL2
-                      - pattern: |
-                          <... $A ...> ? $VAL2 : $VAL1
-                  - pattern: $VAL1
-              - patterns:
-                  - pattern-either:
-                      - pattern-inside: |
-                          if (<... !$A($SOURCE) ...>) { 
-                              ... 
-                          }
-                          ...
-                      - pattern-inside: |
-                          if (<... !$SANITIZE. ... .$A($SOURCE) ...>) { 
-                              ... 
-                          } 
-                          ...
-                      - pattern-inside: |
-                          if (<... !$A. ... .$SANITIZE($SOURCE) ...>) { 
-                              ... 
-                          } 
-                          ...
-                      - pattern-inside: |
-                          if (<... $A. ... .$SANITIZE($SOURCE) ...>) { 
-                              ... 
-                          } 
-                      - pattern-inside: |
-                          if (<... $S. ... .$A($SOURCE) ...>) { 
-                              ... 
-                          } 
-                      - pattern-inside: |
-                          if (<... $A($SOURCE) ...>) { 
-                              ... 
-                          }
-                      - pattern: $A($SOURCE)
-                      - pattern: $SANITIZE. ... .$A($SOURCE)
-                      - pattern: $A. ... .$SANITIZE($SOURCE)
-                  - pattern: $SOURCE
-          - metavariable-regex:
-              metavariable: $A
-              regex: (?i)(.*valid|.*sanitiz)
-      - patterns:
-          - pattern-inside: |
-              if (<... $SOURCE.startsWith(...) ...>) { 
-                  ... 
-              }
-          - pattern: $SOURCE

--- a/typescript/react/security/audit/react-href-var.yaml
+++ b/typescript/react/security/audit/react-href-var.yaml
@@ -40,6 +40,11 @@ rules:
               - pattern-inside: |
                   function ...(..., $X, ...) { ... }
           - focus-metavariable: $X
+          # This rule causes too many false positives without this addition
+          - pattern-either:
+            - pattern: $X.$Y
+            - pattern: $X[...]
+          # this removes .map(...) etc which likely comes from hard coded values.
           - pattern-not-inside: |
               $F. ... .$SANITIZEUNC(...)
       - label: CONCAT


### PR DESCRIPTION
This update does the following:

1. Removes map values from sources
2. Removes properties from dangerouslySetInnerHTML, this rule should be a little more verbose than href
3. Updates the href rule to use taint labels to remove noise 
4. Reduces the sink so it only removes buttons
5. Updates the sanitizers to be more generic, before they would miss things in ternary operators