### PR TITLE
Add deconstruction lint check

### DIFF
--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -40,6 +40,7 @@ jobs:
             --config yaml/semgrep/message-whitespace.yaml \
             --config yaml/semgrep/metadata-deepsemgrep.yaml \
             --config yaml/semgrep/slow-pattern-top-ellipsis.yaml \
+            --config yaml/semgrep/rule-missing-deconstructed-value.yaml \
             --exclude *.test.yaml \
             --exclude contrib/ \
             --exclude stats/ \

--- a/javascript/jose/security/jwt-hardcode.yaml
+++ b/javascript/jose/security/jwt-hardcode.yaml
@@ -37,7 +37,7 @@ rules:
   severity: WARNING
   patterns:
   - pattern-inside: |
-      var $JOSE = require("jose");
+      $JOSE = require("jose");
       ...
   - pattern-either:
     - pattern-inside: |
@@ -45,6 +45,18 @@ rules:
         ...
     - pattern-inside: |
         var {JWK, JWT} = $JOSE;
+        ...
+    - pattern-inside: |
+        const {JWT} = $JOSE;
+        ...
+    - pattern-inside: |
+        const {JWK, JWT} = $JOSE;
+        ...
+    - pattern-inside: |
+        let {JWT} = $JOSE;
+        ...
+    - pattern-inside: |
+        let {JWK, JWT} = $JOSE;
         ...
   - pattern-either:
     - pattern: |

--- a/javascript/lang/security/audit/sqli/node-postgres-sqli.yaml
+++ b/javascript/lang/security/audit/sqli/node-postgres-sqli.yaml
@@ -34,18 +34,26 @@ rules:
           ...
         }
     - focus-metavariable: $FUNC
+    - pattern-not-inside: |
+        $F. ... .$SOURCE(...)
   pattern-sinks:
   - patterns:
+    - pattern-either: 
+      - pattern-inside: |
+         const { $CLIENT } = require('pg')
+          ...
+      - pattern-inside: |
+         var { $CLIENT } = require('pg')
+          ...
+      - pattern-inside: |
+         let { $CLIENT } = require('pg')
+          ...
     - pattern-either:
       - pattern-inside: |
-          const { $CLIENT } = require('pg')
-          ...
           $DB = new $CLIENT(...)
           ...
       - pattern-inside: |
-          const { $POOL } = require('pg')
-          ...
-          const $NEWPOOL = new $POOL(...)
+          $NEWPOOL = new $CLIENT(...)
           ...
           $NEWPOOL.connect((..., $DB, ...) => {
               ...

--- a/yaml/semgrep/message-whitespace.test.yaml
+++ b/yaml/semgrep/message-whitespace.test.yaml
@@ -9,8 +9,5 @@ rules:
       - js
     severity: WARNING
     patterns:
-      - pattern-inside: |
-          const {...,createCipheriv,...} = require('node:crypto');
-          ...
       - pattern: |
           createCipheriv($ALGO, $KEY, $IV);

--- a/yaml/semgrep/rule-missing-deconstructed-value.test.yaml
+++ b/yaml/semgrep/rule-missing-deconstructed-value.test.yaml
@@ -1,0 +1,35 @@
+rules:
+  - id: half-written-crypto-example
+    message: >-
+      A lav crypto hun
+    languages:
+      - js
+    severity: WARNING
+    patterns:
+      - pattern-inside: |
+          # ruleid: missing-deconstructed-value
+          const {...,createCipheriv,...} = require('node:crypto');
+          ...
+      - pattern: |
+          createCipheriv($ALGO, $KEY, $IV);
+      - pattern-either: 
+       # ok: missing-deconstructed-value
+        - pattern-inside: |
+            const {...,createCipheriv,...} = require('node:crypto');
+            ...
+        - pattern-inside: |
+            let {...,createCipheriv,...} = require('node:crypto');
+            ...
+        - pattern-inside: |
+            var {...,createCipheriv,...} = require('node:crypto');
+            ...
+      - pattern-either: 
+        # ruleid: missing-deconstructed-value
+        - pattern-inside: |
+            const {...,createCipheriv,...} = require('node:crypto');
+            ...
+        # ruleid: missing-deconstructed-value
+        - pattern-inside: |
+            let {...,createCipheriv,...} = require('node:crypto');
+            ...
+ 

--- a/yaml/semgrep/rule-missing-deconstructed-value.yaml
+++ b/yaml/semgrep/rule-missing-deconstructed-value.yaml
@@ -1,0 +1,68 @@
+rules:
+  - id: missing-deconstructed-value
+    message: >-
+      Looks like this value is deconstructing a const/var/let you need to use
+      all three `const {...} =` `var {...} =` and `let {...} =` to provide
+      accurate coverage consider adding the missing patterns in a
+      `pattern-inside` for better coverage.
+    languages:
+      - yaml
+    severity: WARNING
+    metadata:
+      references:
+        - https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository
+      category: correctness
+      technology:
+        - semgrep
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern-inside: |
+                  rules: ...
+              - pattern-not-inside: |
+                  - pattern-either:
+                      ...
+              - pattern: |
+                  - pattern-inside:
+                      $VALUE
+              - pattern-either:
+                  - pattern-regex: const {.*}.*=
+                  - pattern-regex: let {.*}.*=
+                  - pattern-regex: var {.*}.*=
+          - patterns:
+              - patterns:
+                  - pattern-inside: |
+                      rules: ...
+                  - pattern-inside: |
+                      - pattern-either:
+                          $VALUE
+                  - focus-metavariable:
+                      - $VALUE
+                  - pattern-inside: |
+                      - pattern-inside: 
+                          $A
+                  - metavariable-regex:
+                      metavariable: $A
+                      regex: .*\s.*(var|const|let)\s{.*}\s=
+              - pattern-not:
+                  patterns:
+                    - pattern-inside: |
+                        ...
+                        - pattern-inside: 
+                            $Z
+                        ...
+                        - pattern-inside: 
+                            $B
+                        ...            
+                        - pattern-inside: 
+                            $C
+                        ...
+                    - metavariable-regex:
+                        metavariable: $Z
+                        regex: .*\s.*(var|const|let).*{.*}
+                    - metavariable-regex:
+                        metavariable: $B
+                        regex: .*\s.*(var|const|let).*{.*}
+                    - metavariable-regex:
+                        metavariable: $C
+                        regex: .*\s.*(var|const|let).*{.*}


### PR DESCRIPTION
This finds places where const/var/let are not used, and also cleaned up the rules which were missing some checks.