### PR TITLE
update html missing-integrity rule

### DIFF
--- a/html/security/audit/missing-integrity.html
+++ b/html/security/audit/missing-integrity.html
@@ -34,6 +34,10 @@
     <link rel="stylesheet" href="https://someurl/style.css" integrity="sha256-somehashdigest">
     <!-- ok: missing-integrity -->
     <link rel="stylesheet" href="./css/mystyle.css">
+	<!-- ok: missing-integrity -->
+	<link rel="preconnect" href="https://fonts.gstatic.com/" />
+	<!-- ok: missing-integrity -->
+	<link rel=preconnect href="https://fonts.gstatic.com/" />
 </head>
 <body>
 

--- a/html/security/audit/missing-integrity.yaml
+++ b/html/security/audit/missing-integrity.yaml
@@ -33,6 +33,7 @@ rules:
           - pattern: href="//..."
         - pattern-not-regex: (?is).*integrity=
         - pattern-not-regex: (google-analytics.com|fonts.googleapis.com|googletagmanager.com)
+        - pattern-not-regex: .*rel\s*=\s*['"]?preconnect.*
   paths:
     include:
     - '*.html'


### PR DESCRIPTION
Fix for: https://github.com/returntocorp/semgrep-rules/issues/2835