### PR TITLE
Fix generic detected-aws-session-token

### DIFF
--- a/generic/secrets/security/detected-aws-session-token.yaml
+++ b/generic/secrets/security/detected-aws-session-token.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: detected-aws-session-token
   patterns:
-    - pattern-regex: ((?i)AWS_SESSION_TOKEN)\s(:|=>|=)\s([A-Za-z0-9/+=]{16,})
+    - pattern-regex: ((?i)AWS_SESSION_TOKEN)(:|=>|=)([A-Za-z0-9/+=]{16,})
     - pattern-not-regex: (?i)example|sample|test|fake
     - metavariable-analysis:
         analyzer: entropy
@@ -28,4 +28,3 @@ rules:
     - audit
     likelihood: LOW
     impact: HIGH
-

--- a/generic/secrets/security/detected-aws-session-token.yaml
+++ b/generic/secrets/security/detected-aws-session-token.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: detected-aws-session-token
   patterns:
-    - pattern-regex: ((?i)AWS_SESSION_TOKEN)(:|=>|=)([A-Za-z0-9/+=]{16,})
+    - pattern-regex: ((?i)AWS_SESSION_TOKEN)\s*(:|=>|=)\s*([A-Za-z0-9/+=]{16,})
     - pattern-not-regex: (?i)example|sample|test|fake
     - metavariable-analysis:
         analyzer: entropy

--- a/generic/secrets/security/detected-aws-session-token.yaml
+++ b/generic/secrets/security/detected-aws-session-token.yaml
@@ -2,11 +2,10 @@ rules:
 - id: detected-aws-session-token
   patterns:
     - pattern-regex: ("|'|`)?((?i)aws)?_?((?i)session)_?((?i)token)("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?([A-Za-z0-9/+=]{16,})("|'|`)?
-    - focus-metavariable: $8
     - metavariable-analysis:
         metavariable: $8
         analyzer: entropy
-  - pattern-not-regex: (?i)example|sample|test|fake
+    - pattern-not-regex: (?i)example|sample|test|fake
   languages: [regex]
   message: AWS Session Token detected
   severity: ERROR

--- a/generic/secrets/security/detected-aws-session-token.yaml
+++ b/generic/secrets/security/detected-aws-session-token.yaml
@@ -1,8 +1,11 @@
 rules:
 - id: detected-aws-session-token
   patterns:
-  - pattern-regex: |-
-      (("|'|`)?((?i)aws)?_?((?i)session)_?((?i)token)("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?[A-Za-z0-9/+=]{16,}("|'|`)?)
+    - pattern-regex: ("|'|`)?((?i)aws)?_?((?i)session)_?((?i)token)("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?([A-Za-z0-9/+=]{16,})("|'|`)?
+    - focus-metavariable: $8
+    - metavariable-analysis:
+        metavariable: $8
+        analyzer: entropy
   - pattern-not-regex: (?i)example|sample|test|fake
   languages: [regex]
   message: AWS Session Token detected

--- a/generic/secrets/security/detected-aws-session-token.yaml
+++ b/generic/secrets/security/detected-aws-session-token.yaml
@@ -1,11 +1,11 @@
 rules:
 - id: detected-aws-session-token
   patterns:
-    - pattern-regex: ("|'|`)?((?i)aws)?_?((?i)session)_?((?i)token)("|'|`)?\s{0,50}(:|=>|=)\s{0,50}("|'|`)?([A-Za-z0-9/+=]{16,})("|'|`)?
-    - metavariable-analysis:
-        metavariable: $8
-        analyzer: entropy
+    - pattern-regex: ((?i)AWS_SESSION_TOKEN)\s(:|=>|=)\s([A-Za-z0-9/+=]{16,})
     - pattern-not-regex: (?i)example|sample|test|fake
+    - metavariable-analysis:
+        analyzer: entropy
+        metavariable: $3
   languages: [regex]
   message: AWS Session Token detected
   severity: ERROR


### PR DESCRIPTION
This rule was trying to do way too much. 

In general, this rule is usually looking for either:

`AWS_SESSION_TOKEN` or `aws_session_token` where its assigned to something with entropy.

So I rewrote the rule to look for assignments in some way to entropy using parts of the old rule. 