### PR TITLE
[Go] Fix incorrect replacement in missing-ssl-minversion

### DIFF
--- a/go/lang/security/audit/crypto/missing-ssl-minversion.yaml
+++ b/go/lang/security/audit/crypto/missing-ssl-minversion.yaml
@@ -32,4 +32,4 @@ rules:
       tls.Config{..., MinVersion: ..., ...}
   fix-regex:
     regex: Config\s*\{
-    replacement: 'Config{MinVersion: SSL.VersionTLS13,'
+    replacement: 'Config{MinVersion: tls.VersionTLS13,'


### PR DESCRIPTION
After running the rules:

```
--- a/oauth2/dcrp/dcrp.go
+++ b/oauth2/dcrp/dcrp.go
@@ -241,7 +241,7 @@ func (c *Config) RemoveRegistration(r *Registration, clientID string) error {
        }
 
        var client http.Client
-       tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: c.SSLInsecureSkipVerify}}
+       tr := &http.Transport{TLSClientConfig: &tls.Config{MinVersion: SSL.VersionTLS13,InsecureSkipVerify: c.SSLInsecureSkipVerify}}
        client.Transport = tr
        req, err := http.NewRequest(http.MethodDelete, clientURI, nil)
        if err != nil {
```

The expected replacement is `tls.VersionTLS13` (godoc: https://pkg.go.dev/crypto/tls#pkg-constants)