### PR TITLE
fix typo in aws-ecr-mutable-image-tags rule message

### DIFF
--- a/terraform/aws/security/aws-ecr-mutable-image-tags.yaml
+++ b/terraform/aws/security/aws-ecr-mutable-image-tags.yaml
@@ -14,7 +14,7 @@ rules:
   message: >- 
     The ECR repository allows tag mutability. Image tags could be overwritten
     with compromised images. ECR images should be set to IMMUTABLE to prevent code
-    injection through image mutation. This can be done by setting image_tab_mutability
+    injection through image mutation. This can be done by setting `image_tag_mutability`
     to IMMUTABLE.
   languages:
   - hcl


### PR DESCRIPTION
small typo fix