### PR TITLE
Allow year in OWASP string for scalar type

### DIFF
--- a/yaml/semgrep/metadata-owasp.test.yaml
+++ b/yaml/semgrep/metadata-owasp.test.yaml
@@ -15,6 +15,22 @@ rules:
     metadata:
       # ok: metadata-owasp
       owasp: A05:2021 - Security Misconfiguration
+  - id: example-bad-zero
+    message: Example
+    severity: ERROR
+    languages: [json, yaml]
+    pattern: "..."
+    metadata:
+      # ruleid: metadata-owasp
+      owasp: "A0: Zero"
+  - id: example-bad-double-zero-year
+    message: Example
+    severity: ERROR
+    languages: [json, yaml]
+    pattern: "..."
+    metadata:
+      # ruleid: metadata-owasp
+      owasp: "A00:2021 Zero"
   - id: example-bad-missing-leading-zero
     message: Example
     severity: ERROR
@@ -67,6 +83,10 @@ rules:
     metadata:
       # ok: metadata-owasp
       owasp:
+        # ruleid: metadata-owasp
+        - A0:2021 - Zero
+        # ruleid: metadata-owasp
+        - A00:2021 - Double Zero
         # Missing leading zero
         # ruleid: metadata-owasp
         - A5:2021 - Security Misconfiguration

--- a/yaml/semgrep/metadata-owasp.test.yaml
+++ b/yaml/semgrep/metadata-owasp.test.yaml
@@ -15,7 +15,15 @@ rules:
     metadata:
       # ok: metadata-owasp
       owasp: A05:2021 - Security Misconfiguration
-  - id: example-2
+  - id: example-bad-missing-leading-zero
+    message: Example
+    severity: ERROR
+    languages: [json, yaml]
+    pattern: "..."
+    metadata:
+      # ruleid: metadata-owasp
+      owasp: A5:2021 - Security Misconfiguration
+  - id: example-bad-greater-than-10
     message: Example
     severity: ERROR
     languages: [json, yaml]
@@ -23,7 +31,7 @@ rules:
     metadata:
       # ruleid: metadata-owasp
       owasp: "A11: Some Vulnerability"
-  - id: example-3
+  - id: example-bad-missing-details
     message: Example
     severity: ERROR
     languages: [json, yaml]
@@ -31,7 +39,7 @@ rules:
     metadata:
       # ruleid: metadata-owasp
       owasp: a4
-  - id: example-4
+  - id: example-bad-missing-colon
     message: Example
     severity: ERROR
     languages: [json, yaml]
@@ -39,7 +47,7 @@ rules:
     metadata:
       # ruleid: metadata-owasp
       owasp: A5 Some Vulnerability
-  - id: example-5
+  - id: example-good-list
     message: Example
     severity: ERROR
     languages: [json, yaml]
@@ -51,7 +59,7 @@ rules:
         - A05:2021 - Security Misconfiguration
         # ok: metadata-owasp
         - A06:2017 - Security Misconfiguration
-  - id: example-6
+  - id: example-bad-list
     message: Example
     severity: ERROR
     languages: [json, yaml]
@@ -59,7 +67,9 @@ rules:
     metadata:
       # ok: metadata-owasp
       owasp:
+        # Missing leading zero
         # ruleid: metadata-owasp
         - A5:2021 - Security Misconfiguration
+        # Crazy year
         # ruleid: metadata-owasp
         - A06:201789 - Security Misconfiguration

--- a/yaml/semgrep/metadata-owasp.test.yaml
+++ b/yaml/semgrep/metadata-owasp.test.yaml
@@ -7,6 +7,14 @@ rules:
     metadata:
       # ok: metadata-owasp
       owasp: "A1: Some Vulnerability"
+  - id: example-1b
+    message: Example
+    severity: ERROR
+    languages: [json, yaml]
+    pattern: "..."
+    metadata:
+      # ok: metadata-owasp
+      owasp: A05:2021 - Security Misconfiguration
   - id: example-2
     message: Example
     severity: ERROR

--- a/yaml/semgrep/metadata-owasp.yaml
+++ b/yaml/semgrep/metadata-owasp.yaml
@@ -9,9 +9,11 @@ rules:
       - pattern-inside: "rules: ..."
       - pattern-inside: "metadata: ..."
       - pattern-either:
+          # A single line year is optional, e.g. `owasp: A1 blah` or `owasp: A1:2021 blah`
           - patterns:
               - pattern: 'owasp: "..."'
-              - pattern-not: 'owasp: "=~/^A(0?[1-9]|10): .+$/"'
+              - pattern-not: 'owasp: "=~/^A(0?[1-9]|10):([0-9]{4})?\s+.+$/"'
+          # A list, must have the year, e.g. `- A1:2021 blah`
           - patterns:
               - pattern-inside: "owasp: [...]"
               - pattern: '"$ANYTHING"'

--- a/yaml/semgrep/metadata-owasp.yaml
+++ b/yaml/semgrep/metadata-owasp.yaml
@@ -9,15 +9,17 @@ rules:
       - pattern-inside: "rules: ..."
       - pattern-inside: "metadata: ..."
       - pattern-either:
-          # A single line year is optional, e.g. `owasp: A1 blah` or `owasp: A1:2021 blah`
+        # A single line year is optional, e.g. `owasp: "A1: blah"` or `owasp: A01:2021 blah`
+        # If there's a year, need leading zero, e.g. `A01:2021 blah` rather than `A1:2021 blah`.
           - patterns:
               - pattern: 'owasp: "..."'
-              - pattern-not: 'owasp: "=~/^A(0?[1-9]|10):([0-9]{4})?\s+.+$/"'
-          # A list, must have the year, e.g. `- A1:2021 blah`
+              - pattern-not: 'owasp: "=~/^A(0?[1-9]|10):\s+.+$/"'
+              - pattern-not: 'owasp: "=~/^A(0[1-9]|10):([0-9]{4})?\s+.+$/"'
+          # A list, must have the year, e.g. `- A01:2021 blah`
           - patterns:
               - pattern-inside: "owasp: [...]"
               - pattern: '"$ANYTHING"'
-              - pattern-not-regex: .*A[01][0-9]:[0-9]{4}\s+.*
+              - pattern-not-regex: .*A(0[1-9]|10):[0-9]{4}\s+.*
               - pattern-not-regex: "owasp:"
     metadata:
       category: best-practice


### PR DESCRIPTION
- The regex for scalar strings and lists are different.
- Before this change scalar strings did not allow specifying a year, whilst lists must have a year.
- After this change a single string may (optionally) have a year, list behaviour is unchanged, a year must be specified.
- I also tweaked the string regex to allow multiple whitespace characters like the list regex.

I didn't changing the lists regex to make years optional (e.g. use the same regex for strings and lists of strings). I figured when specifying multiple OWASP references, it's probably the one category mapped to different years, rather than several categories from a single year. I think years been mandatory is probably a good thing.