### PR TITLE
feat: update aws-network-acl-allows-all-ports to cover aws_default_network_acl resources

### DIFF
--- a/terraform/aws/security/aws-network-acl-allows-all-ports.tf
+++ b/terraform/aws/security/aws-network-acl-allows-all-ports.tf
@@ -1,5 +1,5 @@
 # ruleid: aws-network-acl-allows-all-ports
-resource "aws_network_acl_rule" "fail_1" {
+resource "aws_network_acl_rule" "fail_ingress_1" {
   network_acl_id = aws_network_acl.example.id
   rule_number    = 200
   protocol       = "all"
@@ -8,7 +8,7 @@ resource "aws_network_acl_rule" "fail_1" {
 }
 
 # ruleid: aws-network-acl-allows-all-ports
-resource "aws_network_acl_rule" "fail_2" {
+resource "aws_network_acl_rule" "fail_ingress_2" {
   network_acl_id = aws_network_acl.example.id
   rule_number    = 200
   protocol       = "-1"
@@ -17,15 +17,15 @@ resource "aws_network_acl_rule" "fail_2" {
 }
 
 # ruleid: aws-network-acl-allows-all-ports
-resource "aws_network_acl_rule" "fail_3" {
-  rule_action    = "allow"
+resource "aws_network_acl_rule" "fail_ingress_3" {
   network_acl_id = aws_network_acl.example.id
   rule_number    = 200
   protocol       = -1
+  rule_action    = "allow"
   cidr_block     = "10.3.0.0/18"
 }
 
-resource "aws_network_acl" "fail_4" {
+resource "aws_network_acl" "fail_ingress_1" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -39,7 +39,7 @@ resource "aws_network_acl" "fail_4" {
   }
 }
 
-resource "aws_network_acl" "fail_5" {
+resource "aws_network_acl" "fail_ingress_2" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -53,7 +53,7 @@ resource "aws_network_acl" "fail_5" {
   }
 }
 
-resource "aws_network_acl" "fail_6" {
+resource "aws_network_acl" "fail_ingress_3" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -67,7 +67,49 @@ resource "aws_network_acl" "fail_6" {
   }
 }
 
-resource "aws_network_acl" "fail_7" {
+resource "aws_default_network_acl" "fail_ingress_1" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  ingress {
+    protocol   = "all"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_network_acl" "fail_ingress_2" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  ingress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_network_acl" "fail_ingress_3" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  ingress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_network_acl" "fail_egress_1" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -81,7 +123,7 @@ resource "aws_network_acl" "fail_7" {
   }
 }
 
-resource "aws_network_acl" "fail_8" {
+resource "aws_network_acl" "fail_egress_2" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -95,7 +137,7 @@ resource "aws_network_acl" "fail_8" {
   }
 }
 
-resource "aws_network_acl" "fail_9" {
+resource "aws_network_acl" "fail_egress_3" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -109,7 +151,49 @@ resource "aws_network_acl" "fail_9" {
   }
 }
 
-resource "aws_network_acl" "fail_10" {
+resource "aws_default_network_acl" "fail_egress_1" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  egress {
+    protocol   = "all"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_network_acl" "fail_egress_2" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  egress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_network_acl" "fail_egress_3" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_network_acl" "fail_multiple_rules_1" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -132,7 +216,7 @@ resource "aws_network_acl" "fail_10" {
   }
 }
 
-resource "aws_network_acl" "fail_11" {
+resource "aws_network_acl" "fail_multiple_rules_2" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -155,7 +239,7 @@ resource "aws_network_acl" "fail_11" {
   }
 }
 
-resource "aws_network_acl" "fail_12" {
+resource "aws_network_acl" "fail_multiple_rules_3" {
   vpc_id = aws_vpc.example.id
 
   # ruleid: aws-network-acl-allows-all-ports
@@ -178,7 +262,7 @@ resource "aws_network_acl" "fail_12" {
   }
 }
 
-resource "aws_network_acl" "fail_13" {
+resource "aws_network_acl" "fail_multiple_rules_4" {
   vpc_id = aws_vpc.example.id
 
   ingress {
@@ -201,7 +285,7 @@ resource "aws_network_acl" "fail_13" {
   }
 }
 
-resource "aws_network_acl" "fail_14" {
+resource "aws_network_acl" "fail_multiple_rules_5" {
   vpc_id = aws_vpc.example.id
 
   ingress {
@@ -224,8 +308,146 @@ resource "aws_network_acl" "fail_14" {
   }
 }
 
-resource "aws_network_acl" "fail_15" {
+resource "aws_network_acl" "fail_multiple_rules_6" {
   vpc_id = aws_vpc.example.id
+
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 80
+    to_port    = 80
+  }
+
+  # ruleid: aws-network-acl-allows-all-ports
+  egress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_network_acl" "fail_multiple_rules_1" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  ingress {
+    protocol   = "all"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  egress {
+    protocol   = "tcp"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 443
+    to_port    = 443
+  }
+}
+
+resource "aws_default_network_acl" "fail_multiple_rules_2" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  ingress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  egress {
+    protocol   = "tcp"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 443
+    to_port    = 443
+  }
+}
+
+resource "aws_default_network_acl" "fail_multiple_rules_3" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ruleid: aws-network-acl-allows-all-ports
+  ingress {
+    protocol   = -1
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  egress {
+    protocol   = "tcp"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 443
+    to_port    = 443
+  }
+}
+
+resource "aws_default_network_acl" "fail_multiple_rules_4" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 80
+    to_port    = 80
+  }
+
+  # ruleid: aws-network-acl-allows-all-ports
+  egress {
+    protocol   = "all"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_network_acl" "fail_multiple_rules_5" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 80
+    to_port    = 80
+  }
+
+  # ruleid: aws-network-acl-allows-all-ports
+  egress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 0
+    to_port    = 0
+  }
+}
+
+resource "aws_default_network_acl" "fail_multiple_rules_6" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
 
   ingress {
     protocol   = "tcp"
@@ -248,7 +470,7 @@ resource "aws_network_acl" "fail_15" {
 }
 
 # ok: aws-network-acl-allows-all-ports
-resource "aws_network_acl_rule" "pass_1" {
+resource "aws_network_acl_rule" "pass" {
   network_acl_id = aws_network_acl.example.id
   rule_number    = 200
   from_port      = 22
@@ -258,10 +480,10 @@ resource "aws_network_acl_rule" "pass_1" {
   cidr_block     = "10.3.0.0/18"
 }
 
-# ok: aws-network-acl-allows-all-ports
-resource "aws_network_acl" "pass_2" {
+resource "aws_network_acl" "pass_multiple_rules" {
   vpc_id = aws_vpc.example.id
 
+  # ok: aws-network-acl-allows-all-ports
   egress {
     protocol   = "tcp"
     rule_no    = 200
@@ -271,6 +493,31 @@ resource "aws_network_acl" "pass_2" {
     to_port    = 443
   }
 
+  # ok: aws-network-acl-allows-all-ports
+  ingress {
+    protocol   = "tcp"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 80
+    to_port    = 80
+  }
+}
+
+resource "aws_default_network_acl" "pass_multiple_rules" {
+  default_network_acl_id = aws_vpc.example.default_network_acl_id
+
+  # ok: aws-network-acl-allows-all-ports
+  egress {
+    protocol   = "tcp"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = "10.3.0.0/18"
+    from_port  = 443
+    to_port    = 443
+  }
+
+  # ok: aws-network-acl-allows-all-ports
   ingress {
     protocol   = "tcp"
     rule_no    = 100

--- a/terraform/aws/security/aws-network-acl-allows-all-ports.yaml
+++ b/terraform/aws/security/aws-network-acl-allows-all-ports.yaml
@@ -32,9 +32,9 @@ rules:
       - metavariable-regex:
           metavariable: $NETWORK_ACL
           regex: ^(aws_network_acl|aws_default_network_acl)$
-    - metavariable-regex:
-        metavariable: $PROTOCOL
-        regex: \A("all"|"-1"|-1)\Z
+  - metavariable-regex:
+      metavariable: $PROTOCOL
+      regex: \A("all"|"-1"|-1)\Z
   message: >-
     Ingress and/or egress is allowed for all ports in the network ACL rule.
     Ensure access to specific required ports is allowed, and nothing else.

--- a/terraform/aws/security/aws-network-acl-allows-all-ports.yaml
+++ b/terraform/aws/security/aws-network-acl-allows-all-ports.yaml
@@ -11,7 +11,7 @@ rules:
         }
     - patterns:
       - pattern-inside: |
-          resource "aws_network_acl" $ANYTHING {
+          resource "$NETWORK_ACL" $ANYTHING {
             ...
           }
       - pattern-either:
@@ -29,7 +29,10 @@ rules:
               action = "allow"
               ...
             }
-  - metavariable-regex:
+      - metavariable-regex:
+          metavariable: $NETWORK_ACL
+          regex: ^(aws_network_acl|aws_default_network_acl)$
+    - metavariable-regex:
       metavariable: $PROTOCOL
       regex: \A("all"|"-1"|-1)\Z
   message: >-
@@ -51,11 +54,10 @@ rules:
     - https://owasp.org/Top10/A01_2021-Broken_Access_Control/
     - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl
     - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/network_acl_rule
+    - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_network_acl
     - https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html
     subcategory:
     - audit
     likelihood: MEDIUM
     impact: MEDIUM
     confidence: LOW
-    rule-origin-note: published from /src/aws-network-acl-allows-all-ports.yml in
-      None

--- a/terraform/aws/security/aws-network-acl-allows-all-ports.yaml
+++ b/terraform/aws/security/aws-network-acl-allows-all-ports.yaml
@@ -33,8 +33,8 @@ rules:
           metavariable: $NETWORK_ACL
           regex: ^(aws_network_acl|aws_default_network_acl)$
     - metavariable-regex:
-      metavariable: $PROTOCOL
-      regex: \A("all"|"-1"|-1)\Z
+        metavariable: $PROTOCOL
+        regex: \A("all"|"-1"|-1)\Z
   message: >-
     Ingress and/or egress is allowed for all ports in the network ACL rule.
     Ensure access to specific required ports is allowed, and nothing else.


### PR DESCRIPTION
## Description

This PR updates the `terraform.aws.security.aws-network-acl-allows-all-ports` rule to cover the `aws_default_network_acl` resource (previously, it only covered `aws_network_acl` and `aws_network_acl_rule`).