### PR TITLE
Add rule jackson-unsafe-deserialization (Java)

### DIFF
--- a/java/lang/security/jackson-unsafe-deserialization.java
+++ b/java/lang/security/jackson-unsafe-deserialization.java
@@ -1,0 +1,73 @@
+private class Car {
+    private Fake variable;
+
+    @JsonTypeInfo(use = Id.CLASS)
+    private Object color;
+    private String type;
+
+    public Car() {
+    }
+
+    public Car(Object color, String type) {
+        this.color = color;
+        this.type = type;
+    }
+
+    public String getColor() {
+        return (String) this.color;
+    }
+
+    public void setColor(Object color) {
+        this.color = color;
+    }
+
+    public String getType() {
+        return this.type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public static void main(String[] args) throws JsonGenerationException, JsonMappingException, IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.enableDefaultTyping();
+
+        try {
+            // ruleid: jackson-unsafe-deserialization
+            Car car = objectMapper.readValue(Paths.get("target/payload.json").toFile(), Car.class);
+            System.out.println((car.getColor()));
+        } catch (Exception e) {
+            System.out.println("Exception raised:" + e.getMessage());
+        }
+
+    }
+
+    public static void anotherMain(String[] args) throws JsonGenerationException, JsonMappingException, IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        // Disable default typing globally
+        //objectMapper.enableDefaultTyping();
+
+        try {
+            // ruleid: jackson-unsafe-deserialization
+            Car car = objectMapper.readValue(Paths.get("target/payload.json").toFile(), Car.class);
+            System.out.println((car.getColor()));
+        } catch (Exception e) {
+            System.out.println("Exception raised:" + e.getMessage());
+        }
+
+    }
+
+    public static void anotherMain2(String[] args) throws JsonGenerationException, JsonMappingException, IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            // ok: jackson-unsafe-deserialization
+            Car car = objectMapper.readValue(Paths.get("target/payload.json").toFile(), Another.class);
+            System.out.println((car.getColor()));
+        } catch (Exception e) {
+            System.out.println("Exception raised:" + e.getMessage());
+        }
+
+    }
+}

--- a/java/lang/security/jackson-unsafe-deserialization.yaml
+++ b/java/lang/security/jackson-unsafe-deserialization.yaml
@@ -23,13 +23,13 @@ rules:
               - pattern: $OM.readValue($JSON, $CLASS.class);
     message: >-
       When using Jackson to marshall/unmarshall JSON to Java objects,
-       enabling default typing is dangerous and can lead to RCE. If an attacker
-       can control `$JSON` it might be possible to provide a malicious JSON which
-       can be used to exploit unsecure deserialization. In order to prevent this
-       issue, avoid to enable default typing (globally or by using "Per-class"
-       annotations) and avoid using `Object` and other dangerous types for member
-       variable declaration which creating classes for Jackson based
-       deserialization.
+      enabling default typing is dangerous and can lead to RCE. If an attacker
+      can control `$JSON` it might be possible to provide a malicious JSON which
+      can be used to exploit unsecure deserialization. In order to prevent this
+      issue, avoid to enable default typing (globally or by using "Per-class"
+      annotations) and avoid using `Object` and other dangerous types for member
+      variable declaration which creating classes for Jackson based
+      deserialization.
     languages:
       - java
     severity: WARNING

--- a/java/lang/security/jackson-unsafe-deserialization.yaml
+++ b/java/lang/security/jackson-unsafe-deserialization.yaml
@@ -1,0 +1,53 @@
+rules:
+  - id: jackson-unsafe-deserialization
+    patterns:
+      - pattern-either:
+          - patterns:
+              - pattern-inside: |
+                  ObjectMapper $OM = new ObjectMapper(...);
+                  ...
+                  $OM.enableDefaultTyping();
+                  ...
+              - pattern: $OM.readValue($JSON, ...);
+          - patterns:
+              - pattern-inside: |
+                  class $CLASS {
+                    ...
+                    @JsonTypeInfo(use = Id.CLASS,...)
+                    $TYPE $VAR;
+                    ...
+                  }
+              - metavariable-regex:
+                  metavariable: $TYPE
+                  regex: (Object|Serializable|Comparable)
+              - pattern: $OM.readValue($JSON, $CLASS.class);
+    message: >-
+      When using Jackson to marshall/unmarshall JSON to Java objects,
+       enabling default typing is dangerous and can lead to RCE. If an attacker
+       can control `$JSON` it might be possible to provide a malicious JSON which
+       can be used to exploit unsecure deserialization. In order to prevent this
+       issue, avoid to enable default typing (globally or by using "Per-class"
+       annotations) and avoid using `Object` and other dangerous types for member
+       variable declaration which creating classes for Jackson based
+       deserialization.
+    languages:
+      - java
+    severity: WARNING
+    metadata:
+      category: security
+      subcategory:
+        - audit
+      cwe:
+        - "CWE 502: Deserialization of Untrusted Data"
+      confidence: MEDIUM
+      likelihood: LOW
+      impact: HIGH
+      owasp:
+        - A8:2017 Insecure Deserialization
+        - A8:2021 Software and Data Integrity Failures
+      references:
+        - https://swapneildash.medium.com/understanding-insecure-implementation-of-jackson-deserialization-7b3d409d2038
+        - https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
+        - https://adamcaudill.com/2017/10/04/exploiting-jackson-rce-cve-2017-7525/
+      technology:
+        - jackson

--- a/java/lang/security/jackson-unsafe-deserialization.yaml
+++ b/java/lang/security/jackson-unsafe-deserialization.yaml
@@ -6,6 +6,7 @@ rules:
               - pattern-inside: |
                   ObjectMapper $OM = new ObjectMapper(...);
                   ...
+              - pattern-inside: |
                   $OM.enableDefaultTyping();
                   ...
               - pattern: $OM.readValue($JSON, ...);


### PR DESCRIPTION
This rule checks if default typing (which can lead to RCE in conjunction with unsafe deserialization) is enabled (globally or via Jackson annotations).
References:
- https://swapneildash.medium.com/understanding-insecure-implementation-of-jackson-deserialization-7b3d409d2038
- https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
- https://snyk.io/blog/java-json-deserialization-problems-jackson-objectmapper/