### PR TITLE
update formatted-sql-string to support concatenated / mutable String objects and a few additional sinks 

### DIFF
--- a/java/lang/security/audit/formatted-sql-string.yaml
+++ b/java/lang/security/audit/formatted-sql-string.yaml
@@ -55,7 +55,7 @@ rules:
       - pattern: (EntityManager $EM).$SQLFUNC(...)
     - metavariable-regex:
         metavariable: $SQLFUNC
-        regex: execute|executeQuery|createQuery|query
+        regex: execute|executeQuery|createQuery|query|addBatch|nativeSQL|create|prepare
   pattern-sanitizers:
   - patterns:
     - pattern: (CriteriaBuilder $CB).$ANY(...)

--- a/java/lang/security/audit/formatted-sql-string.yaml
+++ b/java/lang/security/audit/formatted-sql-string.yaml
@@ -42,9 +42,28 @@ rules:
             $ANNOT $FUNC (..., $INPUT, ...) {
               ...
             }
-        - pattern-either:
-          - pattern: (String $INPUT)
-          - pattern: String.format(..., (String $INPUT), ...)
+        - pattern: (String $INPUT)
+    - focus-metavariable: $INPUT
+    label: INPUT
+  - patterns:
+    - pattern-either:
+      - pattern: $X + $INPUT
+      - pattern: $X += $INPUT
+      - pattern: $STRB.append($INPUT)
+      - pattern: String.format(..., $INPUT, ...)
+      - pattern: String.join(..., $INPUT, ...)
+      - pattern: (String $STR).concat($INPUT)
+      - pattern: $INPUT.concat(...)
+      - pattern: new $STRB(..., $INPUT, ...)
+    label: CONCAT
+    requires: INPUT
+  pattern-propagators:
+    - pattern: (StringBuffer $S).append($X)
+      from: $X
+      to: $S
+    - pattern: (StringBuilder $S).append($X)
+      from: $X
+      to: $S
   pattern-sinks:
   - patterns:
     - pattern-not: $S.$SQLFUNC(<... "=~/.*TABLE *$/" ...>)
@@ -58,6 +77,7 @@ rules:
     - metavariable-regex:
         metavariable: $SQLFUNC
         regex: execute|executeQuery|createQuery|query|addBatch|nativeSQL|create|prepare
+    requires: CONCAT
   pattern-sanitizers:
   - patterns:
     - pattern: (CriteriaBuilder $CB).$ANY(...)

--- a/java/lang/security/audit/formatted-sql-string.yaml
+++ b/java/lang/security/audit/formatted-sql-string.yaml
@@ -51,7 +51,9 @@ rules:
     - pattern-not: $S.$SQLFUNC(<... "=~/.*TABLE %s$/" ...>)
     - pattern-either:
       - pattern: (Statement $S).$SQLFUNC(...)
+      - pattern: (PreparedStatement $P).$SQLFUNC(...)
       - pattern: (Connection $C).createStatement(...).$SQLFUNC(...)
+      - pattern: (Connection $C).prepareStatement(...).$SQLFUNC(...)
       - pattern: (EntityManager $EM).$SQLFUNC(...)
     - metavariable-regex:
         metavariable: $SQLFUNC

--- a/java/spring/security/injection/tainted-system-command.yaml
+++ b/java/spring/security/injection/tainted-system-command.yaml
@@ -33,7 +33,7 @@ rules:
       - pattern: String.join("...", ..., $SOURCE, ...)
       - pattern: (String $STR).concat($SOURCE)
       - pattern: $SOURCE.concat(...)
-      - pattern: $X += SOURCE
+      - pattern: $X += $SOURCE
       - pattern: $SOURCE += $X
     label: CONCAT
     requires: INPUT


### PR DESCRIPTION
- Missing $ in metavariable SOURCE.
- Added addBatch / nativeSQL / create(.*) / prepare as potential sink methods for sqli   (execute(), executeQuery(), executeUpdate() already covered by regex Statement sink methods:   execute, executeQuery, executeUpdate, ... EntityManager sink methods:   createNativeQuery, createQuery, createStoredProcedureQuery Connection sink methods:   nativeSQL, prepareCall
- Add prepared statements (can be used incorrectly) as sinks.
- Handle string concats + mutable StringBuffer/StringBuilder as propagators. (does not handle sbf.append().append() ... )
