### PR TITLE
Add rule for Intercom Messenger configuration without Identity Verification

### DIFF
--- a/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.js
+++ b/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.js
@@ -1,0 +1,95 @@
+// ok: intercom-settings-user-identifier-without-user-hash
+window.intercomSettings = {
+  app_id: appId,
+  name: myUserName,
+  email: myUserEmail,
+  user_hash: "my-user-hash",
+};
+
+// ok: intercom-settings-user-identifier-without-user-hash
+window.intercomSettings = {
+  app_id: appId,
+  name: myUserName,
+  user_id: myUserID,
+  user_hash: "my-user-hash",
+};
+
+// ruleid: intercom-settings-user-identifier-without-user-hash
+window.intercomSettings = {
+  app_id: appId,
+  name: myUserName,
+  email: myUserEmail,
+};
+
+// ruleid: intercom-settings-user-identifier-without-user-hash
+window.intercomSettings = {
+  app_id: appId,
+  name: myUserName,
+  user_id: myUserID,
+};
+
+// ruleid: intercom-settings-user-identifier-without-user-hash
+Intercom('boot', {
+    app_id: 'abc12345',
+    email: 'john.doe@example.com',
+    name: 'John Doe',
+    user_id: '9876'
+});
+
+// ok: intercom-settings-user-identifier-without-user-hash
+Intercom('boot', {
+    app_id: 'abc12345',
+    email: 'john.doe@example.com',
+    name: 'John Doe',
+    user_id: '9876',
+    user_hash: 'my-user-hash'
+});
+
+// ruleid: intercom-settings-user-identifier-without-user-hash
+Intercom('boot', {
+    app_id: 'abc12345',
+    email: 'john.doe@example.com',
+    name: 'John Doe',
+});
+
+// ok: intercom-settings-user-identifier-without-user-hash
+Intercom('boot', {
+    app_id: 'abc12345',
+    email: 'john.doe@example.com',
+    name: 'John Doe',
+    user_hash: 'my-user-hash'
+});
+
+// ruleid: intercom-settings-user-identifier-without-user-hash
+Intercom('boot', {
+    app_id: 'abc12345',
+    name: 'John Doe',
+    user_id: '9876'
+});
+
+// ok: intercom-settings-user-identifier-without-user-hash
+Intercom('boot', {
+    app_id: 'abc12345',
+    name: 'John Doe',
+    user_id: '9876',
+    user_hash: 'my-user-hash'
+});
+
+// ruleid: intercom-settings-user-identifier-without-user-hash
+myCustomSettings = {
+  app_id: appId,
+  name: myUserName,
+  user_id: myUserID,
+};
+
+Intercom('boot', myCustomSettings);
+
+// ok: intercom-settings-user-identifier-without-user-hash
+myCustomSettingsWithHash = {
+  app_id: appId,
+  name: myUserName,
+  user_id: myUserID,
+  user_hash: 'my-user-hash'
+};
+
+Intercom('boot', myCustomSettingsWithHash);

--- a/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.yaml
+++ b/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.yaml
@@ -1,0 +1,49 @@
+rules:
+  - id: intercom-settings-user-identifier-without-user-hash
+    patterns:
+      - pattern-either:
+          - pattern: |
+              window.intercomSettings = {..., email: $EMAIL, ...};
+          - pattern: |
+              window.intercomSettings = {..., user_id: $USER_ID, ...};
+          - pattern: |
+              Intercom('boot', {..., email: $EMAIL, ...});
+          - pattern: |
+              Intercom('boot', {..., user_id: $USER_ID, ...});
+          - pattern: |
+              $VAR = {..., email: $EMAIL, ...};
+              ...
+              Intercom('boot', $VAR);
+          - pattern: |
+              $VAR = {..., user_id: $EMAIL, ...};
+              ...
+              Intercom('boot', $VAR);
+      - pattern-not: |
+          window.intercomSettings = {..., user_hash: $USER_HASH, ...};
+      - pattern-not: |
+          Intercom('boot', {..., user_hash: $USER_HASH, ...});
+      - pattern-not: |
+          $VAR = {..., user_hash: $USER_HASH, ...};
+          ...
+          Intercom('boot', $VAR);
+    message: Found an initialization of the Intercom Messenger that identifies a
+      User, but does not specify a `user_hash`.This configuration allows users
+      to impersonate one another. See the Intercom Identity Verification docs
+      for more context
+      https://www.intercom.com/help/en/articles/183-set-up-identity-verification-for-web-and-mobile
+    languages:
+      - js
+    severity: WARNING
+    metadata:
+      category: security
+      subcategory:
+        - guardrail
+      cwe:
+        - "CWE 287: Improper Authentication"
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      technology:
+        - intercom
+      references:
+        - https://www.intercom.com/help/en/articles/183-set-up-identity-verification-for-web-and-mobile

--- a/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.yaml
+++ b/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.yaml
@@ -40,7 +40,7 @@ rules:
         - guardrail
       cwe:
         - "CWE 287: Improper Authentication"
-      confidence: HIGH
+      confidence: MEDIUM
       likelihood: MEDIUM
       impact: HIGH
       technology:


### PR DESCRIPTION
Intercom provides an [Identity Verification](https://www.intercom.com/help/en/articles/183-set-up-identity-verification-for-web-and-mobile#h_3ff88de271) feature to prevent user impersonation. 

When enabling this feature, a hash of a user-identifier is supplied on the initialization of the Messenger widget. The hash value is then validated by Intercom for each request. If this hash doesn't exist, the end user could manipulate their own user identifier and claim to be someone else.