### PR TITLE
Fix FPs in python empty hardcoded password

### DIFF
--- a/python/lang/security/audit/hardcoded-password-default-argument.py
+++ b/python/lang/security/audit/hardcoded-password-default-argument.py
@@ -18,3 +18,7 @@ def whoops(password="this-could-be-bad"):
 # ok:hardcoded-password-default-argument
 def ok(password=None):
     print(password)
+
+# ok:hardcoded-password-default-argument
+def ok(password=""):
+    print(password)

--- a/python/lang/security/audit/hardcoded-password-default-argument.yaml
+++ b/python/lang/security/audit/hardcoded-password-default-argument.yaml
@@ -8,11 +8,11 @@ rules:
   severity: WARNING
   patterns:
     - pattern: |
-        def $FUNC(..., password="$PASSWORD", ...):
+        def $FUNC(..., password="...", ...):
           ...
-    - metavariable-regex:
-        metavariable: $PASSWORD
-        regex: .+
+    - pattern-not: |
+        def $FUNC(..., password="", ...):
+          ...
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'

--- a/python/lang/security/audit/hardcoded-password-default-argument.yaml
+++ b/python/lang/security/audit/hardcoded-password-default-argument.yaml
@@ -6,9 +6,13 @@ rules:
     a real password is not supplied.
   languages: [python]
   severity: WARNING
-  pattern: |
-    def $FUNC(..., password="...", ...):
-      ...
+  patterns:
+    - pattern: |
+        def $FUNC(..., password="$PASSWORD", ...):
+          ...
+    - metavariable-regex:
+        metavariable: $PASSWORD
+        regex: .+
   metadata:
     cwe:
     - 'CWE-798: Use of Hard-coded Credentials'


### PR DESCRIPTION
Here's a fix for the FPs that I've encountered. An example of such a FP:
```python
def __init__(self, password=""):
        self.domain = domain
        if not password:
            password = getpass.getpass()
```