### PR TITLE
Remove colons from message in bind.avoid-bind-to-all-interfaces rule

### DIFF
--- a/python/lang/security/audit/network/bind.yaml
+++ b/python/lang/security/audit/network/bind.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: avoid-bind-to-all-interfaces
   message: >-
-    Running `socket.bind` to 0.0.0.0, ::, or empty string could unexpectedly
+    Running `socket.bind` to 0.0.0.0, or empty string could unexpectedly
     expose the server publicly as it binds to all available interfaces. Consider
     instead getting correct address from an environment variable or
     configuration file.


### PR DESCRIPTION
The rule works fine but when fetched as part of https://semgrep.dev/c/p/r2c-ci rule pack, message field gets reformatted into:
```
  message: Running `socket.bind` to 0.0.0.0, ::, or empty string could unexpectedly
    expose the server publicly as it binds to all available interfaces. Consider instead
    getting correct address from an environment variable or configuration file.
```

and colons cause parsing errors on some systems, we got multiple complains including: https://github.com/returntocorp/semgrep-rules/issues/2939