### PR TITLE
Update intercom-settings-user-identifier-without-user-hash.yaml

### DIFF
--- a/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.yaml
+++ b/javascript/intercom/security/audit/intercom-settings-user-identifier-without-user-hash.yaml
@@ -39,7 +39,7 @@ rules:
       subcategory:
         - guardrail
       cwe:
-        - "CWE 287: Improper Authentication"
+        - "CWE-287: Improper Authentication"
       confidence: MEDIUM
       likelihood: MEDIUM
       impact: HIGH


### PR DESCRIPTION
Fix `CWE-*` metadata field