### PR TITLE
Match app-specific class/module when configuring Rails session-store

### DIFF
--- a/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.rb
+++ b/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.rb
@@ -23,3 +23,9 @@ Rails.application.config.session_store :cookie_store, httponly: false
 
 # ok: check-cookie-store-session-security-attributes
 Rails.application.config.session_store :cookie_store, some_harmless_key: false
+
+# ruleid: check-cookie-store-session-security-attributes
+MyRailsApp::Application.config.session_store :cookie_store, httponly: false
+
+# ruleid: check-cookie-store-session-security-attributes
+MyRailsApp.application.config.session_store :cookie_store, httponly: false

--- a/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.rb
+++ b/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.rb
@@ -18,6 +18,10 @@ Rails3::Application.config.session_store :cookie_store, :key => '_rails3_session
 # ruleid: check-cookie-store-session-security-attributes
 Rails3::Application.config.session_store :cookie_store, :httponly => false, :key => '_rails3_session'
 
+#rails3
+# ruleid: check-cookie-store-session-security-attributes
+Rails.application.config.session_store :cookie_store, key: '_rails3_session', httponly: false, domain: :all
+
 # ruleid: check-cookie-store-session-security-attributes
 Rails.application.config.session_store :cookie_store, httponly: false
 

--- a/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.yaml
+++ b/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.yaml
@@ -8,9 +8,9 @@ rules:
       - pattern-inside: |
           ActionController::Base.session = {...}
     - pattern: |
-        Rails3::Application.config.session_store :cookie_store, ..., :$KEY => false, ...
+        $MODULE::Application.config.session_store :cookie_store, ..., :$KEY => false, ...
     - pattern: |
-        Rails.application.config.session_store :cookie_store, ..., $KEY: false
+        $CLASS.application.config.session_store :cookie_store, ..., $KEY: false
   - metavariable-regex:
       metavariable: $KEY
       regex: ^(session_)?(http_?only|secure)$

--- a/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.yaml
+++ b/ruby/rails/security/brakeman/check-cookie-store-session-security-attributes.yaml
@@ -10,7 +10,7 @@ rules:
     - pattern: |
         $MODULE::Application.config.session_store :cookie_store, ..., :$KEY => false, ...
     - pattern: |
-        $CLASS.application.config.session_store :cookie_store, ..., $KEY: false
+        $CLASS.application.config.session_store :cookie_store, ..., $KEY: false, ...
   - metavariable-regex:
       metavariable: $KEY
       regex: ^(session_)?(http_?only|secure)$


### PR DESCRIPTION
Rails apps can derive their own custom class from `Rails::Application`, then use that when configuring the app. An example from `OWASP/railsgoat`:

```
module Railsgoat
  class Application < Rails::Application
    ...
  end
end

...

Railsgoat::Application.config.session_store :cookie_store, key: "_railsgoat_session", httponly: false
```

---

Also, `httponly` doesn't have to be the last argument so support that too.