### PR TITLE
fix(c#): fix c-sharp rules

### DIFF
--- a/csharp/lang/correctness/double/double-epsilon-equality.yaml
+++ b/csharp/lang/correctness/double/double-epsilon-equality.yaml
@@ -5,7 +5,7 @@ rules:
         $V1 - $V2
     - pattern-either:
       - pattern-inside: |
-          ... <= Double.Epsilon;
+          ... <= Double.Epsilon
       - pattern-inside: | 
           Double.Epsilon <= ...
     - pattern-not-inside: |

--- a/csharp/lang/security/regular-expression-dos/regular-expression-dos.yaml
+++ b/csharp/lang/security/regular-expression-dos/regular-expression-dos.yaml
@@ -32,14 +32,14 @@ rules:
         {
           Regex $Y = new Regex($P);
           ...
-          $Y.Match($X)
+          $Y.Match($X);
         }
     - pattern: |
         public $T $F($X)
         {
           Regex $Y = new Regex($P, $O);
           ...
-          $Y.Match($X)
+          $Y.Match($X);
         }
     - pattern: |
         public $T $F($X)

--- a/csharp/lang/security/sqli/csharp-sqli.yaml
+++ b/csharp/lang/security/sqli/csharp-sqli.yaml
@@ -61,7 +61,7 @@ rules:
       $S.$PATTERN = "..." + "...";
   - pattern-not-inside: |
       ...
-      $S.Parameters
+      <... $S.Parameters ...>;
   message: >-
     Detected a formatted string in a SQL statement. This could lead to SQL injection if variables in the
     SQL statement are not properly sanitized.

--- a/csharp/lang/security/ssrf/http-client.yaml
+++ b/csharp/lang/security/ssrf/http-client.yaml
@@ -34,7 +34,7 @@ rules:
         ...
         HttpClient $Y = new HttpClient();
         ...
-        ... $Y.GetAsync(<... $X ...>, ...)
+        ... $Y.GetAsync(<... $X ...>, ...);
         }
     - pattern: |
         $T $F(..., $X, ...)
@@ -44,7 +44,7 @@ rules:
         ...
         HttpClient $Y = new HttpClient();
         ...
-        ... $Y.GetAsync($B, ...)
+        ... $Y.GetAsync($B, ...);
         }
     - pattern: |
         $T $F(..., $X, ...)
@@ -52,7 +52,7 @@ rules:
         ...
         HttpClient $Y = new HttpClient();
         ...
-        ... $Y.GetStringAsync(<... $X ...>)
+        ... $Y.GetStringAsync(<... $X ...>);
         }
     - pattern: |
         $T $F(..., $X, ...)
@@ -62,5 +62,5 @@ rules:
         ...
         HttpClient $Y = new HttpClient();
         ...
-        ... $Y.GetStringAsync($B)
+        ... $Y.GetStringAsync($B);
         }

--- a/csharp/lang/security/ssrf/rest-client.yaml
+++ b/csharp/lang/security/ssrf/rest-client.yaml
@@ -32,7 +32,7 @@ rules:
         $T $F(..., $X, ...)
         {
         ...
-        ... new RestClient(<... $X ...>)
+        ... new RestClient(<... $X ...>);
         }
     - pattern: |
         $T $F(..., $X, ...)
@@ -40,5 +40,5 @@ rules:
         ...
         $A $B = <... $X ...>;
         ...
-        ... new RestClient($B)
+        ... new RestClient($B);
         }

--- a/csharp/lang/security/ssrf/web-client.yaml
+++ b/csharp/lang/security/ssrf/web-client.yaml
@@ -34,7 +34,7 @@ rules:
         ...
         WebClient $Y = new WebClient();
         ...
-        ... $Y.OpenRead(<... $X ...>)
+        ... $Y.OpenRead(<... $X ...>);
         }
     - pattern: |
         $T $F(..., $X, ...)
@@ -44,7 +44,7 @@ rules:
         ...
         WebClient $Y = new WebClient();
         ...
-        ... $Y.OpenRead($B)
+        ... $Y.OpenRead($B);
         }
     - pattern: |
         $T $F(..., $X, ...)
@@ -52,25 +52,7 @@ rules:
         ...
         WebClient $Y = new WebClient();
         ...
-        ... $Y.OpenReadAsync(<... $X ...>, ...)
-        }
-    - pattern: |
-        $T $F(..., $X, ...)
-        {
-        ...
-        $A $B = <... $X ...>;
-        ...
-        WebClient $Y = new WebClient();
-        ...
-        ... $Y.OpenReadAsync($B, ...)
-        }
-    - pattern: |
-        $T $F(..., $X, ...)
-        {
-        ...
-        WebClient $Y = new WebClient();
-        ...
-        ... $Y.DownloadString(<... $X ...>)
+        ... $Y.OpenReadAsync(<... $X ...>, ...);
         }
     - pattern: |
         $T $F(..., $X, ...)
@@ -80,5 +62,23 @@ rules:
         ...
         WebClient $Y = new WebClient();
         ...
-        ... $Y.DownloadString($B)
+        ... $Y.OpenReadAsync($B, ...);
+        }
+    - pattern: |
+        $T $F(..., $X, ...)
+        {
+        ...
+        WebClient $Y = new WebClient();
+        ...
+        ... $Y.DownloadString(<... $X ...>);
+        }
+    - pattern: |
+        $T $F(..., $X, ...)
+        {
+        ...
+        $A $B = <... $X ...>;
+        ...
+        WebClient $Y = new WebClient();
+        ...
+        ... $Y.DownloadString($B);
         }


### PR DESCRIPTION
In preparation for https://github.com/returntocorp/semgrep/pull/8023, which will cause C# patterns that do not use expression statements ending in semicolons to no longer parse properly.

There were two other significant changes I had to make, which was namely to the `double-epsilon-equality` and `csharp-sqli` rules. Please double-check me on whether or not my changes make sense. To be honest, I don't really know why they used to work in the first place.