### PR TITLE
fix artifactory password regex regression

### DIFF
--- a/generic/secrets/security/detected-artifactory-password.txt
+++ b/generic/secrets/security/detected-artifactory-password.txt
@@ -106,7 +106,7 @@ b3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20KIHRoaXMgc29mdHdhcmUgd2l0aG9
 
 {
     # ok: detected-artifactory-password
-    "integrity": "sha512-12345678APAjZas32d1f32a1sd2fasdfasdf32a1sd32f1a3s2d1feeeeeeeeee=="
+    "integrity": "sha512-APAjZas32d1f32a1sd2fasdfasdf32a1sd32f1a3s2d1feeeeeeeeee=="
 }
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/generic/secrets/security/detected-artifactory-password.yaml
+++ b/generic/secrets/security/detected-artifactory-password.yaml
@@ -7,12 +7,7 @@ rules:
     - metavariable-regex:
         metavariable: $ITEM
         regex: \bAP[\dABCDEF][a-zA-Z0-9]{8,}
-    - metavariable-pattern:
-        metavariable: $ITEM
-        language: regex
-        patterns:
-          - pattern-not-regex: |
-              sha(128|256|512).*
+    - pattern-not-regex: sha(128|256|512).*
     - pattern-not-inside: |
         -BEGIN ...-
         -END ...-


### PR DESCRIPTION
Fixes #2959.

It appears that the yarn lock test case for the artifactory password rule had a prefix added that provided false confidence in #2956.

This change moves the not-regex out of a `metavariable-pattern` context and into a top-level `pattern-not-regex`.

I've validated that the lock file example triggers before this change and succeeds after it.