### PR TITLE
Deprecate some Ruby rules

### DIFF
--- a/ruby/lang/security/nested-attributes-bypass.rb
+++ b/ruby/lang/security/nested-attributes-bypass.rb
@@ -1,16 +1,12 @@
 def bad_nested_attributes_bypass
-    # ruleid: nested-attributes-bypass
     accepts_nested_attributes_for allow_destroy: false
 
-    # ruleid: nested-attributes-bypass
     accepts_nested_attributes_for :avatar, :book, allow_destroy: false
 
-    # ruleid: nested-attributes-bypass
     accepts_nested_attributes_for :avatar, :book, allow_destroy: false, :name
 end
 
 def ok_nested_attributes_bypass
     has_one :avatar
-    # ok: nested-attributes-bypass
     accepts_nested_attributes_for :avatar, allow_destroy: true
 end

--- a/ruby/lang/security/nested-attributes-bypass.yaml
+++ b/ruby/lang/security/nested-attributes-bypass.yaml
@@ -1,14 +1,6 @@
 rules:
 - id: nested-attributes-bypass
-  message: >-
-    Checks for nested attributes vulnerability (CVE-2015-7577). Setting allow_destroy:
-    false in
-    accepts_nested_attributes_for can lead to attackers setting attributes to invalid
-    values and clearing all attributes.
-    This affects versions 3.1.0 and newer, with fixed versions 5.0.0.beta1.1, 4.2.5.1,
-    4.1.14.1, 3.2.22.1.
-    To fix, upgrade to a newer version or use the initializer specified in the google
-    groups.
+  message: This rule is deprecated.
   metadata:
     cwe:
     - 'CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes'
@@ -28,4 +20,6 @@ rules:
   languages:
   - ruby
   severity: WARNING
-  pattern: 'accepts_nested_attributes_for ..., allow_destroy: false, ...'
+  patterns:
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/mime-type-dos.rb
+++ b/ruby/rails/security/audit/mime-type-dos.rb
@@ -1,10 +1,8 @@
 def bad(string, symbol, mime_type_synonyms = [], extension_synonyms = [], skip_lookup = false)
-  # ruleid: mime-type-dos
   Mime.const_set(symbol.to_s.upcase, Type.new(string, symbol, mime_type_synonyms))
 end
 
 def ok()
-  # ok: mime-type-dos
   Mime.const_set :LOOKUP, Hash.new { |h,k|
     Mime::Type.new(k) unless k.blank?
   }

--- a/ruby/rails/security/audit/mime-type-dos.yaml
+++ b/ruby/rails/security/audit/mime-type-dos.yaml
@@ -16,17 +16,9 @@ rules:
     likelihood: LOW
     impact: HIGH
     confidence: LOW
-  message: >-
-    Detected usage of `Mime.const_set`. This could lead to a Denial of Service attack,
-    as an attacker could send lots of different mime types to the server,
-    causing the cache to grow large and use all available RAM.
-    Make sure you are using 5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1 or higher. If this is not possible,
-    use the workaround with "Mime.const_set :LOOKUP, Hash.new { |h,k| Mime::Type.new(k) unless k.blank?
-    }"
+  message: This rule is deprecated.
   languages: [ruby]
   severity: WARNING
   patterns:
-  - pattern: |
-      Mime.const_set ... 
-  - pattern-not: |
-      Mime.const_set :LOOKUP, ... 
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/rails-check-page-caching-cve.rb
+++ b/ruby/rails/security/audit/rails-check-page-caching-cve.rb
@@ -1,15 +1,12 @@
 class CachingController < ApplicationController
-  # ruleid: rails-check-page-caching-cve
   caches_page :show
 end
 
 class CachingController2 < ApplicationController
-  # ruleid: rails-check-page-caching-cve
   caches_page :uhoh
 end
 
 class SafeController < ApplicationController
-  # ok
   asdf :show
 end
 

--- a/ruby/rails/security/audit/rails-check-page-caching-cve.yaml
+++ b/ruby/rails/security/audit/rails-check-page-caching-cve.yaml
@@ -1,16 +1,9 @@
 rules:
 - id: rails-check-page-caching-cve
   patterns:
-  - pattern-inside: |
-      class $CONTROLLER < $BIGCONTROLLER
-      ...
-      end
-  - pattern: |
-      caches_page :$ACTION
-  message: >-
-    All versions below 1.2.1 of the 'actionpack_page-caching' gem are vulnerable to arbitrary file write
-    and remote code execution (CVE-2020-8159) when using caching methods. Update to version 1.2.1 or greater
-    or remove calls to 'caches_page'.
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   languages:
   - ruby
   severity: WARNING

--- a/ruby/rails/security/audit/rails-check-render-dos-cve.rb
+++ b/ruby/rails/security/audit/rails-check-render-dos-cve.rb
@@ -1,10 +1,8 @@
 class Text < ApplicationController
-  # ruleid: rails-check-render-dos
   render :hello
 end
 
 class Text < ApplicationController
-  # ok
   send :hello
 end
 

--- a/ruby/rails/security/audit/rails-check-render-dos-cve.yaml
+++ b/ruby/rails/security/audit/rails-check-render-dos-cve.yaml
@@ -1,15 +1,9 @@
 rules:
 - id: rails-check-render-dos
   patterns:
-  - pattern-inside: |
-      class $CONTROLLER < $BIGCONTROLLER
-      ...
-      end
-  - pattern: |
-      render :$TEXT
-  message: The render method in Rails versions 3.0.0 - 3.0.20, 3.1.0 - 3.1.12, and 3.2.0 - 3.2.16 are
-    vulnerable to a denial of service attack (CVE-2014-0082), which could lead to service downtime. Upgrade
-    to 3.2.17 or higher instead.
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   languages:
   - generic
   severity: WARNING


### PR DESCRIPTION
These rules do not check the gem versions so they are false-positive prone.