### PR TITLE
Fix multiline BEGIN-END pattern

### DIFF
--- a/generic/secrets/security/detected-artifactory-password.txt
+++ b/generic/secrets/security/detected-artifactory-password.txt
@@ -124,7 +124,7 @@ b3IgcHJvbW90ZSBwcm9kdWN0cyBkZXJpdmVkIGZyb20KIHRoaXMgc29mdHdhcmUgd2l0aG9
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 # ok: detected-artifactory-password
-AKCxxxxxxxxxx
+AP6xxxxxxxxxx
 -----END PGP PUBLIC KEY BLOCK-----
 
 apiVersion: appprotectdos.f5.com/v1beta1

--- a/generic/secrets/security/detected-artifactory-password.yaml
+++ b/generic/secrets/security/detected-artifactory-password.yaml
@@ -23,8 +23,8 @@ rules:
           sha512...
       - pattern-not-inside: |
           -BEGIN ...-
-          ...
-          -END ...-
+          ....
+          ...-END ...-
       - metavariable-analysis:
           analyzer: entropy
           metavariable: $ITEM


### PR DESCRIPTION
`AKCxxxxxxxxxx` wasn't matching the password pattern. After changing it to `AP6xxxxxxxxxx`, we would get an undesirable match due to a non-matching pattern-not-inside. I fixed the pattern-not-inside.