### PR TITLE
Deprecate some more brakeman gem rules

### DIFF
--- a/ruby/lang/security/jruby-xml.rb
+++ b/ruby/lang/security/jruby-xml.rb
@@ -1,14 +1,11 @@
 include ActiveSupport
 
  def bad_xml
-     # ruleid: jruby-xml
      XmlMini.backend = 'JDOM'
 
-     # ruleid: jruby-xml
      XmlMini.backend = 'LibXMLSAX'
  end
 
  def ok_xml
-     # ok: jruby-xml
      XmlMini.backend = 'REXML'
  end

--- a/ruby/lang/security/jruby-xml.yaml
+++ b/ruby/lang/security/jruby-xml.yaml
@@ -1,16 +1,9 @@
 rules:
 - id: jruby-xml
   patterns:
-  - pattern: |
-      XmlMini.backend = $STR
-  - pattern-not: |
-      XmlMini.backend = "REXML"
-  message: >-
-    The JDOM backend for XmlMini has a vulnerability that lets an attacker perform
-    a denial of service attack
-    or gain access to files on the application server. This affects versions 3.0,
-    but is fixed in versions
-    3.1.12 and 3.2.13. To fix, either upgrade or use XmlMini.backend="REXML".
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   metadata:
     cwe:
     - 'CWE-611: Improper Restriction of XML External Entity Reference'

--- a/ruby/lang/security/json-encoding.rb
+++ b/ruby/lang/security/json-encoding.rb
@@ -1,11 +1,8 @@
  def bad_json_encoding
-     # ruleid: json-encoding
      params[:User].to_json
-     # ruleid: json-encoding
      JSON.encode(params[:User]).html_safe
  end
 
  def ok_xml
-     # ok: json-encoding
      "hello".to_json
  end

--- a/ruby/lang/security/json-encoding.yaml
+++ b/ruby/lang/security/json-encoding.yaml
@@ -1,11 +1,6 @@
 rules:
 - id: json-encoding
-  message: >-
-    When a 'Hash' with user-supplied input is encoded in JSON, Rails doesn't provide
-    adequate escaping.
-    If the JSON string is supplied into HTML, the page will be vulnerable to XXS attacks.
-    The affected Rails versions are 3.0.x, 3.1.x, 3.2.x, 4.1.x, 4.2.x.
-    To fix, either upgrade or add an initializer.
+  message: This rule is deprecated.
   metadata:
     cwe:
     - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
@@ -28,18 +23,6 @@ rules:
   languages:
   - ruby
   severity: WARNING
-  mode: taint
-  pattern-sources:
-  - patterns:
-    - pattern: |
-        params
-    - pattern-not: |
-        cookies
-  pattern-sinks:
-  - pattern-either:
-    - patterns:
-      - focus-metavariable: $X
-      - pattern: |
-          $X.to_json
-    - pattern: |
-        JSON.encode(...)
+  patterns:
+  - pattern: a()
+  - pattern: b()

--- a/ruby/lang/security/model-attributes-attr-protected.rb
+++ b/ruby/lang/security/model-attributes-attr-protected.rb
@@ -1,5 +1,4 @@
 class bad_use_attr_protected
-  # ruleid: model-attributes-attr-protected
   attr_protected :admin
 
   public :sanitize_for_mass_assignment
@@ -7,7 +6,6 @@ end
 
 class ok_use_attr_protected
   include ActiveModel::MassAssignmentSecurity
-  # ok: model-attributes-attr-protected
   attr_accessible :name, :email
   attr_accessible :name, :email, :admin, :as => :admin
 

--- a/ruby/lang/security/model-attributes-attr-protected.yaml
+++ b/ruby/lang/security/model-attributes-attr-protected.yaml
@@ -1,11 +1,6 @@
 rules:
 - id: model-attributes-attr-protected
-  message: >-
-    Checks for models that use attr_protected, as use of allowlist instead of denylist
-    is better practice.
-    Attr_protected was also found to be vulnerable to bypass. The fixed versions of
-    Rails are: 3.2.12, 3.1.11, 2.3.17.
-    To prevent bypass, use attr_accessible instead.
+  message: This rule is deprecated.
   metadata:
     cwe:
     - 'CWE-284: Improper Access Control'
@@ -26,4 +21,6 @@ rules:
   languages:
   - ruby
   severity: WARNING
-  pattern: attr_protected
+  patterns:
+  - pattern: a()
+  - pattern: b()

--- a/ruby/lang/security/nested-attributes.rb
+++ b/ruby/lang/security/nested-attributes.rb
@@ -2,7 +2,6 @@ class bad_use_nested_attrs
   has_one :author
   has_many :pages
 
-  # ruleid: nested-attributes
   accepts_nested_attributes_for :author, :pages
 end
 

--- a/ruby/lang/security/nested-attributes.yaml
+++ b/ruby/lang/security/nested-attributes.yaml
@@ -1,11 +1,6 @@
 rules:
 - id: nested-attributes
-  message: >-
-    Checks for models that enable nested attributes. A vulnerability in
-    nested_attributes_for results in an attacker begin able to change
-    parameters apart from the ones intended by the developer. Affected Rails
-    versions: 3.0.0, 2.3.9. Fix: don't use accepts_nested_attributes_for or
-    upgrade Rails version.
+  message: This rule is deprecated.
   metadata:
     cwe:
     - 'CWE-20: Improper Input Validation'
@@ -28,4 +23,5 @@ rules:
   - ruby
   severity: WARNING
   patterns:
-  - pattern: accepts_nested_attributes_for
+  - pattern: a()
+  - pattern: b()

--- a/ruby/lang/security/timing-attack.rb
+++ b/ruby/lang/security/timing-attack.rb
@@ -1,6 +1,4 @@
 class timing_attack
-  # ruleid: timing-attack
   http_basic_authenticate_with name: "Chris", password: "LimpBizkitRules420"
-  # ruleid: timing-attack
   http_basic_authenticate_with :name => ENV["NAME"], :password => ENV["PASSWORD"]
 end

--- a/ruby/lang/security/timing-attack.yaml
+++ b/ruby/lang/security/timing-attack.yaml
@@ -1,11 +1,6 @@
 rules:
 - id: timing-attack
-  message: >-
-    Checks for unsafe use of method http_basic_authenticate_with, which is vulnerable
-    to timing attacks as it
-    does not use constant-time checking when comparing passwords. Affected Rails versions
-    include:
-    5.0.0.beta1.1, 4.2.5.1, 4.1.14.1, 3.2.22.1. Avoid this function if possible.
+  message: This rule is deprecated.
   metadata:
     cwe:
     - 'CWE-208: Observable Timing Discrepancy'
@@ -23,4 +18,6 @@ rules:
   languages:
   - ruby
   severity: ERROR
-  pattern: http_basic_authenticate_with ...
+  patterns:
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/mail-to-erb.erb
+++ b/ruby/rails/security/audit/mail-to-erb.erb
@@ -1,11 +1,6 @@
-// ruleid: mail-to-erb
 <%= mail_to user.email, user.name, :encode => :javascript %>
-// ruleid: mail-to-erb
 <%= mail_to user.email, user.name, :encode => :javascript, :replace_at => :_at_ %>
-// ok: mail-to-erb
 <%= mail_to user.email, user.name, :encode => :hex %>
-// ok: mail-to-erb
 <%= mail_to escape_javascript(user.email),
 escape_javascript(user.name), :encode => :javascript %>
-// ok: mail-to-erb
 <%= mail_to "domain", "email", :encode => :javascript %>

--- a/ruby/rails/security/audit/mail-to-erb.yaml
+++ b/ruby/rails/security/audit/mail-to-erb.yaml
@@ -19,26 +19,9 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: LOW
-  message: >-
-    Detected use of mail_to helper used with the `:encode => :javascript option`. The attacker could specify
-    a malicious name or email value that could lead to a XSS attack. Instead, use `:encode => :hex` or
-    patch to Rails 3.0.4 or 2.3.11.
+  message: This rule is deprecated.
   languages: [generic]
   severity: WARNING
-  paths:
-    include:
-    - '*.erb'
   patterns:
-  - pattern-either:
-    - pattern: |
-        <%= mail_to ..., ..., :encode => :javascript %>
-    - pattern: |
-        <%= mail_to ..., ..., :encode => :javascript, ... %>
-  - pattern-not: |
-      <%= mail_to escape_javascript(...), escape_javascript(...), ... :encode => :javascript %>
-  - pattern-not: |
-      <%= mail_to escape_javascript(...), escape_javascript(...), ... :encode => :javascript, ... %>
-  - pattern-not: |
-      <%= mail_to "...", "...", ... :encode => :javascript %>
-  - pattern-not: |
-      <%= mail_to "...", "...", ... :encode => :javascript, ... %>
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/mail-to.rb
+++ b/ruby/rails/security/audit/mail-to.rb
@@ -1,24 +1,19 @@
 def bad1(email, domain)
-  # ruleid: mail-to
   mail_to domain, email, :encode => "javascript"
 end
 
 def bad2()
-  # ruleid: mail-to
   mail_to domain, "email", :replace_at => "_at_", encode: "javascript", :replace_dot => "_dot_", :class => "email"
 end
 
 def ok1()
-  # ok: mail-to
   mail_to "me@domain.com", "My email", :encode => "hex"
 end
 
 def ok2()
-  # ok: mail-to
   mail_to "me@domain.com", "My email", encode: "javascript"
 end
 
 def ok3()
-  # ok: mail-to
   mail_to escape_javascript("me@domain.com"), escape_javascript("My email"), :encode => "javascript"
 end

--- a/ruby/rails/security/audit/mail-to.yaml
+++ b/ruby/rails/security/audit/mail-to.yaml
@@ -19,16 +19,9 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: LOW
-  message: >-
-    Detected use of mail_to helper used with the `:encode => :javascript option`. The attacker could specify
-    a malicious name or email value that could lead to a XSS attack. Instead, use `:encode => :hex` or
-    patch to Rails 3.0.4 or 2.3.11.
+  message: This rule is deprecated.
   languages: [ruby]
   severity: WARNING
   patterns:
-  - pattern: |
-      mail_to ..., :encode => "javascript", ...
-  - pattern-not: |
-      mail_to escape_javascript(...), escape_javascript(...), ..., :encode => "javascript", ...
-  - pattern-not: |
-      mail_to "...", "...", ..., :encode => "javascript", ...
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/number-to-currency-erb.erb
+++ b/ruby/rails/security/audit/number-to-currency-erb.erb
@@ -1,11 +1,7 @@
-// ruleid: number-to-currency-erb
 <%= number_to_currency(1.02, unit: params[:currency]) %>
 
-// ruleid: number-to-currency-erb
 <%= number_to_currency(1.02, unit: params[:currency], separator: ",", delimiter: "") %>
 
-// ok: number-to-currency-erb
 <%= number_to_currency(1.02, unit: h(params[:currency])) %>
 
-// ok: number-to-currency-erb
 <%= number_to_currency(1.02, unit: h(params[:currency]), separator: ",", delimiter: "") %>

--- a/ruby/rails/security/audit/number-to-currency-erb.yaml
+++ b/ruby/rails/security/audit/number-to-currency-erb.yaml
@@ -19,25 +19,9 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: LOW
-  message: >-
-    Detected user input flowing into number_to_currency helper.
-    One of the parameters to the helper (unit) is not escaped correctly and could lead to XSS, which
-    in turn could lead to sensitive data being exfiltrated. Instead, sanitize
-    data with the 'html_escape' or 'h' function
-    before passing it into `number_to_currency`
-    or upgrade to Rails 4.0.2 or 3.2.16.
+  message: This rule is deprecated.
   languages: [generic]
   severity: WARNING
-  paths:
-    include:
-    - '*.erb'
   patterns:
-  - pattern-either:
-    - pattern: |
-        <%= ... number_to_currency(..., unit: params[:$UNIT], ...) ... %>
-    - pattern: |
-        <%= ... number_to_currency(..., unit: params[:$UNIT]) ... %>
-  - pattern-not: |
-      <%= ... number_to_currency(..., h(unit: params[:$UNIT]), ...) ... %>
-  - pattern-not: |
-      <%= ... number_to_currency(..., h(unit: params[:$UNIT])) ... %>
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/number-to-currency.rb
+++ b/ruby/rails/security/audit/number-to-currency.rb
@@ -1,17 +1,14 @@
 def bad1()
-  # ruleid: number-to-currency
   number_to_currency(1.02, unit: params[:currency])
 end
 
 def bad2()
   currency = params[:currency]
   currency = currency + "unit"
-  # ruleid: number-to-currency
   number_to_currency(1.02, unit: currency)
 end
 
 def ok1()
-  # ok: number-to-currency
   number_to_currency(1.03, unit: h(params[:currency]))
 end
 

--- a/ruby/rails/security/audit/number-to-currency.yaml
+++ b/ruby/rails/security/audit/number-to-currency.yaml
@@ -19,22 +19,9 @@ rules:
     likelihood: LOW
     impact: MEDIUM
     confidence: LOW
-  message: >-
-    Detected user input flowing into number_to_currency helper.
-    One of the parameters to the helper (unit) is not escaped correctly and could lead to XSS, which
-    in turn could lead to sensitive data being exfiltrated. Instead, sanitize
-    data before passing it into `number_to_currency` with the
-    html_escape (h) function
-    or upgrade to Rails 4.0.2 or 3.2.16.
+  message: This rule is deprecated.
   languages: [ruby]
   severity: WARNING
-  mode: taint
-  pattern-sources:
-  - pattern: params[$X]
-  pattern-sinks:
-  - patterns:
-    - pattern: $UNIT
-    - pattern-inside: |
-        number_to_currency(..., unit: $UNIT, ...)
-  pattern-sanitizers:
-  - pattern: h(...)
+  patterns:
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/quote-table-name.rb
+++ b/ruby/rails/security/audit/quote-table-name.rb
@@ -1,21 +1,17 @@
 def bad1()
-  # ruleid: quote-table-name
   quote_table_name(params[:table])
 end
 
 def bad2()
   table = params[:table]
-  # ruleid: quote-table-name
   quote_table_name(table)
 end
 
 def ok1()
-  # ok: quote-table-name
   quote_table_name("name")
 end
 
 def ok2()
   table = "table"
-  # ok: quote-table-name
   quote_table_name(table)
 end

--- a/ruby/rails/security/audit/quote-table-name.yaml
+++ b/ruby/rails/security/audit/quote-table-name.yaml
@@ -19,16 +19,9 @@ rules:
     likelihood: HIGH
     impact: MEDIUM
     confidence: LOW
-  message: >-
-    Detected usage of `quote_table_name`, which has a vulnerability
-    allowing malicious users to inject arbitrary SQL into a query.
-    This is fixed in Rails versions 3.0.10, 2.3.13, and 3.1.0.rc5 and above. If updating your Rails version
-    is not possible, sanitize input thoroughly before passing it to
-    a `quote_table_name` call.
+  message: This rule is deprecated.
   languages: [ruby]
   severity: WARNING
-  mode: taint
-  pattern-sources:
-  - pattern: params[$X]
-  pattern-sinks:
-  - pattern: quote_table_name(...)
+  patterns:
+  - pattern: a()
+  - pattern: b()

--- a/ruby/rails/security/audit/rails-check-header-dos.Gemfile
+++ b/ruby/rails/security/audit/rails-check-header-dos.Gemfile
@@ -1,38 +1,26 @@
 source 'https://rubygems.org'
 
-# ok: 
 gem 'rails', '5.2.4'
 
-# ok
 gem 'rails', '3.3.16'
 
-# ok
 gem 'rails', '3.2.16'
 
-# ok
 gem 'rails', '4.0.2'
 
-# ok
 gem 'rails', '4.1.0'
 
-# ok
 gem 'rails', '~> 3.2.15'
 
-# ok
 gem 'rails', '~> 3.0'
 
-# ruleid: rails-check-header-dos
 gem 'rails', '3.0.1'
 
-# ruleid: rails-check-header-dos
 gem 'rails', '3.2.15'
 
-# ruleid: rails-check-header-dos
 gem 'rails', '3.1.16'
 
-# ruleid: rails-check-header-dos
 gem 'rails', '4.0.0'
 
-# ruleid: rails-check-header-dos
 gem 'rails', '4.0.1'
 

--- a/ruby/rails/security/audit/rails-check-header-dos.yaml
+++ b/ruby/rails/security/audit/rails-check-header-dos.yaml
@@ -3,30 +3,9 @@ rules:
   languages:
   - generic
   patterns:
-  - pattern-either:
-    - patterns:
-      - pattern: gem 'rails', '3.$Y'
-      - metavariable-comparison:
-          metavariable: $Y
-          comparison: $Y <= 2
-    - patterns:
-      - pattern-either:
-        - pattern: gem 'rails', '3.0.$Z'
-        - pattern: gem 'rails', '3.1.$Z'
-    - patterns:
-      - pattern: gem 'rails', '3.2.$Z'
-      - metavariable-comparison:
-          metavariable: $Z
-          comparison: $Z < 16
-    - patterns:
-      - pattern: gem 'rails', '4.0.$Z'
-      - metavariable-comparison:
-          metavariable: $Z
-          comparison: $Z == 0 or $Z == 1
-  message: >-
-    Rails versions 3.0.0 - 3.2.15 and 4.0.0 and 4.0.1 are vulnerable to a
-    DoS attack (CVE-2013-6414). This can cause your service to be taken down for substantial amount of
-    time. Instead, upgrade to 4.0.2 or 3.2.16 or higher.
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   severity: WARNING
   metadata:
     technology:
@@ -46,8 +25,3 @@ rules:
     likelihood: LOW
     impact: HIGH
     confidence: LOW
-  paths:
-    include:
-    - '*Gemfile'
-    - gems.rb
-

--- a/ruby/rails/security/audit/rails-check-page-caching-gem.Gemfile
+++ b/ruby/rails/security/audit/rails-check-page-caching-gem.Gemfile
@@ -1,25 +1,17 @@
 source 'https://rubygems.org'
 
-# ok
 gem 'actionpack_page-caching', '1.2.1'
 
-# ok
 gem 'actionpack_page-caching', '2.0.0'
 
-# ok
 gem 'actionpack_page-caching', '~> 1.2'
 
-# ruleid: rails-check-page-caching-gem 
 gem 'actionpack_page-caching', '1.2.0'
 
-# ruleid: rails-check-page-caching-gem 
 gem 'actionpack_page-caching', '1.0.99'
 
-# ruleid: rails-check-page-caching-gem 
 gem 'actionpack_page-caching', '~> 0.99'
 
-# ruleid: rails-check-page-caching-gem 
 gem 'actionpack_page-caching', '~> 1.1'
 
-# ruleid: rails-check-page-caching-gem 
 gem 'actionpack_page-caching', '~> 1.1.2'

--- a/ruby/rails/security/audit/rails-check-page-caching-gem.yaml
+++ b/ruby/rails/security/audit/rails-check-page-caching-gem.yaml
@@ -1,42 +1,12 @@
 rules:
 - id: rails-check-page-caching-gem
-  pattern-either:
-  - patterns:
-    - pattern: gem 'actionpack_page-caching', '1.$MIN'
-    - metavariable-comparison:
-        metavariable: $MIN
-        comparison: $MIN <= 2
-  - patterns:
-    - pattern: gem 'actionpack_page-caching', '1.$MIN.$PATCH'
-    - metavariable-comparison:
-        metavariable: $MIN
-        comparison: $MIN < 2
-  - patterns:
-    - patterns:
-      - pattern: gem 'actionpack_page-caching', '1.2.$PATCH'
-      - metavariable-comparison:
-          metavariable: $PATCH
-          comparison: $PATCH < 1
-  - pattern-either:
-    - pattern: gem 'actionpack_page-caching', '~> 0.$MIN'
-    - pattern: gem 'actionpack_page-caching', '~> 0.$MIN.$PATCH'
-    - patterns:
-      - pattern-either:
-        - pattern: gem 'actionpack_page-caching', '~> 1.$MIN'
-        - pattern: gem 'actionpack_page-caching', '~> 1.$MIN.$PATCH'
-      - metavariable-comparison:
-          metavariable: $MIN
-          comparison: $MIN < 2
-  message: All versions below 1.2.1 of the 'actionpack_page-caching' gem are vulnerable to arbitrary file
-    write and remote code execution (CVE-2020-8159). Update to version 1.2.1 or greater or remove calls
-    to 'caches_page'.
+  patterns:
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   languages:
   - generic
   severity: WARNING
-  paths:
-    include:
-    - '*Gemfile'
-    - gems.rb
   metadata:
     cwe:
     - "CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')"

--- a/ruby/rails/security/audit/rails-check-render-dos-gem.Gemfile
+++ b/ruby/rails/security/audit/rails-check-render-dos-gem.Gemfile
@@ -1,29 +1,20 @@
 source 'https://rubygems.org'
 
-# ok
 gem 'rails', '3.2.17'
 
-# ok
 gem 'rails', '2.0.0'
 
-# ok
 gem 'rails', '~> 3.2'
 
-# ok
 gem 'rails', '3.0.30'
 
-# ruleid: rails-check-render-dos
 gem 'rails', '3.2.16'
 
-# ruleid: rails-check-render-dos
 gem 'rails', '3.1.5'
 
-# ruleid: rails-check-render-dos
 gem 'rails', '3.2.0'
 
-# ruleid: rails-check-render-dos
 gem 'rails', '3.1'
 
-# ruleid: rails-check-render-dos
 gem 'rails', '~> 3.1'
 

--- a/ruby/rails/security/audit/rails-check-render-dos-gem.yaml
+++ b/ruby/rails/security/audit/rails-check-render-dos-gem.yaml
@@ -1,43 +1,12 @@
 rules:
 - id: rails-check-render-dos
-  pattern-either:
-  - pattern-either:
-    - patterns:
-      - pattern: gem 'rails', '3.$VER'
-      - metavariable-comparison:
-          metavariable: $VER
-          comparison: $VER <= 2
-    - patterns:
-      - pattern: gem 'rails', '~> 3.$VER'
-      - metavariable-comparison:
-          metavariable: $VER
-          comparison: $VER < 2
-  - pattern-either:
-    - patterns:
-      - pattern: gem 'rails', '3.0.$PATCH'
-      - metavariable-comparison:
-          metavariable: $PATCH
-          comparison: $PATCH <= 20
-    - patterns:
-      - pattern: gem 'rails', '3.1.$PATCH'
-      - metavariable-comparison:
-          metavariable: $PATCH
-          comparison: $PATCH <= 12
-    - patterns:
-      - pattern: gem 'rails', '3.2.$PATCH'
-      - metavariable-comparison:
-          metavariable: $PATCH
-          comparison: $PATCH <= 16
-  message: Rails versions 3.0.0 - 3.0.20, 3.1.0 - 3.1.12, and 3.2.0 - 3.2.16 are vulnerable to a denial
-    of service attack (CVE-2014-0082), which could lead to service downtime. Upgrade to 3.2.17 or higher
-    instead.
+  patterns:
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   languages:
   - generic
   severity: WARNING
-  paths:
-    include:
-    - '*Gemfile'
-    - gems.rb
   metadata:
     cwe:
     - 'CWE-20: Improper Input Validation'

--- a/ruby/rails/security/audit/rails-check-response-splitting.Gemfile
+++ b/ruby/rails/security/audit/rails-check-response-splitting.Gemfile
@@ -1,14 +1,10 @@
 source 'https://rubygems.org'
 
-# ok
 gem 'rails', '2.3.15'
 
-# ok
 gem 'rails', '~> 2.3'
 
-# ruleid: rails-check-response-splitting
 gem 'rails', '2.3.0'
 
-# ruleid: rails-check-response-splitting
 gem 'rails', '~> 2.3.12'
 

--- a/ruby/rails/security/audit/rails-check-response-splitting.yaml
+++ b/ruby/rails/security/audit/rails-check-response-splitting.yaml
@@ -1,24 +1,12 @@
 rules:
 - id: rails-check-response-splitting
-  pattern-either:
-  - pattern-either:
-    - pattern: gem 'rails', '2.3'
-    - patterns:
-      - pattern-either:
-        - pattern: gem 'rails', '2.3.$PATCH'
-        - pattern: gem 'rails', '~> 2.3.$PATCH'
-      - metavariable-comparison:
-          metavariable: $PATCH
-          comparison: $PATCH < 14
-  message: Rails versions 2.3.14 are vulnerable to response splitting, allowing header injection (CVE-2011-3186).
-    Upgrade to 2.3.14 or greater.
+  patterns:
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   languages:
   - generic
   severity: WARNING
-  paths:
-    include:
-    - '*Gemfile'
-    - gems.rb
   metadata:
     cwe:
     - "CWE-94: Improper Control of Generation of Code ('Code Injection')"

--- a/ruby/rails/security/injection/rails-check-json-parsing-rce.Gemfile
+++ b/ruby/rails/security/injection/rails-check-json-parsing-rce.Gemfile
@@ -1,29 +1,20 @@
 source 'https://rubygems.org'
 
-# ok
 gem 'rails', '2.3.16'
 
-# ok
 gem 'rails', '3.0.20'
 
-# ok
 gem 'rails', '~> 2.3.15'
 
-# ruleid: rails-check-json-parsing-rce
 gem 'rails', '~> 0.99.99'
 
-# ruleid: rails-check-json-parsing-rce
 gem 'rails', '~> 2.2.99'
 
-# ruleid: rails-check-json-parsing-rce
 gem 'rails', '2.3.0'
 
-# ruleid: rails-check-json-parsing-rce
 gem 'rails', '~> 2.3.0'
 
-# ruleid: rails-check-json-parsing-rce
 gem 'rails', '3.0.15'
 
-# ruleid: rails-check-json-parsing-rce
 gem 'rails', '~> 3.0.15'
 

--- a/ruby/rails/security/injection/rails-check-json-parsing-rce.yaml
+++ b/ruby/rails/security/injection/rails-check-json-parsing-rce.yaml
@@ -1,56 +1,12 @@
 rules:
 - id: rails-check-json-parsing-rce
   patterns:
-  - pattern-either:
-    - patterns:
-      - pattern-either:
-        - pattern: gem 'rails', '$MAJ'
-        - pattern: gem 'rails', '$MAJ.$MIN'
-        - pattern: gem 'rails', '$MAJ.$MIN.$PATCH'
-        - pattern: gem 'rails', '~> $MAJ'
-        - pattern: gem 'rails', '~> $MAJ.$MIN'
-        - pattern: gem 'rails', '~> $MAJ.$MIN.$PATCH'
-      - metavariable-comparison:
-          metavariable: $MAJ
-          comparison: $MAJ < 2
-    - patterns:
-      - pattern-either:
-        - pattern: gem 'rails', '2.$MAJ'
-        - pattern: gem 'rails', '2.$MAJ.$PATCH'
-        - pattern: gem 'rails', '~> 2.$MAJ'
-        - pattern: gem 'rails', '~> 2.$MAJ.$PATCH'
-      - metavariable-comparison:
-          metavariable: $MAJ
-          comparison: $MAJ < 3
-    - patterns:
-      - pattern-either:
-        - pattern: gem 'rails', '2.3.$PATCH'
-        - pattern: gem 'rails', '~> 2.3.$PATCH'
-      - metavariable-comparison:
-          metavariable: $PATCH
-          comparison: $PATCH <= 14
-    - patterns:
-      - pattern-either:
-        - pattern: gem 'rails', '3.0.$PATCH'
-        - pattern: gem 'rails', '~> 3.0.$PATCH'
-      - metavariable-comparison:
-          metavariable: $PATCH
-          comparison: $PATCH <= 19
-  - pattern-not-inside: |
-      source '...'
-      ...
-      gem 'yajl' ...
-      ...
-  message: Rails versions 0.0.0 - 2.3.14 and 3.0.0 - 3.0.19 are vulnerable to a Remote Code Execution
-    attack via JSON parsing (CVE-2013-0333). Either use the 'yajl' gem or update to Rails 2.3.16 or greater
-    if using Rails 0.0.0 - 2.3.14 and Rails 3.0.20 or greater if using Rails 3.0.0 - 3.0.19
+  - pattern: a()
+  - pattern: b()
+  message: This rule is deprecated.
   languages:
   - generic
   severity: WARNING
-  paths:
-    include:
-    - '*Gemfile'
-    - gems.rb
   metadata:
     cwe:
     - "CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')"


### PR DESCRIPTION
Deprecate another set of Ruby rules which rely on specific gem versions. They have a high false-positive rate.