### PR TITLE
feat: metacheck for poorly indented rules

### DIFF
--- a/yaml/semgrep/key-indentation.test.yaml
+++ b/yaml/semgrep/key-indentation.test.yaml
@@ -10,6 +10,7 @@ rules:
       # ruleid: yaml-key-indentation-check 
       -pattern: |
         bar
+    patterns-again:
       # ok: yaml-key-indentation-check 
       - pattern: |
-        bar
+            bar

--- a/yaml/semgrep/key-indentation.test.yaml
+++ b/yaml/semgrep/key-indentation.test.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: yaml-key-indentation-check-example 
+    message: >-
+      There should be a finding here, because the YAML
+      fuses the hyphen and the key together! 
+    languages:
+      - js
+    severity: WARNING
+    patterns:
+      # ruleid: yaml-key-indentation-check 
+      -pattern: |
+        bar

--- a/yaml/semgrep/key-indentation.test.yaml
+++ b/yaml/semgrep/key-indentation.test.yaml
@@ -10,3 +10,6 @@ rules:
       # ruleid: yaml-key-indentation-check 
       -pattern: |
         bar
+      # ok: yaml-key-indentation-check 
+      - pattern: |
+        bar

--- a/yaml/semgrep/key-indentation.yaml
+++ b/yaml/semgrep/key-indentation.yaml
@@ -23,4 +23,4 @@ rules:
         - focus-metavariable: $KEY
         - metavariable-regex:
             metavariable: $KEY
-            regex: "^-(\w)$"
+            regex: "^-(\w*)$"

--- a/yaml/semgrep/key-indentation.yaml
+++ b/yaml/semgrep/key-indentation.yaml
@@ -23,4 +23,4 @@ rules:
         - focus-metavariable: $KEY
         - metavariable-regex:
             metavariable: $KEY
-            regex: "^-(.*)$"
+            regex: "^-(\\w)$"

--- a/yaml/semgrep/key-indentation.yaml
+++ b/yaml/semgrep/key-indentation.yaml
@@ -23,4 +23,4 @@ rules:
         - focus-metavariable: $KEY
         - metavariable-regex:
             metavariable: $KEY
-            regex: "^-(\\w)$"
+            regex: "^-(\w)$"

--- a/yaml/semgrep/key-indentation.yaml
+++ b/yaml/semgrep/key-indentation.yaml
@@ -1,0 +1,26 @@
+rules:
+  - id: yaml-key-indentation-check 
+    message: >-
+      It looks like you have an YAML indentation issue -- instead of writing `$KEY`, 
+      put a space between the hyphen and what comes after! Otherwise, it reads 
+      as a single string. 
+    languages:
+      - yaml
+    severity: WARNING
+    metadata:
+      references:
+        - https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository
+      category: correctness
+      technology:
+        - semgrep
+    pattern-either:
+      - patterns:
+        - pattern-inside: |
+            rules: ...
+        - pattern: |
+            $KEY: >-
+              $VALUE
+        - focus-metavariable: $KEY
+        - metavariable-regex:
+            metavariable: $KEY
+            regex: "^-(.*)$"

--- a/yaml/semgrep/key-indentation.yaml
+++ b/yaml/semgrep/key-indentation.yaml
@@ -1,9 +1,8 @@
 rules:
-  - id: yaml-key-indentation-check 
-    message: >-
-      It looks like you have an YAML indentation issue -- instead of writing `$KEY`, 
-      put a space between the hyphen and what comes after! Otherwise, it reads 
-      as a single string. 
+  - id: yaml-key-indentation-check
+    message: "It looks like you have an YAML indentation issue -- instead of writing
+      `$KEY`,  put a space between the hyphen and what comes after! Otherwise,
+      it reads  as a single string. "
     languages:
       - yaml
     severity: WARNING
@@ -15,12 +14,12 @@ rules:
         - semgrep
     pattern-either:
       - patterns:
-        - pattern-inside: |
-            rules: ...
-        - pattern: |
-            $KEY: >-
-              $VALUE
-        - focus-metavariable: $KEY
-        - metavariable-regex:
-            metavariable: $KEY
-            regex: "^-(\w*)$"
+          - pattern-inside: |
+              rules: ...
+          - pattern: |
+              $KEY: >-
+                $VALUE
+          - focus-metavariable: $KEY
+          - metavariable-regex:
+              metavariable: $KEY
+              regex: ^-(\w*)$


### PR DESCRIPTION
## What:
This PR adds in a metacheck which detects poorly indented YAML, such as
```
patterns:
  -pattern: |
    foo
```
Notably, this is an invalid Semgrep rule, because in YAML, this is actually interpreted as a map from the string `"-pattern"` to the string `"foo"`.

## Test plan:
Automated tests