### PR TITLE
Update r2c/Return to Corp to Semgrep

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at semgrep@semgrep.dev. All
+reported by contacting the project team at support@semgrep.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at semgrep@r2c.dev. All
+reported by contacting the project team at semgrep@semgrep.dev. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,5 +6,5 @@ See [Contributing to Semgrep rules](https://semgrep.dev/docs/contributing/contri
 
 We're happy to help!
 
-- Email us: [support@r2c.dev](mailto:support@r2c.dev)
-- [Join our Slack](https://r2c.dev/slack)
+- Email us: [support@semgrep.com](mailto:support@semgrep.com)
+- [Join our Slack](https://go.semgrep.dev/slack)

--- a/LICENSE
+++ b/LICENSE
@@ -8,4 +8,4 @@ For purposes of the foregoing, “Sell” means practicing any or all of the rig
 
 Software: semgrep-rules (https://github.com/returntocorp/semgrep-rules)
 License: LGPL 2.1 (GNU Lesser General Public License, Version 2.1)
-Licensor: Return To Corporation (https://r2c.dev)
+Licensor: Semgrep, Inc. (https://semgrep.dev)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # semgrep-rules
 
 [![powered by semgrep](https://img.shields.io/badge/powered%20by-semgrep-1B2F3D?labelColor=lightgrey&link=https://semgrep.live/&style=flat-square&logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAAA0AAAAOCAYAAAD0f5bSAAAABmJLR0QA/gD+AP+cH+QUAAAACXBIWXMAAA3XAAAN1wFCKJt4AAAAB3RJTUUH5AYMEy0l8dkqrQAAAvFJREFUKBUB5gIZ/QEAAP8BAAAAAAMG6AD9+hn/GzA//wD//wAAAAD+AAAAAgABAQDl0MEBAwbmAf36GQAAAAAAAQEC9QH//gv/Gi1GFQEC+OoAAAAAAAAAAAABAQAA//8AAAAAAAAAAAD//ggX5tO66gID9AEBFSRxAgYLzRQAAADpAAAAAP7+/gDl0cMPAAAA+wAAAPkbLz39AgICAAAAAAAAAAAs+vU12AEbLz4bAAAA5P8AAAAA//4A5NDDEwEBAO///wABAQEAAP//ABwcMD7hAQEBAAAAAAAAAAAaAgAAAOAAAAAAAQEBAOXRwxUAAADw//8AAgAAAAD//wAAAAAA5OXRwhcAAQEAAAAAAAAAAOICAAAABP3+/gDjzsAT//8A7gAAAAEAAAD+AAAA/wAAAAAAAAAA//8A7ePOwA/+/v4AAAAABAIAAAAAAAAAAAAAAO8AAAABAAAAAAAAAAIAAAABAAAAAAAAAAgAAAD/AAAA8wAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAA8AAAAEAAAA/gAAAP8AAAADAAAA/gAAAP8AAAAAAAAAAAAAAAACAAAAAAAAAAAAAAAAAAAA7wAAAPsAAAARAAAABAAAAP4AAAAAAAAAAgAAABYAAAAAAAAAAAIAAAD8AwICAB0yQP78/v4GAAAA/wAAAPAAAAD9AAAA/wAAAPr9//8aHTJA6AICAgAAAAD8AgAAADIAAAAAAP//AB4wPvgAAAARAQEA/gEBAP4BAQABAAAAGB0vPeIA//8AAAAAAAAAABAC+vUz1QAAAA8AAAAAAwMDABwwPu3//wAe//8AAv//ABAcMD7lAwMDAAAAAAAAAAAG+vU0+QEBAvUB//4L/xotRhUBAvjqAAAAAAAAAAAAAQEAAP//AAAAAAAAAAAA//4IF+bTuuoCA/QBAQAA/wEAAAAAAwboAP36Gf8bMD//AP//AAAAAP4AAAACAAEBAOXQwQEDBuYB/foZAAAAAAD4I6qbK3+1zQAAAABJRU5ErkJggg==)](https://semgrep.dev/)
-[![r2c community slack](https://img.shields.io/badge/slack-join-green?style=flat-square)](https://r2c.dev/slack)
+[![Semgrep community slack](https://img.shields.io/badge/slack-join-green?style=flat-square)](https://go.semgrep.dev/slack)
 
 | branch | using semgrep docker image | test status          |
 | ------------ | ------------------------ | -------------------- |
 | `develop` | `returntocorp/semgrep:develop`  | [![semgrep-rules-test-develop](https://github.com/returntocorp/semgrep-rules/workflows/semgrep-develop/badge.svg)](https://github.com/returntocorp/semgrep-rules/actions?query=workflow%3Asemgrep-develop+branch%3Adevelop) |
 
-Welcome! This repository is the standard library for [Semgrep](https://semgrep.dev/) rules. There are many more rules available in the [Semgrep Registry](https://semgrep.dev/explore) written by [r2c](https://r2c.dev/) and other contributors. The [Semgrep Registry](https://semgrep.dev/explore) includes rules from this repository and additional rules that are accessible with the Team or Enterprise tiers of [Semgrep App](https://semgrep.dev/pricing). If there is a specific rule you are looking for, see the [Semgrep registry search](https://semgrep.dev/r). To contribute, find details about contributing in the [Contributing to Semgrep rules](https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository/) documentation.
+Welcome! This repository is the standard library for [Semgrep](https://semgrep.dev/) rules. There are many more rules available in the [Semgrep Registry](https://semgrep.dev/explore) written by [Semgrep, Inc.](https://semgrep.dev/) and other contributors. The [Semgrep Registry](https://semgrep.dev/explore) includes rules from this repository and additional rules that are accessible within [Semgrep Cloud Platform](https://semgrep.dev/pricing). If there is a specific rule you are looking for, see the [Semgrep registry search](https://semgrep.dev/r). To contribute, find details about contributing in the [Contributing to Semgrep rules](https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository/) documentation.
 
 ## Using Semgrep rules repository
 
@@ -15,17 +15,17 @@ Run existing and custom Semgrep rules locally with the Semgrep command line inte
 
 ## Contributing
 
-We welcome Semgrep rule contributions directly to this repository! When you submit your contribution to the `semgrep-rules` repository we’ll ask you to make r2c a joint owner of your contributions. While you still own copyright rights to your rule, joint ownership allows r2c to license these contributions to other [Semgrep Registry](https://semgrep.dev/r) users pursuant to the LGPL 2.1 under the [Commons Clause](https://commonsclause.com/). See full [license details](https://github.com/returntocorp/semgrep-rules/blob/develop/LICENSE).
+We welcome Semgrep rule contributions directly to this repository! When you submit your contribution to the `semgrep-rules` repository we’ll ask you to make Semgrep, Inc. a joint owner of your contributions. While you still own copyright rights to your rule, joint ownership allows Semgrep, Inc. to license these contributions to other [Semgrep Registry](https://semgrep.dev/r) users pursuant to the LGPL 2.1 under the [Commons Clause](https://commonsclause.com/). See full [license details](https://github.com/returntocorp/semgrep-rules/blob/develop/LICENSE).
 
 Note: To contribute, review the **[Contributing to Semgrep rules](https://semgrep.dev/docs/contributing/contributing-to-semgrep-rules-repository/)** documentation.
 
-You can also contact us at support@r2c.dev to make Semgrep rule contributions. We will import your rules for everyone to use!
+You can also contact us at support@semgrep.com to make Semgrep rule contributions. We will import your rules for everyone to use!
 
 ## Additional information
 
 ### Help
 
-Join [Slack](https://r2c.dev/slack) for the fastest answers to your questions! Or contact the team at support@r2c.dev.
+Join [Slack](https://go.semgrep.dev/slack) for the fastest answers to your questions! Or contact the team at support@semgrep.com.
 
 ### GitHub action to run tests
 
@@ -34,4 +34,4 @@ If you fork this repository or create your own, you can add a special [semgrep
 
 ### Rulesets
 
-Rulesets are groups of rules organized by purpose, language, or framework sourced from the Semgrep Registry. If you want to modify existing rulesets or create your own, please contact us at support@r2c.dev.
+Rulesets are groups of rules organized by purpose, language, or framework sourced from the Semgrep Registry. If you want to modify existing rulesets or create your own, please contact us at support@semgrep.com.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,4 +6,4 @@ All rules on `develop` are supported.
 
 ## Reporting a Vulnerability
 
-Please email security@r2c.dev to make a vulnerability report
+Please email security@semgrep.com to make a vulnerability report

--- a/dockerfile/best-practice/missing-pip-no-cache-dir.dockerfile
+++ b/dockerfile/best-practice/missing-pip-no-cache-dir.dockerfile
@@ -47,7 +47,7 @@ ENV PIP_NO_CACHE_DIR=true
 RUN pip install MySQL_python
 
 FROM python:3.10.1-alpine3.15@sha256:dce56d40d885d2c8847aa2a278a29d50450c8e3d10f9d7ffeb2f38dcc1eb0ea4
-LABEL maintainer="support@r2c.dev"
+LABEL maintainer="support@semgrep.com"
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true PIP_NO_CACHE_DIR=true
 
 # ugly: circle CI requires valid git and ssh programs in the container

--- a/generic/ci/security/use-frozen-lockfile.yaml
+++ b/generic/ci/security/use-frozen-lockfile.yaml
@@ -95,7 +95,7 @@ rules:
         - javascript
         - typescript
       references:
-        - https://r2c.dev
+        - https://semgrep.dev
       subcategory:
         - audit
       likelihood: LOW
@@ -121,7 +121,7 @@ rules:
         - javascript
         - typescript
       references:
-        - https://r2c.dev
+        - https://semgrep.dev
       subcategory:
         - audit
       likelihood: LOW

--- a/generic/secrets/security/detected-jwt-token.yaml
+++ b/generic/secrets/security/detected-jwt-token.yaml
@@ -13,7 +13,7 @@ rules:
     - jwt
     confidence: LOW
     references:
-    - https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    - https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     cwe:
     - 'CWE-321: Use of Hard-coded Cryptographic Key'
     owasp:

--- a/go/jwt-go/security/audit/jwt-parse-unverified.yaml
+++ b/go/jwt-go/security/audit/jwt-parse-unverified.yaml
@@ -11,7 +11,7 @@ rules:
     - 'CWE-345: Insufficient Verification of Data Authenticity'
     owasp:
     - A08:2021 - Software and Data Integrity Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/go/jwt-go/security/jwt-none-alg.yaml
+++ b/go/jwt-go/security/jwt-none-alg.yaml
@@ -12,7 +12,7 @@ rules:
     owasp:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/java/java-jwt/security/audit/jwt-decode-without-verify.yaml
+++ b/java/java-jwt/security/audit/jwt-decode-without-verify.yaml
@@ -10,7 +10,7 @@ rules:
     - 'CWE-345: Insufficient Verification of Data Authenticity'
     owasp:
     - A08:2021 - Software and Data Integrity Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/java/java-jwt/security/jwt-none-alg.yaml
+++ b/java/java-jwt/security/jwt-none-alg.yaml
@@ -12,7 +12,7 @@ rules:
     owasp:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/java/jjwt/security/jwt-none-alg.yaml
+++ b/java/jjwt/security/jwt-none-alg.yaml
@@ -12,7 +12,7 @@ rules:
     owasp:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     asvs:
       section: 'V3: Session Management Verification Requirements'
       control_id: 3.5.3 Insecue Stateless Session Tokens

--- a/java/lang/security/audit/xss/no-direct-response-writer.yaml
+++ b/java/lang/security/audit/xss/no-direct-response-writer.yaml
@@ -27,7 +27,7 @@ rules:
       - java
       - servlets
     interfile: true
-    license: proprietary license - copyright © r2c
+    license: proprietary license - copyright © Semgrep, Inc.
   languages:
     - java
   mode: taint

--- a/javascript/jose/security/audit/jose-exposed-data.yaml
+++ b/javascript/jose/security/audit/jose-exposed-data.yaml
@@ -9,7 +9,7 @@ rules:
     - A04:2021 - Insecure Design
     cwe:
     - 'CWE-522: Insufficiently Protected Credentials'
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     asvs:
       section: 'V3: Session Management Verification Requirements'
       control_id: 3.5.2 Static API keys or secret

--- a/javascript/jose/security/jwt-none-alg.yaml
+++ b/javascript/jose/security/jwt-none-alg.yaml
@@ -12,7 +12,7 @@ rules:
     owasp:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     asvs:
       section: 'V3: Session Management Verification Requirements'
       control_id: 3.5.3 Insecue Stateless Session Tokens

--- a/javascript/jsonwebtoken/security/audit/jwt-decode-without-verify.yaml
+++ b/javascript/jsonwebtoken/security/audit/jwt-decode-without-verify.yaml
@@ -10,7 +10,7 @@ rules:
     - 'CWE-345: Insufficient Verification of Data Authenticity'
     owasp:
     - A08:2021 - Software and Data Integrity Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     asvs:
       section: 'V3: Session Management Verification Requirements'
       control_id: 3.5.3 Insecue Stateless Session Tokens

--- a/javascript/jsonwebtoken/security/audit/jwt-exposed-data.yaml
+++ b/javascript/jsonwebtoken/security/audit/jwt-exposed-data.yaml
@@ -9,7 +9,7 @@ rules:
     - A04:2021 - Insecure Design
     cwe:
     - 'CWE-522: Insufficiently Protected Credentials'
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     asvs:
       section: 'V3: Session Management Verification Requirements'
       control_id: 3.5.3 Insecue Stateless Session Tokens

--- a/javascript/jsonwebtoken/security/jwt-none-alg.yaml
+++ b/javascript/jsonwebtoken/security/jwt-none-alg.yaml
@@ -12,7 +12,7 @@ rules:
     owasp:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     asvs:
       section: 'V3: Session Management Verification Requirements'
       control_id: 3.5.3 Insecue Stateless Session Tokens

--- a/python/django/security/audit/custom-expression-as-sql.yaml
+++ b/python/django/security/audit/custom-expression-as-sql.yaml
@@ -13,7 +13,7 @@ rules:
     - A03:2021 - Injection
     references:
     - https://docs.djangoproject.com/en/3.0/ref/models/expressions/#django.db.models.Func.as_sql
-    - https://blog.r2c.dev/2020/preventing-sql-injection-a-django-authors-perspective/
+    - https://semgrep.dev/blog/2020/preventing-sql-injection-a-django-authors-perspective/
     category: security
     technology:
     - django

--- a/python/django/security/audit/extends-custom-expression.yaml
+++ b/python/django/security/audit/extends-custom-expression.yaml
@@ -15,7 +15,7 @@ rules:
     - A03:2021 - Injection
     references:
     - https://docs.djangoproject.com/en/3.0/ref/models/expressions/#avoiding-sql-injection
-    - https://blog.r2c.dev/2020/preventing-sql-injection-a-django-authors-perspective/
+    - https://semgrep.dev/blog/2020/preventing-sql-injection-a-django-authors-perspective/
     category: security
     technology:
     - django

--- a/python/django/security/audit/query-set-extra.yaml
+++ b/python/django/security/audit/query-set-extra.yaml
@@ -14,7 +14,7 @@ rules:
     - A03:2021 - Injection
     references:
     - https://docs.djangoproject.com/en/3.0/ref/models/querysets/#django.db.models.query.QuerySet.extra
-    - https://blog.r2c.dev/2020/preventing-sql-injection-a-django-authors-perspective/
+    - https://semgrep.dev/blog/2020/preventing-sql-injection-a-django-authors-perspective/
     category: security
     technology:
     - django

--- a/python/django/security/audit/raw-query.yaml
+++ b/python/django/security/audit/raw-query.yaml
@@ -13,7 +13,7 @@ rules:
     - A03:2021 - Injection
     references:
     - https://docs.djangoproject.com/en/3.0/ref/models/expressions/#raw-sql-expressions
-    - https://blog.r2c.dev/2020/preventing-sql-injection-a-django-authors-perspective/
+    - https://semgrep.dev/blog/2020/preventing-sql-injection-a-django-authors-perspective/
     category: security
     technology:
     - django

--- a/python/django/security/audit/secure-cookies.yaml
+++ b/python/django/security/audit/secure-cookies.yaml
@@ -44,7 +44,7 @@ rules:
       version: '4'
     references:
     - https://docs.djangoproject.com/en/3.0/ref/request-response/#django.http.HttpResponse.set_cookie
-    - https://blog.r2c.dev/2020/bento-check-keeping-cookies-safe-in-flask/
+    - https://semgrep.dev/blog/2020/bento-check-keeping-cookies-safe-in-flask/
     - https://bento.dev/checks/flask/secure-set-cookie/
     category: security
     technology:

--- a/python/flask/security/audit/secure-set-cookie.yaml
+++ b/python/flask/security/audit/secure-set-cookie.yaml
@@ -24,7 +24,7 @@ rules:
     owasp:
     - A05:2021 - Security Misconfiguration
     references:
-    - https://blog.r2c.dev/2020/bento-check-keeping-cookies-safe-in-flask/
+    - https://semgrep.dev/blog/2020/bento-check-keeping-cookies-safe-in-flask/
     - https://bento.dev/checks/flask/secure-set-cookie/
     - https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options
     category: security

--- a/python/flask/security/unescaped-template-extension.yaml
+++ b/python/flask/security/unescaped-template-extension.yaml
@@ -15,7 +15,7 @@ rules:
     source-rule-url: https://pypi.org/project/flake8-flask/
     references:
     - https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup
-    - https://blog.r2c.dev/2020/bento-check-unescaped-template-extensions-in-flask/
+    - https://semgrep.dev/blog/2020/bento-check-unescaped-template-extensions-in-flask/
     - https://bento.dev/checks/flask/unescaped-file-extension/
     category: security
     technology:

--- a/python/jwt/security/audit/jwt-exposed-data.yaml
+++ b/python/jwt/security/audit/jwt-exposed-data.yaml
@@ -10,7 +10,7 @@ rules:
     - A04:2021 - Insecure Design
     cwe:
     - 'CWE-522: Insufficiently Protected Credentials'
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/python/jwt/security/jwt-exposed-credentials.yaml
+++ b/python/jwt/security/jwt-exposed-credentials.yaml
@@ -8,7 +8,7 @@ rules:
     owasp:
     - A02:2017 - Broken Authentication
     - A04:2021 - Insecure Design
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     references:
     - https://cwe.mitre.org/data/definitions/522.html
     category: security

--- a/python/jwt/security/jwt-hardcode.yaml
+++ b/python/jwt/security/jwt-hardcode.yaml
@@ -12,7 +12,7 @@ rules:
     - A02:2017 - Broken Authentication
     - A04:2021 - Insecure Design
     references:
-    - https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    - https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/python/jwt/security/jwt-none-alg.yaml
+++ b/python/jwt/security/jwt-none-alg.yaml
@@ -12,7 +12,7 @@ rules:
     owasp:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/python/requests/security/no-auth-over-http.yaml
+++ b/python/requests/security/no-auth-over-http.yaml
@@ -17,7 +17,7 @@ rules:
     - A02:2021 - Cryptographic Failures
     source-rule-url: https://pypi.org/project/flake8-flask/
     references:
-    - https://blog.r2c.dev/2020/bento-check-no-auth-over-http/
+    - https://semgrep.dev/blog/2020/bento-check-no-auth-over-http/
     - https://bento.dev/checks/requests/no-auth-over-http/
     category: security
     technology:

--- a/ruby/jwt/security/audit/jwt-decode-without-verify.yaml
+++ b/ruby/jwt/security/audit/jwt-decode-without-verify.yaml
@@ -10,7 +10,7 @@ rules:
     - 'CWE-345: Insufficient Verification of Data Authenticity'
     owasp:
     - A08:2021 - Software and Data Integrity Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/ruby/jwt/security/audit/jwt-exposed-data.yaml
+++ b/ruby/jwt/security/audit/jwt-exposed-data.yaml
@@ -10,7 +10,7 @@ rules:
     - A04:2021 - Insecure Design
     cwe:
     - 'CWE-522: Insufficiently Protected Credentials'
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/ruby/jwt/security/jwt-exposed-credentials.yaml
+++ b/ruby/jwt/security/jwt-exposed-credentials.yaml
@@ -8,7 +8,7 @@ rules:
     owasp:
     - A02:2017 - Broken Authentication
     - A04:2021 - Insecure Design
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     references:
     - https://cwe.mitre.org/data/definitions/522.html
     category: security

--- a/ruby/jwt/security/jwt-hardcode.yaml
+++ b/ruby/jwt/security/jwt-hardcode.yaml
@@ -11,7 +11,7 @@ rules:
     owasp:
     - A02:2017 - Broken Authentication
     - A04:2021 - Insecure Design
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/ruby/jwt/security/jwt-none-alg.yaml
+++ b/ruby/jwt/security/jwt-none-alg.yaml
@@ -12,7 +12,7 @@ rules:
     owasp:
     - A03:2017 - Sensitive Data Exposure
     - A02:2021 - Cryptographic Failures
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     category: security
     technology:
     - jwt

--- a/scala/scala-jwt/security/jwt-hardcode.yaml
+++ b/scala/scala-jwt/security/jwt-hardcode.yaml
@@ -14,7 +14,7 @@ rules:
     owasp:
     - A02:2017 - Broken Authentication
     - A04:2021 - Insecure Design
-    source-rule-url: https://r2c.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
+    source-rule-url: https://semgrep.dev/blog/2020/hardcoded-secrets-unverified-tokens-and-other-common-jwt-mistakes/
     technology:
     - jwt
     confidence: HIGH

--- a/typescript/react/security/audit/react-router-redirect.yaml
+++ b/typescript/react/security/audit/react-router-redirect.yaml
@@ -15,7 +15,7 @@ rules:
     references:
     - https://v5.reactrouter.com/web/api/Redirect
     - https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
-    - https://r2c.dev
+    - https://semgrep.dev
     cwe2022-top25: true
     cwe2021-top25: true
     subcategory:

--- a/typescript/react/security/react-controlled-component-password.yaml
+++ b/typescript/react/security/react-controlled-component-password.yaml
@@ -13,7 +13,7 @@ rules:
     cwe:
     - "CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
     references:
-    - https://r2c.dev
+    - https://semgrep.dev
     cwe2022-top25: true
     cwe2021-top25: true
     subcategory:


### PR DESCRIPTION
Administrative update to align with company rename.

Generally (with a few exceptions):
https://r2c.dev/slack -> https://go.semgrep.dev/slack
https://r2c.dev -> https://semgrep.dev
@r2c.dev -> @semgrep.com
Return To Corporation -> Semgrep, Inc.
r2c -> Semgrep **or** Semgrep, Inc. as appropriate