### PR TITLE
fix: rule after matching fields with stmts

### DIFF
--- a/java/lang/security/audit/crypto/no-static-initialization-vector.java
+++ b/java/lang/security/audit/crypto/no-static-initialization-vector.java
@@ -17,6 +17,7 @@ public class StaticIV {
 
 // ruleid: no-static-initialization-vector
 public class StaticIV2 {
+    // ruleid: no-static-initialization-vector
     byte[] iv = {
         (byte) 0, (byte) 0, (byte) 0, (byte) 0,
         (byte) 0, (byte) 0, (byte) 0, (byte) 0,


### PR DESCRIPTION
After https://github.com/returntocorp/semgrep/pull/8052, this has the effect of making statements patterns work on sequences of fields (such as class bodies, etc). This has the consequence of adding this finding to one of our rules.

CI fails, but that's OK, it will succeed after it's merged.