### PR TITLE
Fix looppointer rule

### DIFF
--- a/go/lang/correctness/looppointer.go
+++ b/go/lang/correctness/looppointer.go
@@ -12,7 +12,7 @@ func() {
 func() {
     // ruleid:exported_loop_pointer
     for _, val := range values {
-        print_pointer(val)
+        print_pointer(&val)
     }
 }
 
@@ -27,4 +27,13 @@ func() {
             fmt.Println(&val)
         })
     }
+}
+
+func (){
+	input := []string{"a", "b", "c"}
+	output := []string{}
+    // ok:exported_loop_pointer
+	for _, val := range input {
+		output = append(output, val)
+	}
 }

--- a/go/lang/correctness/looppointer.yaml
+++ b/go/lang/correctness/looppointer.yaml
@@ -25,5 +25,5 @@ rules:
           }
       - pattern: |
           for _, $VALUE := range $SOURCE {
-            <... $ANYTHING(..., <... $VALUE ...>, ...) ...>
+            <... $ANYTHING(..., <... &$VALUE ...>, ...) ...>
           }


### PR DESCRIPTION
Fix missing pointers in go.lang.correctness.looppointer rule