### PR TITLE
fix: update regex capture groups

### DIFF
--- a/generic/secrets/gitleaks/generic-api-key.yaml
+++ b/generic/secrets/gitleaks/generic-api-key.yaml
@@ -43,11 +43,11 @@ rules:
         # :*(?!("|'))[0-9A-Za-z]+\.[0-9A-Za-z]+,  : 0123.0312abc, 
         # [A-Z]+_[A-Z]+_ VALUE_VALUE_
     - pattern-regex: (?i)(?-s)(?:key|api|token|secret|client|passwd|password|auth|access).(?:[0-9a-z\-_\t
-        .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:).(?:'|\"|@|\s|=|\x60){0,5}(?!([a-z]+\.[a-zA-Z]+)|.*(\d{4}-\d{2}-\d{2}|[a-z]+-[a-z]+.*)|:*(?!("|'))[0-9A-Za-z]+\.[0-9A-Za-z]+,|[A-Z]+_[A-Z]+_)([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)
+        .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:).(?:'|\"|@|\s|=|\x60){0,5}(?!([a-z]+\.[a-zA-Z]+)|.*(\d{4}-\d{2}-\d{2}|[a-z]+-[a-z]+.*)|:*(?!("|'))[0-9A-Za-z]+\.[0-9A-Za-z]+,|[A-Z]+_[A-Z]+_)(?P<CONTENT>[0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)
     - metavariable-analysis:
         analyzer: entropy
-        metavariable: $4
-    - focus-metavariable: $4
+        metavariable: $CONTENT
+    - focus-metavariable: $CONTENT
       # These remove test examples in addition to public keys, author= etc. 
     - pattern-not-regex: (?i)publickeytoken=.*
     - pattern-not-regex: (?i)(?:"|')pub

--- a/generic/secrets/security/detected-aws-session-token.yaml
+++ b/generic/secrets/security/detected-aws-session-token.yaml
@@ -1,11 +1,11 @@
 rules:
 - id: detected-aws-session-token
   patterns:
-    - pattern-regex: ((?i)AWS_SESSION_TOKEN)\s*(:|=>|=)\s*([A-Za-z0-9/+=]{16,})
+    - pattern-regex: ((?i)AWS_SESSION_TOKEN)\s*(:|=>|=)\s*(?P<TOKEN>[A-Za-z0-9/+=]{16,})
     - pattern-not-regex: (?i)example|sample|test|fake
     - metavariable-analysis:
         analyzer: entropy
-        metavariable: $3
+        metavariable: $TOKEN
   languages: [regex]
   message: AWS Session Token detected
   severity: ERROR


### PR DESCRIPTION
This PR updates some rules to use the named regex capture groups, instead of the to-be-deprecated numerical offsets.

See https://github.com/returntocorp/semgrep/pull/8115