### PR TITLE
chore: use deepok to mark lines as ok when run with the pro engine

### DIFF
--- a/java/spring/security/injection/tainted-sql-string.java
+++ b/java/spring/security/injection/tainted-sql-string.java
@@ -177,8 +177,7 @@ class Test {
   public ResultSet ok7(@RequestBody String name, Foo foo) {
         var v = foo.getBars(name).get(0).getX();
         String sql = "SELECT * FROM table WHERE name = ";
-        // ok in pro engine
-        // ruleid: tainted-sql-string
+        // ruleid: deepok: tainted-sql-string
         sql += v + ";";
         Connection conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password");
         Statement stmt = conn.createStatement();
@@ -213,8 +212,7 @@ class Test2 {
   public ResultSet ok8(@RequestBody String name, SiteModel sitemodel) {
         var v = sitemodel.getPrefixes(name).sites.ids.get(0);
         String sql = "SELECT * FROM table WHERE name = ";
-        // ok in pro-engine
-        // ruleid: tainted-sql-string
+        // ruleid: deepok: tainted-sql-string
         sql += v + ";";
         Connection conn = DriverManager.getConnection("jdbc:mysql://localhost:8080", "guest", "password");
         Statement stmt = conn.createStatement();


### PR DESCRIPTION
We have deepruleid to mark lines as matching only with the pro engine, but we didn't have anything to mark lines as ok only with the pro engine. deepok is intended for that.

This PR updates annotations to use deepok.