### PR TITLE
Deprecate Ruby YAML and MySQL rules

### DIFF
--- a/ruby/lang/security/yaml-parsing.rb
+++ b/ruby/lang/security/yaml-parsing.rb
@@ -1,9 +1,6 @@
 # cf. https://github.com/presidentbeef/brakeman/blob/v3.6.2/test/apps/rails_with_xss_plugin/config/initializers/yaml_parsing.rb
 
-# ruleid:yaml-parsing
 ActionController::Base.param_parsers[Mime::YAML] = :yaml
 
-# ok:yaml-parsing
 ActiveSupport::CoreExtensions::Hash::Conversions::XML_PARSING.delete('symbol')
-# ok:yaml-parsing
 ActiveSupport::CoreExtensions::Hash::Conversions::XML_PARSING.delete('yaml')

--- a/ruby/lang/security/yaml-parsing.yaml
+++ b/ruby/lang/security/yaml-parsing.yaml
@@ -1,16 +1,12 @@
 rules:
 - id: yaml-parsing
-  message: >-
-    Detected enabled YAML parsing. This is vulnerable to remote code execution in
-    Rails 2.x
-    versions up to 2.3.14. To fix, delete this line.
-  fix-regex:
-    regex: ActionController.*:yaml
-    replacement: ' '
+  message: This rule is deprecated.
   severity: WARNING
   languages:
   - ruby
-  pattern: ActionController::Base.param_parsers[Mime::YAML] = :yaml
+  patterns:
+  - pattern: a()
+  - pattern: b()
   metadata:
     cwe:
     - "CWE-94: Improper Control of Generation of Code ('Code Injection')"

--- a/ruby/rails/security/audit/dynamic-finders.rb
+++ b/ruby/rails/security/audit/dynamic-finders.rb
@@ -1,19 +1,15 @@
 def bad1
-  # ruleid: dynamic-finders
   User.find_by_token(params[:user][:token])
 end
 
 def bad2
-  # ruleid: dynamic-finders
   Record.find_by_password(params[:record][:password])
 end
 
 def ok1
-  # ok: dynamic-finders
   Record.find_by_name(params[:record][:password])
 end
 
 def ok2
-  # ok: dynamic-finders
   PostItemCategory.create!(item: Item.find_by(item_number: 633))
 end

--- a/ruby/rails/security/audit/dynamic-finders.yaml
+++ b/ruby/rails/security/audit/dynamic-finders.yaml
@@ -19,22 +19,9 @@ rules:
     likelihood: HIGH
     impact: MEDIUM
     confidence: LOW
-  message: >-
-    Discovered an application that uses MySQL and find_by_* dynamic finders on potentially sensitive
-    fields. There is a vulnerability in MySQL integer conversion, which could case "0" to match any string,
-    and could therefore lead to sensitive data being exposed. Instead, upgrade to Rails version 4.
+  message: This rule is deprecated.
   languages: [ruby]
   severity: WARNING
-  mode: taint
-  pattern-sources:
-  - pattern: params
-  - pattern: request.env
-  pattern-sinks:
-  - pattern: $X.find_by_token(...)
-  - pattern: $X.find_by_guid(...)
-  - pattern: $X.find_by_password(...)
-  - pattern: $X.find_by_api_key(...)
-  - pattern: $X.find_by_activation(...)
-  - pattern: $X.find_by_code(...)
-  - pattern: $X.find_by_private(...)
-  - pattern: $X.find_by_reset(...)
+  patterns:
+  - pattern: a()
+  - pattern: b()


### PR DESCRIPTION
Deprecate the `yaml-parsing` and `dynamic-finders` rules because they rely on a specific version of Rails.
