### PR TITLE
update yaml/github-actions/security/run-shell-injection to remove commit_hash from being reported as injectable.

### DIFF
--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -106,6 +106,11 @@ jobs:
         run: |
           AUTH_HEADER="Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}";
           HEADER="Accept: application/vnd.github.v3+json";
+          
+      - name: hash-is-ok
+        # ok: run-shell-injection
+        run: |
+          echo "${{ github.event.inputs.commit_hash }}"
 
       # cf. https://github.com/magma/magma/blob/5caf0cb5151a9b0dce05985e6cb2cdcf70b94af5/.github/workflows/unit-test-workflow.yml
       - name: Download and Extract Artifacts

--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -55,4 +55,6 @@ rules:
         - pattern: ${{ github.event.pull_request.head.repo.default_branch }}
         - pattern: ${{ github.head_ref }}
         - pattern: ${{ github.event.inputs ... }}
+      - pattern-not: 
+          pattern: ${{ github.event.inputs.commit_hash }}
   severity: ERROR


### PR DESCRIPTION
`github.event.inputs.commit_hash` might not be treated as injectable, since it's not user-controlled.
This PR removes this specific event from the list being reported as injectable, and adds a test case.