### PR TITLE
add missing $ in pattern for csharp-sqli

### DIFF
--- a/csharp/lang/security/sqli/csharp-sqli.yaml
+++ b/csharp/lang/security/sqli/csharp-sqli.yaml
@@ -32,7 +32,7 @@ rules:
     - pattern: |
         $S = String.Format(...);
         ...
-        $PATTERN $SQL = new PATTERN($S,...);
+        $PATTERN $SQL = new $PATTERN($S,...);
     - pattern: |
         $S = String.Concat(...);
         ...


### PR DESCRIPTION
There was a missing named placeholder ($PATTERN) annotation