### PR TITLE
Add another pattern in asyncpg-sqli ruleset

### DIFF
--- a/python/lang/security/audit/sqli/asyncpg-sqli.py
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.py
@@ -58,6 +58,12 @@ async def bad9(conn: Connection, user_input):
     conn.execute(
     "insert into %s values (%%s, %%s)" % ext.quote_ident(table_name),[10, 20])
 
+def bad10(conn: asyncpg.Connection):
+    async with conn.transaction():
+        sql_query = 'SELECT * FROM {}'.format(user_input)
+        # ruleid: asyncpg-sqli
+        cur = await conn.cursor(sql_query)
+
 def ok1(user_input):
     con = await asyncpg.connect(user='postgres')
     # ok: asyncpg-sqli

--- a/python/lang/security/audit/sqli/asyncpg-sqli.yaml
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.yaml
@@ -82,6 +82,9 @@ rules:
     - pattern-inside: |
         def $FUNCNAME(..., $CONN: Connection, ...):
             ...
+    - pattern-inside: |
+        def $FUNCNAME(..., $CONN: asyncpg.Connection, ...):
+            ...
   - pattern-not: $CONN.$METHOD(..., "..." + "...", ...)
   - pattern-not: $CONN.$METHOD(..., '...'.format(), ...)
   - pattern-not: $CONN.$METHOD(..., '...'%(), ...)


### PR DESCRIPTION
This PR adds another pattern in asyncpg-sqli ruleset to catch more bad code patterns.


### Before this PR

```
┌─────────────────┐
│ 9 Code Findings │
└─────────────────┘
                                   
    asyncpg-sqli.py 
       asyncpg-sqli                                                                         
          Detected string concatenation with a non-literal variable in a asyncpg Python SQL statement.
          This could lead to SQL injection if the variable is user-controlled and not properly        
          sanitized. In order to prevent SQL injection, use parameterized queries or prepared         
          statements instead. You can create parameterized queries like so: 'conn.fetch("SELECT $1    
          FROM table", value)'. You can also create prepared statements with 'Connection.prepare':    
          'stmt = conn.prepare("SELECT $1 FROM table"); await stmt.fetch(user_value)'                 
                                                                                                      
           10┆ values = await conn.fetch(query)
            ⋮┆----------------------------------------
           17┆ cur = await conn.cursor(sql_query)
            ⋮┆----------------------------------------
           23┆ await connection.execute(sql_query)
            ⋮┆----------------------------------------
           30┆ await pool.fetch(sql_query)
            ⋮┆----------------------------------------
           37┆ await con.execute("SELECT name FROM users WHERE age=" + req.FormValue("age"))
            ⋮┆----------------------------------------
           44┆ await con.execute('SELECT * FROM {}'.format(user_input))
            ⋮┆----------------------------------------
           50┆ conn.execute('SELECT * FROM %s'%(user_input))
            ⋮┆----------------------------------------
           54┆ conn.fetchrow(f'SELECT * FROM {user_input}')
            ⋮┆----------------------------------------
           58┆ conn.execute(
           59┆ "insert into %s values (%%s, %%s)" % ext.quote_ident(table_name),[10, 20])
```           
           
It does NOT detect the following SQLi problem (aka a false negative):

```python
def bad10(conn: asyncpg.Connection):
    async with conn.transaction():
        sql_query = 'SELECT * FROM {}'.format(user_input)
        # ruleid: asyncpg-sqli
        cur = await conn.cursor(sql_query)
```

### After this PR

```
┌──────────────────┐
│ 10 Code Findings │
└──────────────────┘
                                   
    asyncpg-sqli.py 
       asyncpg-sqli                                                                         
          Detected string concatenation with a non-literal variable in a asyncpg Python SQL statement.
          This could lead to SQL injection if the variable is user-controlled and not properly        
          sanitized. In order to prevent SQL injection, use parameterized queries or prepared         
          statements instead. You can create parameterized queries like so: 'conn.fetch("SELECT $1    
          FROM table", value)'. You can also create prepared statements with 'Connection.prepare':    
          'stmt = conn.prepare("SELECT $1 FROM table"); await stmt.fetch(user_value)'                 
                                                                                                      
           10┆ values = await conn.fetch(query)
            ⋮┆----------------------------------------
           17┆ cur = await conn.cursor(sql_query)
            ⋮┆----------------------------------------
           23┆ await connection.execute(sql_query)
            ⋮┆----------------------------------------
           30┆ await pool.fetch(sql_query)
            ⋮┆----------------------------------------
           37┆ await con.execute("SELECT name FROM users WHERE age=" + req.FormValue("age"))
            ⋮┆----------------------------------------
           44┆ await con.execute('SELECT * FROM {}'.format(user_input))
            ⋮┆----------------------------------------
           50┆ conn.execute('SELECT * FROM %s'%(user_input))
            ⋮┆----------------------------------------
           54┆ conn.fetchrow(f'SELECT * FROM {user_input}')
            ⋮┆----------------------------------------
           58┆ conn.execute(
           59┆ "insert into %s values (%%s, %%s)" % ext.quote_ident(table_name),[10, 20])
            ⋮┆----------------------------------------
           65┆ cur = await conn.cursor(sql_query)
```