### PR TITLE
Flag more code patterns in asyncpg-sqli ruleset

### DIFF
--- a/python/lang/security/audit/sqli/asyncpg-sqli.py
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.py
@@ -64,6 +64,11 @@ def bad10(conn: asyncpg.Connection):
         # ruleid: asyncpg-sqli
         cur = await conn.cursor(sql_query)
 
+def bad11(conn: asyncpg.Connection):
+    import common
+    # ruleid: asyncpg-sqli
+    cur = conn.fetch(common.bad_query_1.format(user_input))
+
 def ok1(user_input):
     con = await asyncpg.connect(user='postgres')
     # ok: asyncpg-sqli

--- a/python/lang/security/audit/sqli/asyncpg-sqli.yaml
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.yaml
@@ -63,6 +63,7 @@ rules:
           $QUERY = '...' % ()
           ...
     - pattern: $CONN.$METHOD(..., $X + $Y, ...)
+    - pattern: $CONN.$METHOD(..., $Y.format(...), ...)
     - pattern: $CONN.$METHOD(..., '...'.format(...), ...)
     - pattern: $CONN.$METHOD(..., '...' % (...), ...)
     - pattern: $CONN.$METHOD(..., f'...{$USERINPUT}...', ...)


### PR DESCRIPTION
Related: https://github.com/returntocorp/semgrep-rules/pull/3022.

This PR adds another pattern in asyncpg-sqli ruleset to catch more bad code patterns.


### Before this PR

```
$ semgrep --config asyncpg-sqli.yaml asyncpg-sqli.py
               
               
┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 1 file tracked by git with 1 Code rule:
  Scanning 1 file.
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00                                                                                                                        
                    
                    
┌──────────────────┐
│ 10 Code Findings │
└──────────────────┘
                                   
    asyncpg-sqli.py 
       asyncpg-sqli                                                                         
          Detected string concatenation with a non-literal variable in a asyncpg Python SQL statement.
          This could lead to SQL injection if the variable is user-controlled and not properly        
          sanitized. In order to prevent SQL injection, use parameterized queries or prepared         
          statements instead. You can create parameterized queries like so: 'conn.fetch("SELECT $1    
          FROM table", value)'. You can also create prepared statements with 'Connection.prepare':    
          'stmt = conn.prepare("SELECT $1 FROM table"); await stmt.fetch(user_value)'                 
                                                                                                      
           10┆ values = await conn.fetch(query)
            ⋮┆----------------------------------------
           17┆ cur = await conn.cursor(sql_query)
            ⋮┆----------------------------------------
           23┆ await connection.execute(sql_query)
            ⋮┆----------------------------------------
           30┆ await pool.fetch(sql_query)
            ⋮┆----------------------------------------
           37┆ await con.execute("SELECT name FROM users WHERE age=" + req.FormValue("age"))
            ⋮┆----------------------------------------
           44┆ await con.execute('SELECT * FROM {}'.format(user_input))
            ⋮┆----------------------------------------
           50┆ conn.execute('SELECT * FROM %s'%(user_input))
            ⋮┆----------------------------------------
           54┆ conn.fetchrow(f'SELECT * FROM {user_input}')
            ⋮┆----------------------------------------
           58┆ conn.execute(
           59┆ "insert into %s values (%%s, %%s)" % ext.quote_ident(table_name),[10, 20])
            ⋮┆----------------------------------------
           65┆ cur = await conn.cursor(sql_query)
```

Note: It does NOT detect the following (two) SQLi problems (aka false negatives):

```python
def bad11(conn: Connection):
    import common
    sql_query = common.bad_query_1.format(user_input)
    # ruleid: asyncpg-sqli
    cur = conn.fetch(sql_query)
    # ruleid: asyncpg-sqli
    cur = conn.fetch(common.bad_query_1.format(user_input))
```

### After this PR

```
$ semgrep --config asyncpg-sqli.yaml asyncpg-sqli.py
               
               
┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 1 file tracked by git with 1 Code rule:
  Scanning 1 file.
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00                                                                                                                        
                    
                    
┌──────────────────┐
│ 11 Code Findings │
└──────────────────┘
                                   
    asyncpg-sqli.py 
       asyncpg-sqli                                                                         
          Detected string concatenation with a non-literal variable in a asyncpg Python SQL statement.
          This could lead to SQL injection if the variable is user-controlled and not properly        
          sanitized. In order to prevent SQL injection, use parameterized queries or prepared         
          statements instead. You can create parameterized queries like so: 'conn.fetch("SELECT $1    
          FROM table", value)'. You can also create prepared statements with 'Connection.prepare':    
          'stmt = conn.prepare("SELECT $1 FROM table"); await stmt.fetch(user_value)'                 
                                                                                                      
           10┆ values = await conn.fetch(query)
            ⋮┆----------------------------------------
           17┆ cur = await conn.cursor(sql_query)
            ⋮┆----------------------------------------
           23┆ await connection.execute(sql_query)
            ⋮┆----------------------------------------
           30┆ await pool.fetch(sql_query)
            ⋮┆----------------------------------------
           37┆ await con.execute("SELECT name FROM users WHERE age=" + req.FormValue("age"))
            ⋮┆----------------------------------------
           44┆ await con.execute('SELECT * FROM {}'.format(user_input))
            ⋮┆----------------------------------------
           50┆ conn.execute('SELECT * FROM %s'%(user_input))
            ⋮┆----------------------------------------
           54┆ conn.fetchrow(f'SELECT * FROM {user_input}')
            ⋮┆----------------------------------------
           58┆ conn.execute(
           59┆ "insert into %s values (%%s, %%s)" % ext.quote_ident(table_name),[10, 20])
            ⋮┆----------------------------------------
           65┆ cur = await conn.cursor(sql_query)
            ⋮┆----------------------------------------
           73┆ cur = conn.fetch(common.bad_query_1.format(user_input))
```

While it catches one more problem, it fails to flag the following code construct:

```python
sql_query = common.bad_query_1.format(user_input)
# ruleid: asyncpg-sqli
cur = conn.fetch(sql_query)
```

It would be awesome to extend this PR to catch this problematic code block as well - thanks for the help.