### PR TITLE
Update Regex to detect secrets in Dockerfile

### DIFF
--- a/dockerfile/security/secret-in-build-arg.dockerfile
+++ b/dockerfile/security/secret-in-build-arg.dockerfile
@@ -27,6 +27,15 @@ ARG SECRET_KEY_BASE
 ARG SECRET_TOKEN
 
 # ruleid: secret-in-build-arg
+ARG AUTH_TOKEN="this-is-a-secret"
+
+# ruleid: secret-in-build-arg
+ARG SSH_PRIVATE_KEY
+
+# ruleid: secret-in-build-arg
+ARG CERT_PASSWORD
+
+# ruleid: secret-in-build-arg
 ARG DJANGO_SECRET_KEY
 
 # ruleid: secret-in-build-arg

--- a/dockerfile/security/secret-in-build-arg.yaml
+++ b/dockerfile/security/secret-in-build-arg.yaml
@@ -4,13 +4,13 @@ rules:
   - pattern: ARG $ARG
   - metavariable-regex:
       metavariable: $ARG
-      regex: (?i).*(password|secret|token)
+      regex: (?i).*(password|secret|token|key|cert|api|auth)
   message: >-
     Docker build time arguments are not suited for secrets, because the
     argument values are saved with the image. Running `docker image history` on the
     image will show information on how the image was built, including arguments. If
-    these contain secrets, anyone with access to the docker image can access those
-    secrets.
+    these contain plain text secrets, anyone with access to the docker image can access
+    those secrets and exploit them.
   metadata:
     category: security
     technology:
@@ -23,10 +23,10 @@ rules:
     - https://cwe.mitre.org/data/definitions/538.html
     - https://docs.docker.com/engine/reference/builder/#arg
     subcategory:
-    - audit
+      - audit
     likelihood: LOW
     impact: HIGH
     confidence: LOW
   languages:
-  - dockerfile
+    - dockerfile
   severity: WARNING

--- a/dockerfile/security/secret-in-build-arg.yaml
+++ b/dockerfile/security/secret-in-build-arg.yaml
@@ -1,7 +1,9 @@
 rules:
 - id: secret-in-build-arg
   patterns:
-  - pattern: ARG $ARG
+  - pattern-either:
+    - pattern: ARG $ARG
+    - pattern: ARG $ARG=...
   - metavariable-regex:
       metavariable: $ARG
       regex: (?i).*(password|secret|token|key|cert|api|auth)


### PR DESCRIPTION
- Updated regex to `regex: (?i).*(password|secret|token|key|cert|api|auth)` to detect secrets such as `auth_token`, `ssh_key`, `cert`, `api_key`, `api_token`, etc.
- Added examples to `dockerfile/security/secret-in-build-arg.dockerfile`.