### PR TITLE
Update reactjs.org reference links to react.dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-## plan to remove by Nov, 15th, 2022. Ask Drew for more questions or before making changes
-
-typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml @LewisArdern
-typescript/react/security/audit/react-missing-noreferrer.yaml @LewisArdern
-typescript/react/security/audit/react-unsanitized-method.yaml @LewisArdern
-typescript/react/security/audit/react-unsanitized-property.yaml @LewisArdern
-typescript/react/security/audit/react-http-leak.yaml @LewisArdern
-typescript/react/security/audit/react-href-var.yaml @LewisArdern
-typescript/react/security/react-insecure-request.yaml @LewisArdern

--- a/typescript/react/best-practice/react-find-dom.yaml
+++ b/typescript/react/best-practice/react-find-dom.yaml
@@ -9,7 +9,7 @@ rules:
       findDOMNode is an escape hatch used to access the underlying DOM node. In most cases, use of this escape hatch is discouraged because it pierces the component abstraction.
     metadata:
       references:
-        - https://reactjs.org/docs/react-dom.html#finddomnode
+        - https://react.dev/reference/react-dom/findDOMNode
         - https://github.com/yannickcr/eslint-plugin-react/issues/678#issue-165177220
       category: best-practice
       technology:

--- a/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
+++ b/typescript/react/security/audit/react-dangerouslysetinnerhtml.yaml
@@ -13,7 +13,7 @@ rules:
     - A07:2017 - Cross-Site Scripting (XSS)
     - A03:2021 - Injection
     references:
-    - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+    - https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html
     category: security
     confidence: MEDIUM
     technology:

--- a/typescript/react/security/audit/react-unsanitized-property.yaml
+++ b/typescript/react/security/audit/react-unsanitized-property.yaml
@@ -12,7 +12,7 @@ rules:
     - A07:2017 - Cross-Site Scripting (XSS)
     - A03:2021 - Injection
     references:
-    - https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml
+    - https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html
     category: security
     confidence: MEDIUM
     technology:


### PR DESCRIPTION
react.dev is the new site and reactjs.org is no longer being updated

Fixes https://github.com/returntocorp/semgrep/issues/8436