### PR TITLE
elixir: add atom exhausting rule

### DIFF
--- a/elixir/lang/correctness/atom-exhaustion.exs
+++ b/elixir/lang/correctness/atom-exhaustion.exs
@@ -1,0 +1,4 @@
+# ruleid: atom_exhaustion
+String.to_atom("dynamic")
+# ruleid: atom_exhaustion
+List.to_atom(~c"dynamic")

--- a/elixir/lang/correctness/atom-exhaustion.fixed.exs
+++ b/elixir/lang/correctness/atom-exhaustion.fixed.exs
@@ -1,0 +1,4 @@
+# ruleid: atom_exhaustion
+String.to_existing_atom("dynamic")
+# ruleid: atom_exhaustion
+List.to_existing_atom(~c"dynamic")

--- a/elixir/lang/correctness/atom-exhaustion.yaml
+++ b/elixir/lang/correctness/atom-exhaustion.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: atom_exhaustion
+    message: >-
+      Atom doesn't garbage by the Garbage Collector. Creating it dynamically with `String.to_atom/1` or `List.to_atom/1` can possible memory leaks if the input cannot control.
+    severity: ERROR
+    languages:
+      - elixir
+    patterns:
+      - pattern: $MODULE.to_atom($STRING)
+      - metavariable-regex:
+          metavariable: $MODULE
+          regex: ^(String|List)$
+    fix: $MODULE.to_existing_atom($STRING)
+    metadata:
+      references:
+        - https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/atom_exhaustion.html
+      category: correctness
+      technology:
+        - elixir

--- a/elixir/lang/correctness/atom-exhaustion.yaml
+++ b/elixir/lang/correctness/atom-exhaustion.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: atom_exhaustion
     message: >-
-      Atom doesn't garbage by the Garbage Collector. Creating it dynamically with `String.to_atom/1` or `List.to_atom/1` can possible memory leaks if the input cannot control.
+      Atom values are appended to a global table but never removed. If input is user-controlled, dynamic instantiations such as `String.to_atom` or `List.to_atom` can lead to possible memory leaks. Instead, use `String.to_existing_atom` or `List.to_existing_atom`.
     severity: ERROR
     languages:
       - elixir


### PR DESCRIPTION
Detect all Elixir `(String|List).to_atom/1` function calls and fix it with `(String|List).to_existing_atom/1`.