### PR TITLE
elixir: add deprecated Bitwise.^^^ rule

### DIFF
--- a/elixir/lang/best-practice/deprecated-bxor-operator.exs
+++ b/elixir/lang/best-practice/deprecated-bxor-operator.exs
@@ -1,0 +1,2 @@
+# ruleid: deprecated_bxor_operator
+1 ^^^ 0

--- a/elixir/lang/best-practice/deprecated-bxor-operator.fixed.exs
+++ b/elixir/lang/best-practice/deprecated-bxor-operator.fixed.exs
@@ -1,0 +1,2 @@
+# ruleid: deprecated_bxor_operator
+Bitwise.bxor(1, 0)

--- a/elixir/lang/best-practice/deprecated-bxor-operator.yaml
+++ b/elixir/lang/best-practice/deprecated-bxor-operator.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: deprecated_bxor_operator
+    message: >-
+      The bitwise operator (`^^^`) is already deprecated. Recommended to use `Bitwise.bxor/2` instead.
+    severity: WARNING
+    languages:
+      - elixir
+    pattern: $LEFT ^^^ $RIGHT
+    fix: Bitwise.bxor($LEFT, $RIGHT)
+    metadata:
+      references:
+        - https://github.com/elixir-lang/elixir/commit/c9a171da5b25e0eb5d1da3b04c622f8b79a8aff4
+      category: best-practice
+      technology:
+        - elixir


### PR DESCRIPTION
Rewrite `^^^` operator with `Bitwise.bxor/2`.