### PR TITLE
elixir: add deprecated Bitwise rules

### DIFF
--- a/elixir/lang/best-practice/deprecated-bnot-operator.exs
+++ b/elixir/lang/best-practice/deprecated-bnot-operator.exs
@@ -1,0 +1,5 @@
+# ruleid: deprecated_bnot_operator
+~~~2
+
+# ruleid: deprecated_bnot_operator
+~~~2 &&& 3

--- a/elixir/lang/best-practice/deprecated-bnot-operator.fixed.exs
+++ b/elixir/lang/best-practice/deprecated-bnot-operator.fixed.exs
@@ -1,0 +1,5 @@
+# ruleid: deprecated_bnot_operator
+Bitwise.bnot(2)
+
+# ruleid: deprecated_bnot_operator
+Bitwise.bnot(2) &&& 3

--- a/elixir/lang/best-practice/deprecated-bnot-operator.yaml
+++ b/elixir/lang/best-practice/deprecated-bnot-operator.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: deprecated_bnot_operator
     message: >-
-      The bitwise operator (`^^^`) is already deprecated. Recommended to use `Bitwise.bnot/2` instead.
+      The bitwise operator (`^^^`) is already deprecated. Please use `Bitwise.bnot($VAL)` instead.
     severity: WARNING
     languages:
       - elixir

--- a/elixir/lang/best-practice/deprecated-bnot-operator.yaml
+++ b/elixir/lang/best-practice/deprecated-bnot-operator.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: deprecated_bnot_operator
+    message: >-
+      The bitwise operator (`^^^`) is already deprecated. Recommended to use `Bitwise.bnot/2` instead.
+    severity: WARNING
+    languages:
+      - elixir
+    pattern: ~~~$VAL
+    fix: Bitwise.bnot($VAL)
+    metadata:
+      references:
+        - https://github.com/elixir-lang/elixir/commit/f1b9d3e818e5bebd44540f87be85979f24b9abfc
+      category: best-practice
+      technology:
+        - elixir

--- a/elixir/lang/best-practice/deprecated-bxor-operator.exs
+++ b/elixir/lang/best-practice/deprecated-bxor-operator.exs
@@ -1,0 +1,2 @@
+# ruleid: deprecated_bxor_operator
+1 ^^^ 0

--- a/elixir/lang/best-practice/deprecated-bxor-operator.fixed.exs
+++ b/elixir/lang/best-practice/deprecated-bxor-operator.fixed.exs
@@ -1,0 +1,2 @@
+# ruleid: deprecated_bxor_operator
+Bitwise.bxor(1, 0)

--- a/elixir/lang/best-practice/deprecated-bxor-operator.yaml
+++ b/elixir/lang/best-practice/deprecated-bxor-operator.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: deprecated_bxor_operator
     message: >-
-      The bitwise operator (`^^^`) is already deprecated. Recommended to use `Bitwise.bxor/2` instead.
+      The bitwise operator (`^^^`) is already deprecated. Please use `Bitwise.bxor($LEFT, $RIGHT)` instead.
     severity: WARNING
     languages:
       - elixir

--- a/elixir/lang/best-practice/deprecated-bxor-operator.yaml
+++ b/elixir/lang/best-practice/deprecated-bxor-operator.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: deprecated_bxor_operator
+    message: >-
+      The bitwise operator (`^^^`) is already deprecated. Recommended to use `Bitwise.bxor/2` instead.
+    severity: WARNING
+    languages:
+      - elixir
+    pattern: $LEFT ^^^ $RIGHT
+    fix: Bitwise.bxor($LEFT, $RIGHT)
+    metadata:
+      references:
+        - https://github.com/elixir-lang/elixir/commit/c9a171da5b25e0eb5d1da3b04c622f8b79a8aff4
+      category: best-practice
+      technology:
+        - elixir

--- a/elixir/lang/best-practice/deprecated-use-bitwise.exs
+++ b/elixir/lang/best-practice/deprecated-use-bitwise.exs
@@ -1,0 +1,2 @@
+# ruleid: deprecated_use_bitwise
+use Bitwise

--- a/elixir/lang/best-practice/deprecated-use-bitwise.fixed.exs
+++ b/elixir/lang/best-practice/deprecated-use-bitwise.fixed.exs
@@ -1,0 +1,2 @@
+# ruleid: deprecated_use_bitwise
+import Bitwise

--- a/elixir/lang/best-practice/deprecated-use-bitwise.yaml
+++ b/elixir/lang/best-practice/deprecated-use-bitwise.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: deprecated_use_bitwise
     message: >-
-      The `use Bitwise` is already deprecated. Recommended to use `import Bitwise` instead.
+      The syntax `use Bitwise` is already deprecated. Please use `import Bitwise` instead.
     severity: WARNING
     languages:
       - elixir

--- a/elixir/lang/best-practice/deprecated-use-bitwise.yaml
+++ b/elixir/lang/best-practice/deprecated-use-bitwise.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: deprecated_use_bitwise
+    message: >-
+      The `use Bitwise` is already deprecated. Recommended to use `import Bitwise` instead.
+    severity: WARNING
+    languages:
+      - elixir
+    pattern: use Bitwise
+    fix: import Bitwise
+    metadata:
+      references:
+        - https://github.com/elixir-lang/elixir/commit/f1b9d3e818e5bebd44540f87be85979f24b9abfc
+      category: best-practice
+      technology:
+        - elixir


### PR DESCRIPTION
Submit 3 `Bitwise` module rules:

1. Rewrite `Bitwise.^^^` into `Bitwise.bxor/2`.
2. Rewrite `Bitwise.~~~` into `Bitwise.bnot/1`.
3. Rewrite `use Bitwise` into `import Bitwise`.