### PR TITLE
opensearch-serverless-cmk

### DIFF
--- a/terraform/aws/security/aws-opensearchserverless-encrypted-with-cmk.tf
+++ b/terraform/aws/security/aws-opensearchserverless-encrypted-with-cmk.tf
@@ -1,0 +1,84 @@
+resource "aws_opensearchserverless_security_policy" "fail" {
+  name        = "fail"
+  type        = "encryption"
+  description = "encryption security policy for example-collection"
+  # ruleid: aws-opensearchserverless-encrypted-with-cmk
+  policy = jsonencode({
+    Rules = [
+      {
+        Resource = [
+          "collection/example-collection"
+        ],
+        ResourceType = "collection"
+      }
+    ],
+    AWSOwnedKey = true
+  })
+}
+
+resource "aws_opensearchserverless_security_policy" "fail_2_heredoc" {
+  name        = "fail_2_heredoc"
+  type        = "encryption"
+  description = "encryption security policy with heredoc"
+  # ruleid: aws-opensearchserverless-encrypted-with-cmk
+  policy = <<POLICY
+{
+   "Rules": [
+      {
+         "Resource": [
+            "collection/example-collection"
+         ],
+         "ResourceType": "collection"
+      }
+   ],
+   "AWSOwnedKey": true
+}
+POLICY
+}
+
+resource "aws_opensearchserverless_security_policy" "pass" {
+  name        = "pass"
+  type        = "encryption"
+  description = "encryption security policy using customer KMS key"
+  # ok: aws-opensearchserverless-encrypted-with-cmk
+  policy = jsonencode({
+    Rules = [
+      {
+        Resource = [
+          "collection/customer-managed-key-collection"
+        ],
+        ResourceType = "collection"
+      }
+    ],
+    AWSOwnedKey = false
+    KmsARN      = "arn:aws:kms:us-east-1:123456789012:key/93fd6da4-a317-4c17-bfe9-382b5d988b36"
+  })
+}
+
+# pass because this is a network policy and not encryption type policy
+resource "aws_opensearchserverless_security_policy" "pass2" {
+  name        = "pass2"
+  type        = "network"
+  description = "Public access"
+  # ok: aws-opensearchserverless-encrypted-with-cmk
+  policy = jsonencode([
+    {
+      Description = "Public access to collection and Dashboards endpoint for example collection",
+      Rules = [
+        {
+          ResourceType = "collection",
+          Resource = [
+            "collection/example-collection"
+          ]
+        },
+        {
+          ResourceType = "dashboard"
+          Resource = [
+            "collection/example-collection"
+          ]
+        }
+      ],
+      AllowFromPublic = true
+    }
+  ])
+}

--- a/terraform/aws/security/aws-opensearchserverless-encrypted-with-cmk.yaml
+++ b/terraform/aws/security/aws-opensearchserverless-encrypted-with-cmk.yaml
@@ -1,0 +1,45 @@
+rules:
+  - id: aws-opensearchserverless-encrypted-with-cmk
+    patterns:
+      - pattern-inside: |
+          resource "aws_opensearchserverless_security_policy" $ANYTHING {
+            ...
+            type =  "encryption"
+            ...
+          }
+      - pattern-either:
+          - patterns:
+              - pattern: policy = "$JSONPOLICY"
+              - metavariable-pattern:
+                  metavariable: $JSONPOLICY
+                  language: json
+                  pattern: |
+                    {..., "AWSOwnedKey":true, ... }
+          - patterns:
+              - pattern-inside: policy = jsonencode(...)
+              - pattern: |
+                  {..., AWSOwnedKey = true, ...}
+    message: Ensure opensearch serverless is encrypted at rest using AWS KMS (Key
+      Management Service)  CMK (Customer Managed Keys). CMKs give you control
+      over the encryption key in terms of access and rotation.
+    languages:
+      - terraform
+    severity: WARNING
+    metadata:
+      category: security
+      subcategory:
+        - vuln
+      cwe:
+        - "CWE-320: CWE CATEGORY: Key Management Errors"
+      confidence: LOW
+      likelihood: MEDIUM
+      impact: LOW
+      source_rule_url: https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-encryption.html#serverless-encryption-policies
+      references:
+        - https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-encryption.html#serverless-encryption-policies
+      technology:
+        - terraform
+        - aws
+      owasp:
+        - A2:2021 Cryptographic Failures
+        - A5:2021 Security Misconfiguration

--- a/terraform/aws/security/aws-opensearchserverless-encrypted-with-cmk.yaml
+++ b/terraform/aws/security/aws-opensearchserverless-encrypted-with-cmk.yaml
@@ -20,7 +20,7 @@ rules:
               - pattern: |
                   {..., AWSOwnedKey = true, ...}
     message: Ensure opensearch serverless is encrypted at rest using AWS KMS (Key
-      Management Service)  CMK (Customer Managed Keys). CMKs give you control
+      Management Service) CMK (Customer Managed Keys). CMKs give you control
       over the encryption key in terms of access and rotation.
     languages:
       - terraform


### PR DESCRIPTION
Determine if the [ terraform resource for AWS opensearch serverless security policy](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/serverless-encryption.html#serverless-encryption-policies) is using a CMK or not. 