### PR TITLE
update php.lang.security.injection.echoed-request.echoed-request rule

### DIFF
--- a/php/lang/security/injection/echoed-request.php
+++ b/php/lang/security/injection/echoed-request.php
@@ -24,6 +24,10 @@ function doSmth4() {
     echo "Hello ".htmlentities($_POST['name'])." !".$_POST['lastname'];
 }
 
+function doSmth5() {
+     // ruleid: echoed-request
+    echo "Hello ".trim($_POST['name']);
+}
 
 function doOK1() {
     // ok: echoed-request
@@ -37,12 +41,9 @@ function doOK2() {
 }
 
 function doOK3() {
-    $name = $_GET['name'];
-    if (str_contains($name, 'foobar')) {
-        $tpl = createSafeTemplate($name);
-        // ok: echoed-request
-        echo "Hello :".$tpl;
-    }
+    $safevar = "Hello ".htmlentities(trim($_GET['name']));
+    // ok: echoed-request
+    echo $safevar;
 }
 
 function doOK4() {
@@ -55,3 +56,17 @@ function doOK5() {
     // ok: echoed-request
     echo "Hello $safevar !";
 }
+
+function doOK6() {
+    $safevar = "Hello ".htmlentities($_GET['name']);
+    // ok: echoed-request
+    echo $safevar;
+}
+
+function doOK7() {
+    $safevar = "Hello ".htmlspecialchars($_GET['name']);
+    // ok: echoed-request
+    echo $safevar;
+}
+
+

--- a/php/lang/security/injection/echoed-request.yaml
+++ b/php/lang/security/injection/echoed-request.yaml
@@ -15,10 +15,8 @@ rules:
   pattern-sanitizers:
   - pattern: isset(...)
   - pattern: empty(...)
-  - pattern: $X = $ANYFUNC(...);
-  - patterns:
-    - pattern-inside: echo <... $ANYFUNC(...) ...>;
-    - pattern: $ANYFUNC(...)
+  - pattern: htmlentities(...)
+  - pattern: htmlspecialchars(...)
   metadata:
     technology:
     - php


### PR DESCRIPTION
With the current rule, the patterns as below are reported as bugs. I would like add two pattern-sanitizers `htmlentities(...)`  and `htmlspecialchars(...)` to ignore these patterns. 
```php
function doOK6() {
    $safevar = "Hello ".htmlentities($_GET['name']);
    // ok: echoed-request
    echo $safevar;
}

function doOK7() {
    $safevar = "Hello ".htmlspecialchars($_GET['name']);
    // ok: echoed-request
    echo $safevar;
}
```

And remove the following pattern-sanitizers
```yaml
- pattern: $X = $ANYFUNC(...);
- patterns:
  - pattern-inside: echo <... $ANYFUNC(...) ...>;
  - pattern: $ANYFUNC(...)
```

Because these patterns are not reported
```php
function doSmth5() {
     // ruleid: echoed-request
    echo "Hello ".trim($_POST['name']);
}
```


Playground: https://semgrep.dev/playground/s/DDlj