### PR TITLE
Used typed mvar for c# javascript deserializer

### DIFF
--- a/csharp/lang/security/insecure-deserialization/javascript-serializer.cs
+++ b/csharp/lang/security/insecure-deserialization/javascript-serializer.cs
@@ -11,6 +11,11 @@ namespace InsecureDeserialization
                 // ruleid: insecure-javascriptserializer-deserialization
                 var serializer = new JavaScriptSerializer(new SimpleTypeResolver());
                 serializer.DeserializeObject(json);
+
+                var resolver = new SimpleTypeResolver()
+                // ruleid: insecure-javascriptserializer-deserialization
+                var serializer2 = new JavaScriptSerializer(resolver);
+                serializer2.DeserializeObject(json);
             }
             catch (Exception e)
             {

--- a/csharp/lang/security/insecure-deserialization/javascript-serializer.yaml
+++ b/csharp/lang/security/insecure-deserialization/javascript-serializer.yaml
@@ -30,4 +30,4 @@ rules:
       using System.Web.Script.Serialization;
       ...
   - pattern: |
-      new JavaScriptSerializer(new SimpleTypeResolver());
+      new JavaScriptSerializer((SimpleTypeResolver $RESOLVER))


### PR DESCRIPTION
Use typed metavariable instead of simple hardcoded pattern.