### PR TITLE
Add TypeScript to the supported languages for a rule that listed only JS

### DIFF
--- a/typescript/react/best-practice/react-props-spreading.yaml
+++ b/typescript/react/best-practice/react-props-spreading.yaml
@@ -9,7 +9,9 @@ rules:
       The spread operator risks passing invalid HTML props to an HTML element,
       which can cause console warnings or worse, give malicious actors a way
       to inject unexpected attributes.
-  languages: [javascript]
+  languages:
+    - typescript
+    - javascript
   severity: WARNING
   metadata:
       source-rule-url: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md


### PR DESCRIPTION
supersedes https://github.com/returntocorp/semgrep-rules/pull/3131