### PR TITLE
Lower confidence for gcm-detection audit rule

### DIFF
--- a/java/lang/security/audit/crypto/gcm-detection.yaml
+++ b/java/lang/security/audit/crypto/gcm-detection.yaml
@@ -11,10 +11,10 @@ rules:
     owasp:
     - A02:2021 - Cryptographic Failures
     subcategory:
-    - vuln
+    - audit
     likelihood: MEDIUM
     impact: MEDIUM
-    confidence: HIGH
+    confidence: LOW
   languages:
   - java
   message: >-


### PR DESCRIPTION
This rule is an audit rule and reporting findings that are supposed to manually reviewed to exclude IV reuse.