### PR TITLE
Proposed change to missing-or-broken-authorization csharp rule

### DIFF
--- a/csharp/dotnet/security/audit/missing-or-broken-authorization.cs
+++ b/csharp/dotnet/security/audit/missing-or-broken-authorization.cs
@@ -1,6 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 
 // ruleid: missing-or-broken-authorization
+public class AtLeast21Controller : Controller
+{
+    public IActionResult Index() => View();
+}
+
+// ok: missing-or-broken-authorization
 [AllowAnonymous]
 public class AtLeast21Controller : Controller
 {

--- a/csharp/dotnet/security/audit/missing-or-broken-authorization.yaml
+++ b/csharp/dotnet/security/audit/missing-or-broken-authorization.yaml
@@ -15,6 +15,7 @@ rules:
     - 'CWE-862: Missing Authorization'
     cwe2021-top25: true
     cwe2022-top25: true
+    cwe2023-top35: true
     owasp:
     - A01:2021 - Broken Access Control
     references:
@@ -30,13 +31,17 @@ rules:
   - csharp
   patterns:
   - pattern: |
-      [AllowAnonymous]
       public class $CLASS : Controller {
         ...
       }
   - pattern-inside: |
       using Microsoft.AspNetCore.Mvc;
       ...
+  - pattern-not: |
+      [AllowAnonymous]
+      public class $CLASS : Controller {
+        ...
+      }
   - pattern-not: |
       [Authorize]
       public class $CLASS : Controller {

--- a/csharp/dotnet/security/audit/missing-or-broken-authorization.yaml
+++ b/csharp/dotnet/security/audit/missing-or-broken-authorization.yaml
@@ -15,7 +15,7 @@ rules:
     - 'CWE-862: Missing Authorization'
     cwe2021-top25: true
     cwe2022-top25: true
-    cwe2023-top35: true
+    cwe2023-top25: true
     owasp:
     - A01:2021 - Broken Access Control
     references:


### PR DESCRIPTION
This is a proposed change to the missing-or-broken-authorization rule which takes into consideration that the default setting of .NET is to allow anonymous, and that explicitly adding [AllowAnonymous] is a design choice.

Please advise if this is appropriate or if I'm missing something simple with the original rule,