### PR TITLE
fix: update tests for locationally aware bindings

### DIFF
--- a/csharp/lang/security/missing-hsts-header.cs
+++ b/csharp/lang/security/missing-hsts-header.cs
@@ -7,14 +7,22 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
     }
     else
     {
+        // ruleid: missing-hsts-header
         app.UseExceptionHandler("/Error");
     }
-    app.UseHttpsRedirection();    
+    // ruleid: missing-hsts-header
+    app.UseHttpsRedirection();
+    // ruleid: missing-hsts-header
     app.UseStaticFiles();
+    // ruleid: missing-hsts-header
     app.UseRouting();
+    // ruleid: missing-hsts-header
     app.UseAuthentication();
+    // ruleid: missing-hsts-header
     app.UseAuthorization();
+    // ruleid: missing-hsts-header
     app.UseSession();
+    // ruleid: missing-hsts-header
     app.UseEndpoints(endpoints =>
     {
         endpoints.MapRazorPages();
@@ -37,7 +45,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         app.UseHsts();
     }
 
-    app.UseHttpsRedirection();        
+    app.UseHttpsRedirection();
     app.UseStaticFiles();
 
     app.UseRouting();

--- a/python/lang/maintainability/useless-literal.py
+++ b/python/lang/maintainability/useless-literal.py
@@ -11,6 +11,7 @@ d = dict(
 # ruleid: useless-literal
 d = {1: "a", 2: "b", 1: "a"}
 d = {
+    # ruleid: useless-literal
     1: "a",
     2: "b",
     # ruleid: useless-literal


### PR DESCRIPTION
This just updates the test to go with the PR https://github.com/semgrep/semgrep/pull/9137, which changes match deduplication to no longer ignore location of metavariable bindings.