### PR TITLE
Add reference to event-binding-payload-with-hyphen rule

### DIFF
--- a/yaml/argo/correctness/event-binding-payload-with-hyphen.yaml
+++ b/yaml/argo/correctness/event-binding-payload-with-hyphen.yaml
@@ -5,6 +5,8 @@ rules:
   message: The parameter `$VALUE` to this WorkflowEventBinding includes hyphens, which will, very confusingly, throw an error when Argo Workflows tries to invoke the workflow. Set the payload value to use underscores instead.
   metadata:
     category: correctness
+    references:
+      - https://argoproj.github.io/argo-workflows/variables/#expression
     technology:
     - argo
     - argo-workflows


### PR DESCRIPTION
This rule was added in #3208 but was missing a reference. CI didn't catch the error because the `Validate metadata` workflow was not running correctly when the PR was merged.