### PR TITLE
Update django-no-csrf-token rule

### DIFF
--- a/python/django/security/django-no-csrf-token.html
+++ b/python/django/security/django-no-csrf-token.html
@@ -13,9 +13,45 @@
 <div class="container">
   <div class="row">
       <div class="col-6">
+<!-- ruleid: django-no-csrf-token -->
+          <form method='POST'>
+              <input type="text" name="some_field">Some Field</input>
+              <input type="submit" name="submit">Submit</input>
+          </form>
+      </div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row">
+      <div class="col-6">
           <form method="post">
 <!-- ok: django-no-csrf-token -->
             {% csrf_token %}
+              <input type="text" name="some_field">Some Field</input>
+              <input type="submit" name="submit">Submit</input>
+          </form>
+      </div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row">
+      <div class="col-6">
+<!-- ok: django-no-csrf-token -->
+          <form>
+              <input type="text" name="some_field">Some Field</input>
+              <input type="submit" name="submit">Submit</input>
+          </form>
+      </div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row">
+      <div class="col-6">
+<!-- ok: django-no-csrf-token -->
+          <form method="GET">
               <input type="text" name="some_field">Some Field</input>
               <input type="submit" name="submit">Submit</input>
           </form>

--- a/python/django/security/django-no-csrf-token.yaml
+++ b/python/django/security/django-no-csrf-token.yaml
@@ -2,6 +2,16 @@ rules:
   - id: django-no-csrf-token
     patterns:
       - pattern: "<form...>...</form>"
+      - pattern-either:
+          - pattern: |
+              <form ... method="$METHOD" ...>...</form>
+          - pattern: |
+              <form ... method='$METHOD' ...>...</form>
+          - pattern: |
+              <form ... method=$METHOD ...>...</form>
+      - metavariable-regex:
+          metavariable: $METHOD
+          regex: (?i)post
       - pattern-not-inside: "<form...>...{% csrf_token %}...</form>"
     message: Manually-created forms in django templates should specify a csrf_token to prevent CSRF attacks
     languages: [generic]


### PR DESCRIPTION
Mitigate FPs for cases when GET method is used (GET is also a default method for forms)