### PR TITLE
Remove incorrect fix for cookie-issecure-false.yaml

### DIFF
--- a/java/servlets/security/cookie-issecure-false.yaml
+++ b/java/servlets/security/cookie-issecure-false.yaml
@@ -10,9 +10,6 @@ rules:
   message: >-
     Default session middleware settings: `setSecure` not set to true.
     This ensures that the cookie is sent only over HTTPS to prevent cross-site scripting attacks.
-  fix-regex:
-    regex: setSecure\(false\)
-    replacement: setSecure(true)
   metadata:
     vulnerability: Insecure Transport
     owasp:


### PR DESCRIPTION
This fix is seemingly copied from another rule. This rule checks for missing `setSecure(true)`, but the fix replaces a `setSecure(false)` with a `setSecure(true)`.

For a good autofix, this rule needs to be split into two rules:
- One for a missing `setSecure` call, that adds one with the right arguments
- One for a `setSecure` call with `false` that needs to be replaced with `true`.

Neither will need `fix-regex`, but can be fixed with a regular `fix`.