### PR TITLE
Update `django-no-csrf-token` rule

### DIFF
--- a/python/django/security/django-no-csrf-token.html
+++ b/python/django/security/django-no-csrf-token.html
@@ -25,7 +25,32 @@
 <div class="container">
   <div class="row">
       <div class="col-6">
+<!-- ruleid: django-no-csrf-token -->
+          <form method='PUT'>
+              <input type="text" name="some_field">Some Field</input>
+              <input type="submit" name="submit">Submit</input>
+          </form>
+      </div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row">
+      <div class="col-6">
           <form method="post">
+<!-- ok: django-no-csrf-token -->
+            {% csrf_token %}
+              <input type="text" name="some_field">Some Field</input>
+              <input type="submit" name="submit">Submit</input>
+          </form>
+      </div>
+  </div>
+</div>
+
+<div class="container">
+  <div class="row">
+      <div class="col-6">
+          <form method="delete">
 <!-- ok: django-no-csrf-token -->
             {% csrf_token %}
               <input type="text" name="some_field">Some Field</input>

--- a/python/django/security/django-no-csrf-token.yaml
+++ b/python/django/security/django-no-csrf-token.yaml
@@ -11,7 +11,7 @@ rules:
               <form ... method=$METHOD ...>...</form>
       - metavariable-regex:
           metavariable: $METHOD
-          regex: (?i)post
+          regex: (?i)(post|put|delete|patch)
       - pattern-not-inside: "<form...>...{% csrf_token %}...</form>"
     message: Manually-created forms in django templates should specify a csrf_token to prevent CSRF attacks
     languages: [generic]


### PR DESCRIPTION
Small update for `django-no-csrf-token` rule, to make it more accurate