### PR TITLE
Update disallow-old-tls-versions1.yaml

### DIFF
--- a/problem-based-packs/insecure-transport/java-stdlib/disallow-old-tls-versions1.java
+++ b/problem-based-packs/insecure-transport/java-stdlib/disallow-old-tls-versions1.java
@@ -53,4 +53,17 @@ class Ok {
                 null,
                 SSLConnectionSocketFactory.BROWSER_COMPATIBLE_HOSTNAME_VERIFIER);
     }
+
+    public void ok_disable_old_tls4() {
+            TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
+			SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
+            //ok: disallow-old-tls-versions1
+			SSLConnectionSocketFactory csf = new SSLConnectionSocketFactory(sslContext);
+			TlsConfig tlsConfig = TlsConfig.custom().setHandshakeTimeout(Timeout.ofSeconds(30)).setSupportedProtocols(TLS.V_1_3).build();
+			HttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create().setSSLSocketFactory(csf).setDefaultTlsConfig(tlsConfig).build();
+			CloseableHttpClient httpClient = HttpClients.custom().setConnectionManager(cm).build();
+			HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+			requestFactory.setHttpClient(httpClient);
+			restTemplate = new RestTemplate(requestFactory);
+    }
 }

--- a/problem-based-packs/insecure-transport/java-stdlib/disallow-old-tls-versions1.yaml
+++ b/problem-based-packs/insecure-transport/java-stdlib/disallow-old-tls-versions1.yaml
@@ -33,3 +33,17 @@ rules:
       new SSLConnectionSocketFactory(..., new String[] {"TLSv1.3"}, ...);
   - pattern-not: |
       new SSLConnectionSocketFactory(..., new String[] {"TLSv1.2"}, ...);
+  - pattern-not-inside: >
+      (SSLConnectionSocketFactory $SF) = new
+      SSLConnectionSocketFactory(...);
+      ...
+      (TlsConfig $TLSCONFIG) = TlsConfig.custom(). ... .setSupportedProtocols(TLS.V_1_2). ... .build();
+      ...
+      HttpClientConnectionManager cm = $CM.create(). ... .setSSLSocketFactory($SF). ... .setDefaultTlsConfig($TLSCONFIG). ... .build();
+  - pattern-not-inside: >
+      (SSLConnectionSocketFactory $SF) = new
+      SSLConnectionSocketFactory(...);
+      ...
+      (TlsConfig $TLSCONFIG) = TlsConfig.custom(). ... .setSupportedProtocols(TLS.V_1_3). ... .build();
+      ...
+      HttpClientConnectionManager cm = $CM.create(). ... .setSSLSocketFactory($SF). ... .setDefaultTlsConfig($TLSCONFIG). ... .build();


### PR DESCRIPTION
Reduce FPs by handling the case where the tls configuration is set using a connection manager and a custom TlsConfig instance.