### PR TITLE
update to rails unsafe reflection methods

### DIFF
--- a/ruby/rails/security/brakeman/check-unsafe-reflection-methods.rb
+++ b/ruby/rails/security/brakeman/check-unsafe-reflection-methods.rb
@@ -8,6 +8,11 @@ class GroupsController < ApplicationController
     # ruleid: check-unsafe-reflection-methods
     Kernel.tap(&params[:method].to_sym)
     User.method("#{User.first.some_method_thing}_stuff")
+    user_input_value = params[:my_user_input]
+    # ruleid: check-unsafe-reflection-methods
+    anything.tap(&user_input_value.to_sym)
+    # ruleid: check-unsafe-reflection-methods
+    anything_else.tap { |thing| thing + user_input_value() }
   end
 
   def dynamic_method_invocations_ok
@@ -17,6 +22,9 @@ class GroupsController < ApplicationController
     SomeClass.method("some_method").("some_argument")
     # ok: check-unsafe-reflection-methods
     Kernel.tap("SomeClass".to_sym)
+    user_input_value = params[:my_user_input]
+    # ok: check-unsafe-reflection-methods
+    user_input_value.tap("some_method")
   end
 
 end

--- a/ruby/rails/security/brakeman/check-unsafe-reflection-methods.yaml
+++ b/ruby/rails/security/brakeman/check-unsafe-reflection-methods.yaml
@@ -22,9 +22,11 @@ rules:
       - pattern-inside: |
           $X. ... .to_proc
       - pattern-inside: |
-          $Y.method(...)
+          $Y.method(<... $X ...>)
       - pattern-inside: |
-          $Y.tap(...)
+          $Y.tap(<... $X ...>)
+      - pattern-inside: |
+          $Y.tap { |$Z| <... $X ...> }
   message: Found user-controllable input to a reflection method. This may allow a user to alter program
     behavior and potentially execute arbitrary instructions in the context of the process. Do not provide
     arbitrary user input to `tap`, `method`, or `to_proc`

--- a/ruby/rails/security/brakeman/check-unsafe-reflection-methods.yaml
+++ b/ruby/rails/security/brakeman/check-unsafe-reflection-methods.yaml
@@ -21,12 +21,18 @@ rules:
     - pattern-either:
       - pattern-inside: |
           $X. ... .to_proc
-      - pattern-inside: |
-          $Y.method(<... $X ...>)
-      - pattern-inside: |
-          $Y.tap(<... $X ...>)
-      - pattern-inside: |
-          $Y.tap { |$Z| <... $X ...> }
+      - patterns:
+          - pattern-inside: |
+              $Y.method($Z)
+          - focus-metavariable: $Z
+      - patterns:
+          - pattern-inside: |
+              $Y.tap($Z)
+          - focus-metavariable: $Z
+      - patterns:
+          - pattern-inside: |
+              $Y.tap{ |$ANY| $Z }
+          - focus-metavariable: $Z
   message: Found user-controllable input to a reflection method. This may allow a user to alter program
     behavior and potentially execute arbitrary instructions in the context of the process. Do not provide
     arbitrary user input to `tap`, `method`, or `to_proc`


### PR DESCRIPTION
👋 Hey team!

I believe I've identified a false positive here.

This rule was intended to match when user input was provided as an argument to the `.tap` method. Here's the relevant brakeman rule that this was related to: https://github.com/presidentbeef/brakeman/blob/main/lib/brakeman/checks/check_unsafe_reflection_methods.rb

What I found in practice was that this would match whenever object the `.tap` method was called ON as well. I ran into this with a bit of code that looked like this

```ruby
  my_id = params[:id]
  my_new_object = MyObject.new(my_id)
  my_new_object.tap { |x| x.anything_here = 'asdf' }
```

In this case, the user input is not being passed in to the `tap` method, so I'm pretty sure there's no risk of unsafe reflection? I couldn't think of a way at least 🙃 