### PR TITLE
Update message to match version formats in rule

### DIFF
--- a/terraform/aws/security/aws-cloudfront-insecure-tls.yaml
+++ b/terraform/aws/security/aws-cloudfront-insecure-tls.yaml
@@ -43,7 +43,7 @@ rules:
     Detected an AWS CloudFront Distribution with an insecure TLS version.
     TLS versions less than 1.2 are considered insecure because they
     can be broken. To fix this, set your `minimum_protocol_version` to
-    `"TLS1.2_2018", "TLS1.2_2019" or "TLS1.2_2021"`.
+    `"TLSv1.2_2018", "TLSv1.2_2019" or "TLSv1.2_2021"`.
   metadata:
     category: security
     technology:


### PR DESCRIPTION
The version formats in the rule contain a v, so the rule message should match that.