### PR TITLE
updated message for Entrypoint docker security rule

### DIFF
--- a/dockerfile/security/missing-user-entrypoint.yaml
+++ b/dockerfile/security/missing-user-entrypoint.yaml
@@ -9,9 +9,7 @@ rules:
   fix: |
     USER non-root
     ENTRYPOINT $...VARS
-  message: By not specifying a USER, a program in the container may run as 'root'. This is a security
-    hazard. If an attacker can control a process running as root, they may have control over the container.
-    Ensure that the last USER in a Dockerfile is a USER other than 'root'. 
+  message: The absence of an ENTRYPOINT in a Dockerfile poses security risks. Without ENTRYPOINT, a program within the container may inadvertently execute with elevated privileges, running as the root user. This creates vulnerabilities as an attacker gaining control over a process running as root can potentially compromise the entire container.. 
   severity: ERROR
   languages: 
     - dockerfile


### PR DESCRIPTION
This PR updates the description for the containsecurity rule in Semgrep's documentation for missing-user-entrypoint rule. The previous description lacked clarity and failed to adequately convey the security implications of not specifying an ENTRYPOINT in a Dockerfile. It seems it had repeated message from previous rule

The updated description emphasizes the importance of defining an ENTRYPOINT to mitigate potential security risks, particularly the elevated privileges that a program may inadvertently run with if not properly configured. By providing more comprehensive guidance, developers using Semgrep will gain a better understanding of the security implications and best practices associated with Dockerfile configurations.

Changes:

- Updated message at dockerfile.security.missing-user-entrypoint.missing-user-entrypoint 