### PR TITLE
Update detected-ssh-password rule

### DIFF
--- a/generic/secrets/security/detected-ssh-password.txt
+++ b/generic/secrets/security/detected-ssh-password.txt
@@ -1,2 +1,8 @@
 # ruleid: detected-ssh-password
 sshpass -p 'blah'
+
+# ok: detected-ssh-password
+cmdInput := fmt.Sprintf("sshpass -p '%s'", password)
+
+# ok: detected-ssh-password
+cmdInput := fmt.Sprintf("sshpass -p %s", password)

--- a/generic/secrets/security/detected-ssh-password.yaml
+++ b/generic/secrets/security/detected-ssh-password.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: detected-ssh-password
   pattern-regex: |-
-    sshpass -p.*['|\\\"]
+    sshpass -p\s*['|\\\"][^%]
   languages: [regex]
   message: SSH Password detected
   severity: ERROR


### PR DESCRIPTION
FP fix for a regex type rule `detected-ssh-password`