### PR TITLE
[PHP] Improve Echoed Requests

### DIFF
--- a/php/lang/security/injection/echoed-request.php
+++ b/php/lang/security/injection/echoed-request.php
@@ -1,18 +1,18 @@
 <?php
 
 // example key-value: name=%3Cscript%3Econfirm%28%29%3C%2Fscript%3E
-function dangerousPrintUsage() {
+function dangerousEchoUsage() {
     $name = $_REQUEST['name'];
     // ruleid: echoed-request
-    print("Hello : $name");
+    echo "Hello : $name";
     // ruleid: echoed-request
-    print("Hello : " . $name);
+    echo "Hello : " . $name;
 }
 
-function safePrintUsage() {
+function safeEchoUsage() {
     $name = $_REQUEST['name'];
     // ok: echoed-request
-    print("Hello : " . htmlentities($name));
+    echo "Hello : " . htmlentities($name);
 }
 
 function doSmth() {

--- a/php/lang/security/injection/echoed-request.php
+++ b/php/lang/security/injection/echoed-request.php
@@ -44,6 +44,22 @@ function doSmth5() {
     echo "Hello ".trim($_POST['name']);
 }
 
+function doSmth6() {
+   $VAR = $_GET['someval']
+    if(isset($VAR)){ 
+        // ruleid: echoed-request
+        echo $VAR; 
+    }
+}
+
+function doSmth7() {
+    $VAR = $_GET['someval']
+     if(empty($VAR)){ 
+         // ruleid: echoed-request
+         echo $VAR; 
+     }
+ }
+
 function doOK1() {
     // ok: echoed-request
     echo "Hello ".htmlentities($_POST['name'])." !";
@@ -84,4 +100,14 @@ function doOK7() {
     echo $safevar;
 }
 
+function doOK8() {
+    // ok: echoed-request
+    echo "Hello ".isset($_POST['name'])." !";
+}
+
+function doOK9() {
+    $safevar = empty($_GET['name']);
+    // ok: echoed-request
+    echo "Hello $safevar !";
+}
 

--- a/php/lang/security/injection/echoed-request.php
+++ b/php/lang/security/injection/echoed-request.php
@@ -63,11 +63,11 @@ function doOK3() {
 
 function doOK4() {
     // ok: echoed-request
-    echo "Hello ".isset($_POST['name'])." !";
+    echo "Hello ".e($_POST['name'])." !";
 }
 
 function doOK5() {
-    $safevar = empty($_GET['name']);
+    $safevar = esc_attr($_GET['name']);
     // ok: echoed-request
     echo "Hello $safevar !";
 }

--- a/php/lang/security/injection/echoed-request.php
+++ b/php/lang/security/injection/echoed-request.php
@@ -45,7 +45,7 @@ function doSmth5() {
 }
 
 function doSmth6() {
-   $VAR = $_GET['someval']
+   $VAR = $_GET['someval'];
     if(isset($VAR)){ 
         // ruleid: echoed-request
         echo $VAR; 
@@ -53,7 +53,7 @@ function doSmth6() {
 }
 
 function doSmth7() {
-    $VAR = $_GET['someval']
+    $VAR = $_GET['someval'];
      if(empty($VAR)){ 
          // ruleid: echoed-request
          echo $VAR; 

--- a/php/lang/security/injection/echoed-request.yaml
+++ b/php/lang/security/injection/echoed-request.yaml
@@ -16,6 +16,8 @@ rules:
   - pattern: htmlentities(...)
   - pattern: htmlspecialchars(...)
   - pattern: strip_tags(...)
+  - pattern: isset(...)
+  - pattern: empty(...)
   # Wordpress Escapes
   - pattern: esc_html(...)
   - pattern: esc_attr(...)

--- a/php/lang/security/injection/echoed-request.yaml
+++ b/php/lang/security/injection/echoed-request.yaml
@@ -14,7 +14,6 @@ rules:
   - pattern: echo $...VARS;
   pattern-sanitizers:
   - pattern: isset(...)
-  - pattern: empty(...)
   - pattern: htmlentities(...)
   - pattern: htmlspecialchars(...)
   - pattern: strip_tags(...)
@@ -25,7 +24,7 @@ rules:
   # Laravel Escapes
   - pattern: e(...)
   # Symfony Escapes
-  - pattern: twig_escape_filter($...)
+  - pattern: twig_escape_filter(...)
   # CodeIgniter Escapes
   - pattern: xss_clean(...)
   - pattern: html_escape(...)

--- a/php/lang/security/injection/echoed-request.yaml
+++ b/php/lang/security/injection/echoed-request.yaml
@@ -13,7 +13,6 @@ rules:
   pattern-sinks:
   - pattern: echo $...VARS;
   pattern-sanitizers:
-  - pattern: isset(...)
   - pattern: htmlentities(...)
   - pattern: htmlspecialchars(...)
   - pattern: strip_tags(...)

--- a/php/lang/security/injection/printed-request.php
+++ b/php/lang/security/injection/printed-request.php
@@ -63,11 +63,11 @@ function doOK3() {
 
 function doOK4() {
     // ok: printed-request
-    print("Hello ".isset($_POST['name'])." !");
+    print("Hello ".e($_POST['name'])." !");
 }
 
 function doOK5() {
-    $safevar = empty($_GET['name']);
+    $safevar = esc_attr($_GET['name']);
     // ok: printed-request
     print("Hello $safevar !");
 }

--- a/php/lang/security/injection/printed-request.php
+++ b/php/lang/security/injection/printed-request.php
@@ -45,7 +45,7 @@ function doSmth5() {
 }
 
 function doSmth6() {
-    $VAR = $_GET['someval']
+    $VAR = $_GET['someval'];
      if(isset($VAR)){ 
          // ruleid: printed-request
          print($VAR); 
@@ -53,7 +53,7 @@ function doSmth6() {
  }
  
  function doSmth7() {
-     $VAR = $_GET['someval']
+     $VAR = $_GET['someval'];
       if(empty($VAR)){ 
           // ruleid: printed-request
           print($VAR); 

--- a/php/lang/security/injection/printed-request.php
+++ b/php/lang/security/injection/printed-request.php
@@ -1,0 +1,87 @@
+<?php
+
+// example key-value: name=%3Cscript%3Econfirm%28%29%3C%2Fscript%3E
+function dangerousEchoUsage() {
+    $name = $_REQUEST['name'];
+    // ruleid: printed-request
+    print("Hello : $name");
+    // ruleid: printed-request
+    print("Hello : " . $name);
+}
+
+function safeEchoUsage() {
+    $name = $_REQUEST['name'];
+    // ok: printed-request
+    print("Hello : " . htmlentities($name));
+}
+
+function doSmth() {
+    $name = $_REQUEST['name'];
+    // ruleid: printed-request
+    print("Hello :".$name);
+}
+
+function doSmth2() {
+    // ruleid: printed-request
+    print("Hello ".$_POST['name']." !");
+}
+
+function doSmth3() {
+    $name = $_GET['name'];
+    if (str_contains($name, 'foobar')) {
+        // ruleid: printed-request
+        print("Hello :".$name);
+    }
+}
+
+function doSmth4() {
+    // ruleid: printed-request
+    print("Hello ".htmlentities($_POST['name'])." !".$_POST['lastname']);
+}
+
+function doSmth5() {
+     // ruleid: printed-request
+    print("Hello ".trim($_POST['name']));
+}
+
+function doOK1() {
+    // ok: printed-request
+    print("Hello ".htmlentities($_POST['name'])." !");
+}
+
+function doOK2() {
+    $input = $_GET['name'];
+    // ok: printed-request
+    print("Hello ".htmlspecialchars($input)." !");
+}
+
+function doOK3() {
+    $safevar = "Hello ".htmlentities(trim($_GET['name']));
+    // ok: printed-request
+    print($safevar);
+}
+
+function doOK4() {
+    // ok: printed-request
+    print("Hello ".isset($_POST['name'])." !");
+}
+
+function doOK5() {
+    $safevar = empty($_GET['name']);
+    // ok: printed-request
+    print("Hello $safevar !");
+}
+
+function doOK6() {
+    $safevar = "Hello ".htmlentities($_GET['name']);
+    // ok: printed-request
+    print($safevar);
+}
+
+function doOK7() {
+    $safevar = "Hello ".htmlspecialchars($_GET['name']);
+    // ok: printed-request
+    print($safevar);
+}
+
+

--- a/php/lang/security/injection/printed-request.php
+++ b/php/lang/security/injection/printed-request.php
@@ -44,6 +44,22 @@ function doSmth5() {
     print("Hello ".trim($_POST['name']));
 }
 
+function doSmth6() {
+    $VAR = $_GET['someval']
+     if(isset($VAR)){ 
+         // ruleid: printed-request
+         print($VAR); 
+     }
+ }
+ 
+ function doSmth7() {
+     $VAR = $_GET['someval']
+      if(empty($VAR)){ 
+          // ruleid: printed-request
+          print($VAR); 
+      }
+  }
+
 function doOK1() {
     // ok: printed-request
     print("Hello ".htmlentities($_POST['name'])." !");
@@ -84,4 +100,13 @@ function doOK7() {
     print($safevar);
 }
 
+function doOK8() {
+    // ok: printed-request
+    print("Hello ".isset($_POST['name'])." !");
+}
 
+function doOK9() {
+    $safevar = empty($_GET['name']);
+    // ok: printed-request
+    print("Hello $safevar !");
+}

--- a/php/lang/security/injection/printed-request.yaml
+++ b/php/lang/security/injection/printed-request.yaml
@@ -1,8 +1,8 @@
 rules:
-- id: echoed-request
+- id: printed-request
   mode: taint
   message: >-
-    `Echo`ing user input risks cross-site scripting vulnerability.
+    `Printing user input risks cross-site scripting vulnerability.
     You should use `htmlentities()` when showing data to users.
   languages: [php]
   severity: ERROR
@@ -11,7 +11,7 @@ rules:
   - pattern: $_GET
   - pattern: $_POST
   pattern-sinks:
-  - pattern: echo $...VARS;
+  - pattern: print($...VARS);
   pattern-sanitizers:
   - pattern: isset(...)
   - pattern: empty(...)
@@ -37,7 +37,7 @@ rules:
   # Laminas Escapes
   - pattern: escapeHtml(...)
   - pattern: escapeHtmlAttr(...)
-  fix: echo htmlentities($...VARS);
+  fix: print(htmlentities($...VARS));
   metadata:
     technology:
     - php

--- a/php/lang/security/injection/printed-request.yaml
+++ b/php/lang/security/injection/printed-request.yaml
@@ -13,7 +13,6 @@ rules:
   pattern-sinks:
   - pattern: print($...VARS);
   pattern-sanitizers:
-  - pattern: isset(...)
   - pattern: htmlentities(...)
   - pattern: htmlspecialchars(...)
   - pattern: strip_tags(...)

--- a/php/lang/security/injection/printed-request.yaml
+++ b/php/lang/security/injection/printed-request.yaml
@@ -16,6 +16,8 @@ rules:
   - pattern: htmlentities(...)
   - pattern: htmlspecialchars(...)
   - pattern: strip_tags(...)
+  - pattern: isset(...)
+  - pattern: empty(...)
   # Wordpress Escapes
   - pattern: esc_html(...)
   - pattern: esc_attr(...)

--- a/php/lang/security/injection/printed-request.yaml
+++ b/php/lang/security/injection/printed-request.yaml
@@ -14,7 +14,6 @@ rules:
   - pattern: print($...VARS);
   pattern-sanitizers:
   - pattern: isset(...)
-  - pattern: empty(...)
   - pattern: htmlentities(...)
   - pattern: htmlspecialchars(...)
   - pattern: strip_tags(...)
@@ -25,7 +24,7 @@ rules:
   # Laravel Escapes
   - pattern: e(...)
   # Symfony Escapes
-  - pattern: twig_escape_filter($...)
+  - pattern: twig_escape_filter(...)
   # CodeIgniter Escapes
   - pattern: xss_clean(...)
   - pattern: html_escape(...)


### PR DESCRIPTION
## Description
This PR aims two improve the echoed requests PHP injection rule by doing the followings:
1. Splitting out Print and Echo into seperate rules to allow for Fixes/Autofixes
2. Adding additional sanitisation functions to reduce the number of false positives associated with the rules
3. Remove a false negative associated with "empty" (more on this below)

## False Negative
The empty function by itself isn't really a sanitiser as it returns a [boolean output rather than an empty string](https://www.php.net/manual/en/function.empty.php). In theory we could add a sanitiser similar to:
`pattern: if(empty($...VARS))`

However, this is likely to be just as noisy/false negative heavy. There may be a smart way to check this with metavariable comparisons. If someone wants to try further improve this rule. 

## Notes
I couldn't find any way to use fix-regex to keep these rules combined but if would love to simplify this if you have any suggestions.