### PR TITLE
Exclude tests files in golang

### DIFF
--- a/problem-based-packs/insecure-transport/go-stdlib/http-customized-request.yaml
+++ b/problem-based-packs/insecure-transport/go-stdlib/http-customized-request.yaml
@@ -1,5 +1,8 @@
 rules:
 - id: http-customized-request
+  paths:
+    exclude:
+      - "**/*_test.go"
   message: >-
     Checks for requests sent via http.NewRequest to http:// URLS. This is dangerous because
     the server is attempting to connect to a website that does not encrypt traffic with TLS. Instead, send


### PR DESCRIPTION
Writing tests for HTTP handlers where we are calling localhost will get matched by the `http-customized-request` rule.

In golang all test files are postfixed with `_test.go` (https://go.dev/doc/tutorial/add-a-test). We suggest that we exclude those files as they are not part of the production code shipped with go build. Alternatively we can check the hostname directly and ensure it is not `localhost` and `127.0.0.1`.