### PR TITLE
Fix CSharp SQLI rule

### DIFF
--- a/csharp/lang/security/sqli/csharp-sqli.cs
+++ b/csharp/lang/security/sqli/csharp-sqli.cs
@@ -135,17 +135,21 @@ namespace Sqli
          }
       }
 
-      public void sqli12(string sqli)
-      {
-         using (SqlConnection connection = new SqlConnection("Data Source=(local);Initial Catalog=Northwind;Integrated Security=SSPI;")) {
-            connection.Open();
-            SqlCommand command= connection.CreateCommand();
-            // ruleid: csharp-sqli
-            command.CommandText = sqli;
-            command.CommandTimeout = 15;
-            command.CommandType = CommandType.Text;
-         }
-      }
+        public void sqli2(string sqli)
+        {
+            using (SqlConnection connection = new SqlConnection("Data Source=(local);Initial Catalog=Northwind;Integrated Security=SSPI;")) {
+               connection.Open();
+               SqlCommand command= connection.CreateCommand();
+               // ruleid: csharp-sqli
+               command.CommandText = String.Format("SELECT c.name AS column_name,t.name AS type_name,c.max_length,c.precision,c.scale,             CAST(CASE WHEN EXISTS(SELECT * FROM sys.index_columns AS i WHERE i.object_id=c.object_id AND i.column_id=c.column_id) THEN 1 ELSE 0 END AS BIT) AS column_indexed             FROM sys.columns AS c              JOIN sys.types AS t ON c.user_type_id=t.user_type_id              WHERE c.object_id = OBJECT_ID('{0}')              ORDER BY c.column_id;", sqli);
+               command.CommandTimeout = 15;
+               command.CommandType = CommandType.Text;
+               await using var connection = new SqlConnection(configuration.GetVaultConnectionString(sqli, "B", true));
+               await using var command = connection.CreateCommand();
+               // ok: csharp-sqli
+               command.CommandText = "SELECT 1;";
+            }
+        }
 
       public void sqli13()
       {

--- a/csharp/lang/security/sqli/csharp-sqli.yaml
+++ b/csharp/lang/security/sqli/csharp-sqli.yaml
@@ -18,8 +18,10 @@ rules:
               - pattern: |
                   new $PATTERN($CMD,...)
               - focus-metavariable: $CMD
-            - pattern: |
-                $CMD.$PATTERN = ...;
+            - patterns:
+              - pattern: |
+                  $CMD.$PATTERN = $VALUE;
+              - focus-metavariable: $VALUE
           - metavariable-regex:
               metavariable: $PATTERN
               regex: ^(SqlCommand|CommandText|OleDbCommand|OdbcCommand|OracleCommand)$


### PR DESCRIPTION
Reported by user where taint tracking was 'tainting' due to a string entering `SqlConnection` first argument, and then a static string was flagging as a finding. 

Community slack context https://semgrep.slack.com/archives/C031LV9H6P9/p1722445805060099