### PR TITLE
python: Future-proof use-ftp-tls for stdlib libdefs

### DIFF
--- a/python/lang/security/audit/insecure-transport/ftplib/use-ftp-tls.yaml
+++ b/python/lang/security/audit/insecure-transport/ftplib/use-ftp-tls.yaml
@@ -1,6 +1,18 @@
 rules:
 - id: use-ftp-tls
-  pattern: ftplib.FTP(...)
+  patterns:
+    - pattern: ftplib.FTP(...)
+    # With stdlib libdefs, Semgrep knows that `ftplib.FTP_TLS` is a subclass of
+    # `ftplib.FTP`, and therefore the pattern `ftplib.FTP` matches when we
+    # encounter `ftplib.FTP_TLS` too.
+    #
+    # Therefore, we explicitly exclude `FTP_TLS`.
+    #
+    # Currently libdefs are only available with the interfile engine, and since
+    # this rule does not have `interfile: true` we only run the interfile engine
+    # over it in tests. However, it's preferable to future-proof this rule
+    # rather than exclude it from our interfile test suite.
+    - pattern-not: ftplib.FTP_TLS(...)
   fix-regex:
     regex: FTP(.*)\)
     replacement: FTP_TLS\1, context=ssl.create_default_context())


### PR DESCRIPTION
Explanation in the rule