### PR TITLE
fix: no pro finding for raw-html-concat.js:18

### DIFF
--- a/javascript/browser/security/raw-html-concat.js
+++ b/javascript/browser/security/raw-html-concat.js
@@ -14,7 +14,7 @@ $(function ($) {
                 
                 var x = `<div align="left">${content}</div>`
 
-                // ruleid: raw-html-concat
+                // deepok: ruleid: raw-html-concat
                 return '<div align="' + (attrs.defaultattr || 'left') + '">' + newContent + '</div>';
             },
             isInline: false

--- a/javascript/browser/security/raw-html-concat.js
+++ b/javascript/browser/security/raw-html-concat.js
@@ -14,7 +14,7 @@ $(function ($) {
                 
                 var x = `<div align="left">${content}</div>`
 
-                // deepok: ruleid: raw-html-concat
+                // ruleid: deepok: raw-html-concat
                 return '<div align="' + (attrs.defaultattr || 'left') + '">' + newContent + '</div>';
             },
             isInline: false


### PR DESCRIPTION
We should not expect a pro finding here since the tainted `newContent` is not in scope, so this actually throws `ReferenceError`. See also discussion on SAF-1013.

Cf. a version written with `var`, where hoisting would mean that `newContent` would be in scope, and the test should generate a finding.