### PR TITLE
Added Onfido API token detection to recognize this type of secrets

### DIFF
--- a/generic/secrets/security/detected-onfido-live-api-token.txt
+++ b/generic/secrets/security/detected-onfido-live-api-token.txt
@@ -1,0 +1,8 @@
+# ruleid: detected-onfido-live-api-token
+api_live.abc123ABC-_.abc123ABC-_abc123ABC-_abc123ABC-
+
+# ruleid: detected-onfido-live-api-token
+api_live_ca.abc123ABC-_.abc123ABC-_abc123ABC-_abc123ABC-
+
+# ruleid: detected-onfido-live-api-token
+api_live_us.abc123ABC-_.abc123ABC-_abc123ABC-_abc123ABC-

--- a/generic/secrets/security/detected-onfido-live-api-token.yaml
+++ b/generic/secrets/security/detected-onfido-live-api-token.yaml
@@ -1,0 +1,20 @@
+rules:
+- id: detected-onfido-live-api-token
+  pattern-regex: (?:api_live(?:_[a-zA-Z]{2})?\.[a-zA-Z0-9-_]{11}\.[-_a-zA-Z0-9]{32})
+  languages: [regex]
+  message: Onfido live API Token detected
+  severity: ERROR
+  metadata:
+    cwe:
+    - 'CWE-798: Use of Hard-coded Credentials'
+    category: security
+    technology:
+    - secrets
+    - onfido
+    confidence: HIGH
+    references:
+    - https://documentation.onfido.com/api/latest/#api-tokens
+    subcategory:
+    - audit
+    likelihood: HIGH
+    impact: HIGH


### PR DESCRIPTION
Add [Onfido](https://onfido.com/) API Token detector to recognize this type of secrets. Documentation on API token can be found here: https://documentation.onfido.com/api/latest/#api-tokens.

Note that Onfido is a GitHub [secret scanning partner](https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns) and those tokens are currently detected by the built-in GitHub scanner.