### PR TITLE
chore: put ruleid annotation alone on its own line for tainted-sql-string.py

### DIFF
--- a/python/django/security/injection/tainted-sql-string.py
+++ b/python/django/security/injection/tainted-sql-string.py
@@ -10,7 +10,8 @@ class Person(models.Model):
 ##### True Positives #########
 def get_user_age1(request):
     user_name = request.POST.get("user_name")
-    user_age = Person.objects.raw( # ruleid: tainted-sql-string
+    user_age = Person.objects.raw(
+        # ruleid: tainted-sql-string
         "SELECT user_age FROM myapp_person where user_name = %s" % user_name
     )
     html = "<html><body>User Age %s.</body></html>" % user_age
@@ -19,7 +20,8 @@ def get_user_age1(request):
 
 def get_user_age2(request):
     user_name = request.POST.get("user_name")
-    user_age = Person.objects.raw( # ruleid: tainted-sql-string
+    user_age = Person.objects.raw(
+        # ruleid: tainted-sql-string
         f"SELECT user_age FROM myapp_person where user_name = {user_name}"
     )
     html = "<html><body>User Age %s.</body></html>" % user_age
@@ -28,7 +30,8 @@ def get_user_age2(request):
 
 def get_user_age3(request):
     user_name = request.POST.get("user_name")
-    user_age = Person.objects.raw( # ruleid: tainted-sql-string
+    user_age = Person.objects.raw(
+        # ruleid: tainted-sql-string
         "SELECT user_age FROM myapp_person where user_name = %s".format(user_name)
     )
     html = "<html><body>User Age %s.</body></html>" % user_age
@@ -37,7 +40,8 @@ def get_user_age3(request):
 
 def get_user_age4(request):
     user_name = request.POST.get("user_name")
-    user_age = Person.objects.raw( # ruleid: tainted-sql-string
+    user_age = Person.objects.raw(
+        # ruleid: tainted-sql-string
         "SELECT user_age FROM myapp_person where user_name = " + user_name
     )
     html = "<html><body>User Age %s.</body></html>" % user_age
@@ -63,7 +67,8 @@ def get_user_age6(request):
 
 def get_users1(request):
     client_id = request.headers.get("client_id")
-    users = Person.objects.raw( # ruleid: tainted-sql-string
+    users = Person.objects.raw(
+        # ruleid: tainted-sql-string
         "SELECT * FROM myapp_person where client_id = %s" % client_id
     )
     html = "<html><body>Users %s.</body></html>" % users
@@ -72,7 +77,8 @@ def get_users1(request):
 
 def get_users2(request):
     client_id = request.headers.get("client_id")
-    users = Person.objects.raw( # ruleid: tainted-sql-string
+    users = Person.objects.raw(
+        # ruleid: tainted-sql-string
         f"SELECT * FROM myapp_person where client_id = {client_id}"
     )
     html = "<html><body>Users %s.</body></html>" % users


### PR DESCRIPTION
This is the only file doing that, so let's be consistent.
It also helps osemgrep test which does not handle this case.

This was mentioned in
https://linear.app/semgrep/issue/SAF-1529/same-line-annotations-fail-when-running-semgrep-test-but-work-with

test plan:
make test