### PR TITLE
Fix broken link in system-wildcard-detected.yaml

### DIFF
--- a/python/lang/security/audit/system-wildcard-detected.yaml
+++ b/python/lang/security/audit/system-wildcard-detected.yaml
@@ -16,7 +16,7 @@ rules:
     if there exist any non-standard file names. Consider a file named '-e sh script.sh'
     -- this
     will execute a script when 'rsync' is called. See
-    https://www.defensecode.com/public/DefenseCode_Unix_WildCards_Gone_Wild.txt
+    https://gist.githubusercontent.com/kylemclaren/37a87bdc2fb34c0d2b44/raw/ae98c7f7f2a3a8158234d102dde1a0d800b23d25/gistfile1.txt
     for more information.
   metadata:
     cwe:
@@ -24,7 +24,7 @@ rules:
     owasp: 'A01:2017 - Injection'
     source-url-open: https://github.com/PyCQA/bandit/blob/b1411bfb43795d3ffd268bef17a839dee954c2b1/bandit/plugins/injection_wildcard.py
     references:
-    - https://www.defensecode.com/public/DefenseCode_Unix_WildCards_Gone_Wild.txt
+    - https://gist.githubusercontent.com/kylemclaren/37a87bdc2fb34c0d2b44/raw/ae98c7f7f2a3a8158234d102dde1a0d800b23d25/gistfile1.txt
     category: security
     technology:
     - python


### PR DESCRIPTION
The previous URL is a good original source, but it has been down for years. Replaced it with a gist posting that has the original content.