### PR TITLE
Fix rule express-xml2json-xxe-event after Pro PR 2587

### DIFF
--- a/javascript/express/security/audit/express-xml2json-xxe-event.js
+++ b/javascript/express/security/audit/express-xml2json-xxe-event.js
@@ -10,7 +10,8 @@ function test1() {
         req.on('data', function (chunk) {
             buf += chunk
         });
-        // ruleid: express-xml2json-xxe-event
+        // The rule isn't written in a way that it can find this
+        // todoruleid: express-xml2json-xxe-event
         req.on('end', function () {
             req.body = expat.toJson(buf, {coerce: true, object: true});
             next();
@@ -29,7 +30,8 @@ function test2() {
         req.on('data', function (chunk) {
             buf += chunk
         });
-        // ruleid: express-xml2json-xxe-event
+        // The rule isn't written in a way that it can find this
+        // todoruleid: express-xml2json-xxe-event
         req.on('end', function () {
             req.body = expat.toJson(buf, {coerce: true, object: true});
             next();

--- a/javascript/express/security/audit/express-xml2json-xxe-event.yaml
+++ b/javascript/express/security/audit/express-xml2json-xxe-event.yaml
@@ -69,3 +69,4 @@ rules:
           import 'xml2json';
           ...
     - pattern: $REQ.on('...', function(...) { ... $EXPAT.toJson($INPUT,...); ... })
+    - focus-metavariable: $INPUT


### PR DESCRIPTION
The rule isn't written in a way that can report those findings, it was reporting them "by accident". Adding `focus-metavariable: $INPUT` already removes the findings because Semgrep is not tracking `buf` as being tainted.

This test was problematic when fixing an engine issue in semgrep/semgrep-proprietary#2587