### PR TITLE
added a rule to detect usage of uuid version 1 in python

### DIFF
--- a/python/lang/security/insecure-uuid-version.py
+++ b/python/lang/security/insecure-uuid-version.py
@@ -1,0 +1,19 @@
+import uuid
+def example_1():
+    # ruleid:insecure-uuid-version
+    uuid = uuid.uuid1()
+
+from uuid import uuid1
+def example_2():
+    # ruleid:insecure-uuid-version
+    uuid = uuid1()
+
+from uuid import *
+def example_3():
+    # ruleid:insecure-uuid-version
+    uuid = uuid1() 
+
+import uuid
+def unrelated_function():
+    # ok:insecure-uuid-version
+    uuid = uuid4()

--- a/python/lang/security/insecure-uuid-version.yaml
+++ b/python/lang/security/insecure-uuid-version.yaml
@@ -3,8 +3,10 @@ rules:
     patterns:
       - pattern: uuid.uuid1(...)
     message: |
-      Using UUID version 1 for UUID generation can lead to predictable UUIDs based on system information (e.g., MAC address, timestamp). This may lead to security risks such as the sandwich attack e.g. https://www.landh.tech/blog/20230811-sandwich-attack/. Consider using `uuid.uuid4()` instead for better randomness and security.
+      Using UUID version 1 for UUID generation can lead to predictable UUIDs based on system information (e.g., MAC address, timestamp). This may lead to security risks such as the sandwich attack. Consider using `uuid.uuid4()` instead for better randomness and security.
     metadata:
+      references:
+        - https://www.landh.tech/blog/20230811-sandwich-attack/
       cwe: 
       - 'CWE-330: Use of Insufficiently Random Values'
       owasp: 

--- a/python/lang/security/insecure-uuid-version.yaml
+++ b/python/lang/security/insecure-uuid-version.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: insecure-uuid-version
+    patterns:
+      - pattern: uuid.uuid1(...)
+    message: |
+      Using UUID version 1 for UUID generation can lead to predictable UUIDs based on system information (e.g., MAC address, timestamp). This may lead to security risks such as the sandwich attack e.g. https://www.landh.tech/blog/20230811-sandwich-attack/. Consider using `uuid.uuid4()` instead for better randomness and security.
+    metadata:
+      cwe: 
+      - 'CWE-330: Use of Insufficiently Random Values'
+      owasp: 
+      - A02:2021 - Cryptographic Failures
+      asvs:
+        section: V6 Stored Cryptography Verification Requirements
+        control_id: 6.3.2 Insecure UUID Generation
+        control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x14-V6-Cryptography.md#v63-random-values
+        version: '4'
+      category: security
+      technology:
+      - python
+      subcategory:
+      - audit
+      likelihood: LOW
+      impact: MEDIUM
+      confidence: MEDIUM
+    languages:
+      - python
+    severity: WARNING
+    fix-regex:
+      regex: uuid1
+      replacement: uuid4
+    


### PR DESCRIPTION
Added a Semgrep rule to detect UUID version 1 in Python, which could lead to predictable UUIDs based on system information (e.g., MAC address, timestamp). This may lead to security risks such as the sandwich attack e.g. https://www.landh.tech/blog/20230811-sandwich-attack/.