### PR TITLE
Also find weak crypto in PHP when hash(...) is called

### DIFF
--- a/php/lang/security/weak-crypto.php
+++ b/php/lang/security/weak-crypto.php
@@ -20,3 +20,12 @@ $hashed_password = str_rot13('totally secure');
 
 // ok: weak-crypto
 $hashed_password = sodium_crypto_generichash('mypassword');
+
+// ruleid: weak-crypto
+var_dump(hash("sha1", "hello"));
+
+// ruleid: weak-crypto
+var_dump(hash("md5", "hello"));
+
+// ok: weak-crypto
+var_dump(hash("sha384", "hello"));

--- a/php/lang/security/weak-crypto.yaml
+++ b/php/lang/security/weak-crypto.yaml
@@ -1,10 +1,15 @@
 rules:
 - id: weak-crypto
   patterns:
-  - pattern: $FUNC(...);
-  - metavariable-regex:
-      metavariable: $FUNC
-      regex: crypt|md5|md5_file|sha1|sha1_file|str_rot13
+  - pattern-either:
+    - pattern: crypt(...)
+    - pattern: hash('md5', ...)
+    - pattern: hash('sha1', ...)
+    - pattern: md5_file(...)
+    - pattern: md5(...)
+    - pattern: sha1_file(...)
+    - pattern: sha1(...)
+    - pattern: str_rot13(...)
   message: >-
     Detected usage of weak crypto function. Consider using stronger alternatives.
   metadata:


### PR DESCRIPTION
MD5 and SHA1 are insecure hash functions. These have their own function names (`md5(...)`, `sha1(...)`) but can also be calculated using `hash('md5', ...)` and `hash('sha1', ...)`. Also find these instances and report them as weak crypto.

Also, write out all function names as function calls instead of matching them with a regular expression, for readability and performance reasons.