### PR TITLE
Add rule for SHA224 hash in PHP, Java, Go, Python, Ruby

### DIFF
--- a/go/lang/security/audit/crypto/sha224-hash.go
+++ b/go/lang/security/audit/crypto/sha224-hash.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"crypto/sha256"
+	"golang.org/x/crypto/sha3"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+func main() {
+}
+
+func test_sha224() {
+	f, err := os.Open("file.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	// ruleid: sha224-hash
+	h := sha256.New224()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Fatal(err)
+	}
+	// ruleid: sha224-hash
+	fmt.Printf("%x", sha256.Sum224(nil))
+}
+
+func test_sha3_224() {
+	f, err := os.Open("file.txt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	// ruleid: sha224-hash
+	h := sha3.New224()
+	if _, err := io.Copy(h, f); err != nil {
+		log.Fatal(err)
+	}
+	// ruleid: sha224-hash
+	fmt.Printf("%x", sha3.Sum224(nil))
+}

--- a/go/lang/security/audit/crypto/sha224-hash.yaml
+++ b/go/lang/security/audit/crypto/sha224-hash.yaml
@@ -1,0 +1,44 @@
+rules:
+- id: sha224-hash
+  pattern-either:
+    - patterns:
+      - pattern-inside: |
+          import "crypto/sha256"
+          ...
+      - pattern-either:
+        - pattern: |
+            sha256.New224()
+        - pattern: |
+            sha256.Sum224(...)
+    - patterns:
+      - pattern-inside: |
+          import "golang.org/x/crypto/sha3"
+          ...
+      - pattern-either:
+        - pattern: |
+            sha3.New224()
+        - pattern: |
+            sha3.Sum224(...)
+  message: >-
+    This code uses a 224-bit hash function, which is deprecated or disallowed
+    in some security policies. Consider updating to a stronger hash function such
+    as SHA-384 or higher to ensure compliance and security.
+  languages: [go]
+  severity: WARNING
+  metadata:
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    cwe:
+    - 'CWE-328: Use of Weak Hash'
+    category: security
+    technology:
+    - go
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar3.ipd.pdf
+    - https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/cyber-security-guidelines/guidelines-cryptography
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: HIGH

--- a/java/lang/security/audit/crypto/use-of-sha224.java
+++ b/java/lang/security/audit/crypto/use-of-sha224.java
@@ -1,0 +1,56 @@
+import java.security.MessageDigest;
+import org.apache.commons.codec.digest.DigestUtils;
+import static org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_224;
+
+public class Bad {
+  public byte[] bad1(String password) {
+    // ruleid: use-of-sha224
+    MessageDigest sha224Digest = MessageDigest.getInstance("SHA-224");
+    sha224Digest.update(password.getBytes());
+    byte[] hashValue = sha224Digest.digest();
+    return hashValue;
+  }
+
+  public byte[] bad2(String password) {
+    // ruleid: use-of-sha224
+    byte[] hashValue = DigestUtils.getSha3_224Digest().digest(password.getBytes());
+    return hashValue;
+  }
+
+  public void bad3() {
+    // ruleid: use-of-sha224
+    java.security.MessageDigest md = java.security.MessageDigest.getInstance("sha224", "SUN");
+    byte[] input = { (byte) '?' };
+    Object inputParam = bar;
+    if (inputParam instanceof String)
+      input = ((String) inputParam).getBytes();
+    if (inputParam instanceof java.io.InputStream) {
+      byte[] strInput = new byte[1000];
+      int i = ((java.io.InputStream) inputParam).read(strInput);
+      if (i == -1) {
+        response.getWriter()
+            .println(
+                "This input source requires a POST, not a GET. Incompatible UI for the InputStream source.");
+        return;
+      }
+      input = java.util.Arrays.copyOf(strInput, i);
+    }
+    md.update(input);
+    byte[] result = md.digest();
+    java.io.File fileTarget = new java.io.File(
+        new java.io.File(org.owasp.benchmark.helpers.Utils.TESTFILES_DIR),
+        "passwordFile.txt");
+    java.io.FileWriter fw = new java.io.FileWriter(fileTarget, true); // the true will append the new data
+    fw.write(
+        "hash_value="
+            + org.owasp.esapi.ESAPI.encoder().encodeForBase64(result, true)
+            + "\n");
+    fw.close();
+  }
+
+  public byte[] bad4(String password) {
+    // ruleid: use-of-sha224
+    byte [] hashValue = new DigestUtils(SHA_224).digest(password.getBytes());
+    return hashValue;
+  }
+}

--- a/java/lang/security/audit/crypto/use-of-sha224.yaml
+++ b/java/lang/security/audit/crypto/use-of-sha224.yaml
@@ -1,0 +1,47 @@
+rules:
+- id: use-of-sha224
+  message: >-
+    This code uses a 224-bit hash function, which is deprecated or disallowed
+    in some security policies. Consider updating to a stronger hash function such
+    as SHA-384 or higher to ensure compliance and security.
+  languages: [java]
+  severity: WARNING
+  metadata:
+    functional-categories:
+      - 'crypto::search::hash-algorithm::javax.crypto'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    cwe:
+    - 'CWE-328: Use of Weak Hash'
+    asvs:
+      section: V6 Stored Cryptography Verification Requirements
+      control_id: 6.2.5 Insecure Algorithm
+      control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x14-V6-Cryptography.md#v62-algorithms
+      version: '4'
+    category: security
+    technology:
+    - java
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar3.ipd.pdf
+    - https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/cyber-security-guidelines/guidelines-cryptography
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: HIGH
+  pattern-either:
+  - pattern: org.apache.commons.codec.digest.DigestUtils.getSha3_224Digest()
+  - pattern: org.apache.commons.codec.digest.DigestUtils.getSha512_224Digest()
+  - pattern: org.apache.commons.codec.digest.DigestUtils.sha3_224(...)
+  - pattern: org.apache.commons.codec.digest.DigestUtils.sha3_224Hex(...)
+  - pattern: org.apache.commons.codec.digest.DigestUtils.sha512_224(...)
+  - pattern: org.apache.commons.codec.digest.DigestUtils.sha512_224Hex(...)
+  - pattern: new org.apache.commons.codec.digest.DigestUtils(org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_224)
+  - pattern: new org.apache.commons.codec.digest.DigestUtils(org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA_512_224)
+  - pattern: new org.apache.commons.codec.digest.DigestUtils(org.apache.commons.codec.digest.MessageDigestAlgorithms.SHA3_224)
+  - patterns:
+    - pattern: java.security.MessageDigest.getInstance("$ALGO", ...);
+    - metavariable-regex:
+        metavariable: $ALGO
+        regex: '.*224'

--- a/php/lang/security/audit/sha224-hash.php
+++ b/php/lang/security/audit/sha224-hash.php
@@ -1,0 +1,22 @@
+<?php
+
+// ruleid: sha224-hash
+var_dump(hash('sha224', 'mypassword'));
+
+// ruleid: sha224-hash
+var_dump(hash('sha512/224', 'mypassword'));
+
+// ruleid: sha224-hash
+var_dump(hash('sha3-224', 'mypassword'));
+
+// ruleid: sha224-hash
+var_dump(hash_hmac('sha224', 'mypassword'));
+
+// ruleid: sha224-hash
+var_dump(hash_hmac('sha512/224', 'mypassword'));
+
+// ruleid: sha224-hash
+var_dump(hash_hmac('sha3-224', 'mypassword'));
+
+// ok: sha224-hash
+var_dump(hash('sha384', 'mypassword'));

--- a/php/lang/security/audit/sha224-hash.yaml
+++ b/php/lang/security/audit/sha224-hash.yaml
@@ -1,0 +1,32 @@
+rules:
+- id: sha224-hash
+  pattern-either:
+  - pattern: hash('sha224', ...);
+  - pattern: hash('sha512/224', ...);
+  - pattern: hash('sha3-224', ...);
+  - pattern: hash_hmac('sha224', ...);
+  - pattern: hash_hmac('sha512/224', ...);
+  - pattern: hash_hmac('sha3-224', ...);
+  message: >-
+    This code uses a 224-bit hash function, which is deprecated or disallowed
+    in some security policies. Consider updating to a stronger hash function such
+    as SHA-384 or higher to ensure compliance and security.
+  metadata:
+    cwe:
+    - 'CWE-328: Use of Weak Hash'
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar3.ipd.pdf
+    - https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/cyber-security-guidelines/guidelines-cryptography
+    category: security
+    technology:
+    - php
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: LOW
+    confidence: HIGH
+  languages: [php]
+  severity: WARNING

--- a/python/lang/security/audit/sha224-hash.py
+++ b/python/lang/security/audit/sha224-hash.py
@@ -1,0 +1,10 @@
+import hashlib
+
+# ruleid:sha224-hash
+hashlib.sha224(b"1")
+
+# ruleid:sha224-hash
+hashlib.sha3_224(b"1")
+
+# ok:sha224-hash
+hashlib.sha384(b"1")

--- a/python/lang/security/audit/sha224-hash.yaml
+++ b/python/lang/security/audit/sha224-hash.yaml
@@ -1,0 +1,29 @@
+rules:
+- id: sha224-hash
+  message: >-
+    This code uses a 224-bit hash function, which is deprecated or disallowed
+    in some security policies. Consider updating to a stronger hash function such
+    as SHA-384 or higher to ensure compliance and security.
+  metadata:
+    cwe:
+    - 'CWE-327: Use of a Broken or Risky Cryptographic Algorithm'
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar3.ipd.pdf
+    - https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/cyber-security-guidelines/guidelines-cryptography
+    category: security
+    technology:
+    - python
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: HIGH
+  severity: WARNING
+  languages:
+  - python
+  pattern-either:
+    - pattern: hashlib.sha224(...)
+    - pattern: hashlib.sha3_224(...)

--- a/ruby/lang/security/audit/sha224-hash.rb
+++ b/ruby/lang/security/audit/sha224-hash.rb
@@ -1,0 +1,48 @@
+require 'digest'
+class Bad_sha224
+    def bad_sha224_code()
+        # ruleid: sha224-hash
+        sha = Digest::SHA224.hexdigest 'abc'
+        # ruleid: sha224-hash
+        sha = Digest::SHA224.new
+        # ruleid: sha224-hash
+        sha = Digest::SHA224.base64digest 'abc'
+        # ruleid: sha224-hash
+        sha = Digest::SHA224.digest 'abc'
+
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest::SHA224.new
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest::SHA224.hexdigest 'abc'
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest::SHA224.new
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest::SHA224.base64digest 'abc'
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest::SHA224.digest 'abc'
+        # ruleid: sha224-hash
+        OpenSSL::HMAC.hexdigest("sha224", key, data)
+        # ok: sha224-hash
+        OpenSSL::HMAC.hexdigest("SHA256", key, data)
+        # ok: sha224-hash
+        digest = OpenSSL::Digest::SHA256.new
+        # ok: sha224-hash
+        digest = OpenSSL::Digest::SHA256.hexdigest 'abc'
+
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest.new('SHA224')
+        
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest.new('SHA512-224')
+
+        # ruleid: sha224-hash
+        digest = OpenSSL::Digest.new('SHA3-224')
+
+        # ruleid: sha224-hash
+        hmac = OpenSSL::HMAC.new(key, 'sha224')
+
+        # ruleid: sha224-hash
+        hmac = OpenSSL::HMAC.new(key, 'SHA224')
+
+    end
+end

--- a/ruby/lang/security/audit/sha224-hash.yaml
+++ b/ruby/lang/security/audit/sha224-hash.yaml
@@ -1,0 +1,40 @@
+rules:
+- id: sha224-hash
+  message: >-
+    This code uses a 224-bit hash function, which is deprecated or disallowed
+    in some security policies. Consider updating to a stronger hash function such
+    as SHA-384 or higher to ensure compliance and security.
+  metadata:
+    cwe:
+    - 'CWE-328: Use of Weak Hash'
+    references:
+    - https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar3.ipd.pdf
+    - https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/cyber-security-guidelines/guidelines-cryptography
+    category: security
+    technology:
+    - ruby
+    owasp:
+    - A03:2017 - Sensitive Data Exposure
+    - A02:2021 - Cryptographic Failures
+    subcategory:
+    - vuln
+    likelihood: LOW
+    impact: LOW
+    confidence: HIGH
+  languages:
+  - ruby
+  severity: WARNING
+  pattern-either:
+  - pattern: Digest::SHA224.$FUNC
+  - pattern: OpenSSL::Digest::SHA224.$FUNC
+  - pattern: SHA3::Digest::SHA224(...)
+  - patterns:
+    - pattern-either:
+      - pattern: OpenSSL::HMAC.hexdigest("$ALGO", ...)
+      - pattern: OpenSSL::HMAC.digest("$ALGO", ...)
+      - pattern: OpenSSL::HMAC.new($KEY, "$ALGO")
+      - pattern: OpenSSL::Digest.digest("$ALGO", ...)
+      - pattern: OpenSSL::Digest.new("$ALGO", ...)
+    - metavariable-regex:
+        metavariable: $ALGO
+        regex: '.*224'


### PR DESCRIPTION
SHA224 and other hashes with 224 bits are currently on the edge of what is considered a secure hash function. The [Australian Cyber Security Center](https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism/cyber-security-guidelines/guidelines-cryptography) and [NIST](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar3.ipd.pdf) have indicated that SHA224 is going to be deprecated in the future.

This adds a rule to detect SHA224 and similar hashes. It is distinct from the existing MD5 and SHA1 rules, because those are currently a security problem, and SHA224 is more of a future compliance problem.