### PR TITLE
Add empty-with-boolean-expression for php

### DIFF
--- a/php/lang/correctness/empty-with-boolean-expression.php
+++ b/php/lang/correctness/empty-with-boolean-expression.php
@@ -1,0 +1,15 @@
+<?php
+
+// ok: empty-with-boolean-expression
+if (!empty($params['name']) && !empty($params['pass'])) {
+}
+// ruleid: empty-with-boolean-expression
+elseif (!empty($params['name'] && !empty($params['pass']))) {
+}
+
+// ok: empty-with-boolean-expression
+if (!empty($params['name']) || !empty($params['pass'])) {
+}
+// ruleid: empty-with-boolean-expression
+elseif (!empty($params['name'] || !empty($params['pass']))) {
+}

--- a/php/lang/correctness/empty-with-boolean-expression.yaml
+++ b/php/lang/correctness/empty-with-boolean-expression.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: empty-with-boolean-expression
+  pattern-either:
+  - pattern: |
+      empty($A && $B)
+  - pattern: |
+      empty($A || $B)
+  message: >-
+    Calling `empty` on a boolean expression may be an indication that a parenthesis is misplaced.
+  metadata:
+    category: correctness
+    technology:
+    - php
+    confidence: LOW
+  languages: [php]
+  severity: WARNING


### PR DESCRIPTION
Detects when:

    empty($foo) && $bar

is accidentally written as

    empty($foo && $bar)