### PR TITLE
Add inputs and steps outputs to github's run-shell-injection rule

### DIFF
--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -129,3 +129,11 @@ jobs:
         # ruleid: run-shell-injection
         run: |
           echo "${{ github.event.discussion.body }}"
+      - name: print input message
+        # ruleid: run-shell-injection
+        run: |
+          echo "${{ inputs.message_to_print }}"
+      - name: Use steps output
+        # ruleid: run-shell-injection
+        run: |
+          echo "${{ steps.shell_command.outputs.some_value }}"

--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -57,4 +57,6 @@ rules:
         - pattern: ${{ github.event.inputs ... }}
         - pattern: ${{ github.event.discussion.title }}
         - pattern: ${{ github.event.discussion.body }}
+        - pattern: ${{ inputs ... }}
+        - pattern: ${{ steps. ... .outputs ...}}
   severity: ERROR


### PR DESCRIPTION
Hey guys

Adding 2 missing injection points (`inputs` and `steps.*.output` for the github actions. 
You can find more documentation about these two context in the [github docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#about-contexts)


Also noticed that `secrets` are being ignored in this rule on purpose (The new `vars` context is also ignored). 
Although these require more permissions that some use cases being flagged by this rule, thinking on these cases from an organization mindset where reusable workflows are provided to be called, inheriting secrets for example can result in shell injections as well. 

In the following example secrets are sent to the reusable workflow which can then have injection. Of course this is all in the same organization so the risk is a bit different

```yaml
uses: MY_ORG/reusable-workflows/deployment.yml
secrets: inherit
```

Happy to open a different PR if you believe these should be addressed
