### PR TITLE
Generically check for loose equal check on hexadecimal strings

### DIFF
--- a/php/lang/security/md5-loose-equality.php
+++ b/php/lang/security/md5-loose-equality.php
@@ -14,3 +14,12 @@ md5("240610708") == md5_file("file.txt");
 
 // ok: md5-loose-equality
 md5("240610708") === "0";
+
+$hash = hash('sha256', 'hello');
+$something = "32";
+
+// ok: md5-loose-equality
+strlen($hash) == $something;
+
+// ruleid: md5-loose-equality
+$hash == $something;

--- a/php/lang/security/md5-loose-equality.yaml
+++ b/php/lang/security/md5-loose-equality.yaml
@@ -1,13 +1,32 @@
 rules:
 - id: md5-loose-equality
-  patterns:
-  - pattern-either:
-    - pattern: $X == $FUNC(...)
-    - pattern: $FUNC(...) == $X
-    - pattern: $FUNC(...) == $FUNC(...)
-  - metavariable-regex:
-      metavariable: $FUNC
-      regex: md5|md5_file
+  mode: taint
+  pattern-sinks:
+    - pattern: |
+        $VAR1 == $VAR2
+    - pattern: |
+        $VAR1 != $VAR2
+  pattern-sources:
+    - pattern: $PHAR->getSignature()
+    - pattern: $RARENTRY->getCrc()
+    - pattern: base_convert(...)
+    - pattern: bin2hex(...)
+    - pattern: dechex(...)
+    - pattern: hash_file(...)
+    - pattern: hash_final(...)
+    - pattern: hash_hmac_file(...)
+    - pattern: hash_hmac(...)
+    - pattern: hash_pbkdf2(...)
+    - pattern: hash(...)
+    - pattern: md5_file(...)
+    - pattern: md5(...)
+    - pattern: openssl_x509_fingerprint(...)
+    - pattern: rnp_locate_key(...)
+    - pattern: sha1_file(...)
+    - pattern: sha1(...)
+    - pattern: sodium_bin2hex(...)
+  pattern-sanitizers:
+    - pattern: strlen(...)
   message: >-
     Make sure comparisons involving md5 values are strict (use `===` not `==`) to
     avoid type juggling issues


### PR DESCRIPTION
Instead of only checking for comparisons containing `md5` or `md5_file`, make a taint mode rule that checks comparisons for all hexadecimal strings.

This PR changes the `md5-loose-equality` rule. However, after the change that rule name is not accurate anymore. Does it make sense to edit that rule, or should this be a new and separate rule?