### PR TITLE
Improve `insecure-load-balancer-tls-version` AWS rule

### DIFF
--- a/terraform/aws/security/insecure-load-balancer-tls-version.tf
+++ b/terraform/aws/security/insecure-load-balancer-tls-version.tf
@@ -137,6 +137,48 @@ resource "aws_alb_listener" "https_fs_1_2" {
   }
 }
 
+resource "aws_alb_listener" "tls_1_3_1_2" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "TLS"
+  port              = "8080"
+  # ok: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
+resource "aws_alb_listener" "tls_1_3_1_2_res" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "TLS"
+  port              = "8080"
+  # ok: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
+resource "aws_alb_listener" "tls_1_3_1_3" {
+  load_balancer_arn = var.aws_lb_arn
+  protocol          = "TLS"
+  port              = "8080"
+  # ok: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-3-2021-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = var.aws_lb_target_group_arn
+  }
+}
+
 resource "aws_lb_target_group" "foo" {
     name = "foo"
     port = 80
@@ -207,12 +249,12 @@ resource "aws_alb_listener" "tls_fs_1_1" {
   }
 }
 
-resource "aws_alb_listener" "tls_1_3" {
+resource "aws_alb_listener" "tls_fs_1_0" {
   load_balancer_arn = var.aws_lb_arn
   protocol          = "TLS"
   port              = "8080"
-  # ok: insecure-load-balancer-tls-version
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-068"
+  # ruleid: insecure-load-balancer-tls-version
+  ssl_policy        = "ELBSecurityPolicy-FS-2018-06"
   certificate_arn   = var.certificate_arn
 
   default_action {

--- a/terraform/aws/security/insecure-load-balancer-tls-version.yaml
+++ b/terraform/aws/security/insecure-load-balancer-tls-version.yaml
@@ -5,7 +5,7 @@ rules:
     - patterns:
       - pattern: ssl_policy = $ANYTHING
       # See: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
-      - pattern-not-regex: "ELBSecurityPolicy-TLS13-1-[23]-[0-9-]+"
+      - pattern-not-regex: "ELBSecurityPolicy-TLS13-1-[23]-[(Res)0-9-]+"
       - pattern-not-regex: "ELBSecurityPolicy-FS-1-2-[(Res)0-9-]+"
     - patterns:
       - pattern: protocol = "HTTP"
@@ -39,8 +39,8 @@ rules:
     Detected an AWS load balancer with an insecure TLS version.
     TLS versions less than 1.2 are considered insecure because they
     can be broken. To fix this, set your `ssl_policy` to
-    `"ELBSecurityPolicy-TLS13-1-2-2021-06"`, or include a default action
-    to redirect to HTTPS.
+    `"ELBSecurityPolicy-TLS13-1-2-Res-2021-06"`, or include a default
+    action to redirect to HTTPS.
   metadata:
     category: security
     technology:


### PR DESCRIPTION
Add support for `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`, which is the most secure TLS 1.2+ policy that AWS ALBs offer. Recommend it as the preferred fix for rule failures.

`ELBSecurityPolicy-TLS13-1-2-Res-2021-06` removes the following (insecure) cipher suites as compared to `ELBSecurityPolicy-TLS13-1-2-2021-06` because they are CBC-based instead of GCM-based:

- ECDHE-ECDSA-AES128-SHA256
- ECDHE-RSA-AES128-SHA256
- ECDHE-ECDSA-AES256-SHA384
- ECDHE-RSA-AES256-SHA384

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html#tls-security-policies

Also, improve/clean-up related test.