### PR TITLE
avoid logging everything

### DIFF
--- a/ruby/rails/security/audit/avoid-logging-everything.rb
+++ b/ruby/rails/security/audit/avoid-logging-everything.rb
@@ -1,0 +1,77 @@
+# ruleid:avoid-logging-everything
+Rails.logger.info(params)
+
+# ruleid:avoid-logging-everything
+Rails.logger.info(params.inspect)
+
+# ruleid:avoid-logging-everything
+Rails.logger.info "my private info :)! #{params}"
+
+# ruleid:avoid-logging-everything
+Rails.logger.info "my private info :)! #{params.inspect}"
+
+# ruleid:avoid-logging-everything
+Rails.logger.info do
+  params
+end
+
+# ruleid:avoid-logging-everything
+Rails.logger.info do
+  params.inspect
+end
+
+# ruleid:avoid-logging-everything
+Rails.logger.info do
+  "my private info :)! #{params}"
+end
+
+# ruleid:avoid-logging-everything
+Rails.logger.info do
+  "my private info :)! #{params.inspect}"
+end
+
+# ruleid:avoid-logging-everything
+Rails.logger.info do
+  params
+end
+
+# ok:avoid-logging-everything
+Rails.logger.info("some static string")
+
+# ok:avoid-logging-everything
+Rails.logger.info(something_that_isnt_params)
+
+# ok:avoid-logging-everything
+Rails.logger.info(params[:a_specific_parameter])
+
+# ok:avoid-logging-everything
+Rails.logger.info("#{params[:a_specific_parameter]}")
+
+# ok:avoid-logging-everything
+Rails.logger.info("not sensitive :( #{params[:a_specific_parameter]}")
+
+# ok:avoid-logging-everything
+Rails.logger.info do
+  "#{not_params} #{still_not_params.inspect} #{params[:test]}"
+end
+
+# ok:avoid-logging-everything
+Rails.logger.info do
+  params[:test]
+end
+
+# ok:avoid-logging-everything
+Rails.logger.debug("go wild #{params} #{params.inspect}")
+
+# ok:avoid-logging-everything
+Rails.logger.debug(params)
+
+# ok:avoid-logging-everything
+Rails.logger.debug do 
+  params
+end
+
+# ok:avoid-logging-everything
+Rails.logger.debug do 
+  params.inspect
+end

--- a/ruby/rails/security/audit/avoid-logging-everything.yaml
+++ b/ruby/rails/security/audit/avoid-logging-everything.yaml
@@ -1,0 +1,50 @@
+rules:
+- id: avoid-logging-everything
+  languages: [ruby]
+  severity: ERROR
+  message: Avoid logging `params` and `params.inspect` as this bypasses Rails filter_parameters and may inadvertently log sensitive data. Instead, reference specific fields to ensure only expected data is logged.
+  metadata:
+    category: security
+    technology:
+      - rails
+    references:
+      - https://guides.rubyonrails.org/configuring.html#config-filter-parameters
+      - https://api.rubyonrails.org/v7.1/classes/ActiveSupport/ParameterFilter.html
+    likelihood: HIGH
+    impact: MEDIUM
+    confidence: HIGH
+    subcategory:
+      - audit
+  patterns:
+    - pattern-either:
+      - pattern: Rails.logger.$METHOD(params)
+      - pattern: Rails.logger.$METHOD("...#{params}...")
+      - pattern: Rails.logger.$METHOD(params.inspect)
+      - pattern: Rails.logger.$METHOD("...#{params.inspect}...")
+      - pattern: |
+          Rails.logger.$METHOD do
+            "...#{params}..."
+          end
+      - pattern: |
+          Rails.logger.$METHOD do
+            "...#{params.inspect}..."
+          end
+      - pattern: |
+          Rails.logger.$METHOD do
+            params
+          end
+      - pattern: |
+          Rails.logger.$METHOD do
+            params.inspect
+          end
+    - pattern-not: |
+        Rails.logger.$METHOD do
+          params[...]
+        end
+    - pattern-not: |
+        Rails.logger.$METHOD do
+          "#{params.inspect[...]}"
+        end
+    - metavariable-regex:
+        metavariable: $METHOD
+        regex: (info|warn|error|fatal|unknown)


### PR DESCRIPTION
This pull request adds a new ruby/rails semgrep rule, avoid-logging-everything. This intends to flag scenarios where params and params.inspect are logged. Sending either of these into Rails.logger casts them into strings which bypasses Rails' built in parameter filtering. This currently looks at all log levels except debug (info, warn, error, fatal, unknown). I excluded debug since in production, Rails.logger.debug is a no op.