### PR TITLE
Fix jwt issue

### DIFF
--- a/python/jwt/security/jwt-hardcode.yaml
+++ b/python/jwt/security/jwt-hardcode.yaml
@@ -24,9 +24,6 @@ rules:
     confidence: HIGH
   patterns:
   - pattern: |
-      jwt.encode($X, $SECRET, ...)
-  - focus-metavariable: $SECRET
-  - pattern: |
-      "..."
+      jwt.encode($_, "...", ...)
   languages: [python]
   severity: ERROR


### PR DESCRIPTION
With the focus-metavariable it was leading to matching strings inside non string code blocks.