### PR TITLE
bump Ubuntu version in Github actions

### DIFF
--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   semgrep:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: semgrep-rule-lints
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9.2
+          python-version: 3.10
       - name: install semgrep
         run: pip3 install semgrep
       - name: lints for semgrep rules

--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: install semgrep
         run: pip3 install semgrep
       - name: lints for semgrep rules

--- a/.github/workflows/semgrep-rule-lints.yaml
+++ b/.github/workflows/semgrep-rule-lints.yaml
@@ -11,7 +11,7 @@ jobs:
     name: semgrep-rule-lints
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9.2
       - name: install semgrep

--- a/.github/workflows/semgrep-rules-test-develop.yml
+++ b/.github/workflows/semgrep-rules-test-develop.yml
@@ -16,7 +16,7 @@ jobs:
     name: rules-test-develop
     # alt: use directly the semgrep/semgrep:pro-develop container here so we
     # don't need the calls to 'docker run ...' below
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # TODO: remove the with: path: below to simplify
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/semgrep-rules-test-historical.yml
+++ b/.github/workflows/semgrep-rules-test-historical.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9.2
+          python-version: 3.10
       - name: Find merge base with develop
         id: merge_base
         run: echo "BASE_COMMIT=$(git -C semgrep-rules merge-base origin/develop HEAD)" >> $GITHUB_ENV

--- a/.github/workflows/semgrep-rules-test-historical.yml
+++ b/.github/workflows/semgrep-rules-test-historical.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-historical:
     name: rules-test-historical
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/semgrep-rules-test-historical.yml
+++ b/.github/workflows/semgrep-rules-test-historical.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: semgrep-rules
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9.2
       - name: Find merge base with develop

--- a/.github/workflows/semgrep-rules-test-historical.yml
+++ b/.github/workflows/semgrep-rules-test-historical.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Find merge base with develop
         id: merge_base
         run: echo "BASE_COMMIT=$(git -C semgrep-rules merge-base origin/develop HEAD)" >> $GITHUB_ENV

--- a/.github/workflows/semgrep-rules-test.yml
+++ b/.github/workflows/semgrep-rules-test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test-latest:
     name: rules-test-latest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/semgrep-rules-test.yml
+++ b/.github/workflows/semgrep-rules-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: 3.9.2
     - name: install semgrep via pip

--- a/.github/workflows/semgrep-rules-test.yml
+++ b/.github/workflows/semgrep-rules-test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.9.2
+        python-version: 3.10
     - name: install semgrep via pip
       run: pip3 install semgrep
     - name: remove stats directory

--- a/.github/workflows/semgrep-rules-test.yml
+++ b/.github/workflows/semgrep-rules-test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: install semgrep via pip
       run: pip3 install semgrep
     - name: remove stats directory

--- a/.github/workflows/trigger-pro-benchmark-scan.yaml
+++ b/.github/workflows/trigger-pro-benchmark-scan.yaml
@@ -11,7 +11,7 @@ jobs:
     # do not run automatically if rule is posted from the playground (can still be started manually)
     # PRs posted by first time contributors already need approval as well
     if: github.actor != 'semgrep-dev-pr-bot'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - id: trigger-run
         name: Trigger semgrep-rules-pro benchmarking argo workflow on PR/push to develop or release

--- a/.github/workflows/trigger-semgrep-scanner-initiate-scan.yaml
+++ b/.github/workflows/trigger-semgrep-scanner-initiate-scan.yaml
@@ -11,7 +11,7 @@ jobs:
     # do not run automatically if rule is posted from the playground (can still be started manually)
     # PRs posted by first time contributors already need approval as well
     if: github.actor != 'semgrep-dev-pr-bot'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/validate-r2c-registry-metadata.yaml
+++ b/.github/workflows/validate-r2c-registry-metadata.yaml
@@ -34,7 +34,7 @@ jobs:
         run: echo $CHANGED_FILES
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9.2
+          python-version: 3.10
       - name: install deps
         run: pip install jsonschema pyyaml
       - name: validate metadata

--- a/.github/workflows/validate-r2c-registry-metadata.yaml
+++ b/.github/workflows/validate-r2c-registry-metadata.yaml
@@ -32,7 +32,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.CHANGED_FILES }}
         name: debugging step - print changed files
         run: echo $CHANGED_FILES
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.9.2
       - name: install deps

--- a/.github/workflows/validate-r2c-registry-metadata.yaml
+++ b/.github/workflows/validate-r2c-registry-metadata.yaml
@@ -15,7 +15,7 @@ jobs:
   validate-metadata:
     if: github.repository == 'semgrep/semgrep-rules'
     name: Validate r2c registry metadata
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/validate-r2c-registry-metadata.yaml
+++ b/.github/workflows/validate-r2c-registry-metadata.yaml
@@ -34,7 +34,7 @@ jobs:
         run: echo $CHANGED_FILES
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: install deps
         run: pip install jsonschema pyyaml
       - name: validate metadata


### PR DESCRIPTION
Github actions stopped working because `Ubuntu-20.04` is no longer supported :disappointed:  [link](https://github.com/actions/runner-images/issues/11101)
```
This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101
```