### PR TITLE
Add hcl and tf to gitleaks rule manually 

### DIFF
--- a/generic/secrets/gitleaks/hashicorp-tf-password.yaml
+++ b/generic/secrets/gitleaks/hashicorp-tf-password.yaml
@@ -4,6 +4,10 @@ rules:
   languages:
     - regex
   severity: INFO
+  paths:
+    include:
+      - "*.tf"
+      - "*.hcl"
   metadata:
       likelihood: LOW
       impact: MEDIUM


### PR DESCRIPTION
Fixes issue https://github.com/semgrep/semgrep-rules/issues/3586 in next few weeks will look at adding it into the automated pipeline, but for now just add it manually