### PR TITLE
Update C# stack-disclosure rule with a syntax variation

### DIFF
--- a/csharp/lang/security/stacktrace-disclosure.cs
+++ b/csharp/lang/security/stacktrace-disclosure.cs
@@ -31,3 +31,17 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
             // ok: stacktrace-disclosure
             app.UseDeveloperExceptionPage();
 }
+
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+        if (env.EnvironmentName == "NotDevelopment")
+            // ruleid: stacktrace-disclosure
+            app.UseDeveloperExceptionPage();
+}
+
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+        if (env.EnvironmentName == "Development")
+            // ok: stacktrace-disclosure
+            app.UseDeveloperExceptionPage();
+}

--- a/csharp/lang/security/stacktrace-disclosure.yaml
+++ b/csharp/lang/security/stacktrace-disclosure.yaml
@@ -6,6 +6,10 @@ rules:
       if ($ENV.IsDevelopment(...)) {
         ...
       }
+  - pattern-not-inside: |
+      if ($ENV.EnvironmentName == "Development") {
+        ...
+      }
   message: >-
     Stacktrace information is displayed in a non-Development environment.
     Accidentally disclosing sensitive stack trace information in a production


### PR DESCRIPTION
Based on a false positive report from a customer (thank you!). [Docs for](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.hostenvironmentenvextensions.isdevelopment?view=net-9.0-pp#microsoft-extensions-hosting-hostenvironmentenvextensions-isdevelopment(microsoft-extensions-hosting-ihostenvironment)) `isDevelopment`:

> returns true if the environment name is [Development](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.environments.development?view=net-9.0-pp#microsoft-extensions-hosting-environments-development), otherwise false.