### PR TITLE
Update format of SQL alchemy functions in rule message

### DIFF
--- a/python/sqlalchemy/security/audit/avoid-sqlalchemy-text.yaml
+++ b/python/sqlalchemy/security/audit/avoid-sqlalchemy-text.yaml
@@ -34,7 +34,7 @@ rules:
             type: string
   message: sqlalchemy.text passes the constructed SQL statement to the database mostly unchanged. This
     means that the usual SQL injection protections are not applied and this function is vulnerable to
-    SQL injection if user input can reach here. Use normal SQLAlchemy operators (such as or_, and_, etc.)
+    SQL injection if user input can reach here. Use normal SQLAlchemy operators (such as `or_()`, `and_()`, etc.)
     to construct SQL.
   metadata:
     owasp:


### PR DESCRIPTION
The rule message contains reference to the SQL Alchemy functions and_ and or_. The formatting does not make it clear that they are functions. 

This change adds the parenthesis to the function names and_ -> and_() and uses the markdown syntax to denote them as code `and_()`. This new formatting is consistent with [the SQL Alchemy docs](https://docs.sqlalchemy.org/en/20/core/sqlelement.html#sqlalchemy.sql.expression.and_).