### PR TITLE
Update dockerfile.security.missing-user

### DIFF
--- a/dockerfile/security/missing-user.yaml
+++ b/dockerfile/security/missing-user.yaml
@@ -19,7 +19,7 @@ rules:
     - dockerfile
   metadata:
     cwe:
-    - 'CWE-269: Improper Privilege Management'
+    - 'CWE-250: Execution with Unnecessary Privileges'
     category: security
     technology:
     - dockerfile


### PR DESCRIPTION
Due to improved checks both in the engine and CI, some older rules are now failing CI due to unmappable or discouraged CWE associations.

This PR updates the CWE mapping to a mappable CWE that is relevant to the rule: https://cwe.mitre.org/data/definitions/250.html