### PR TITLE
a fix of issue 3376

### DIFF
--- a/php/lang/security/injection/tainted-sql-string.php
+++ b/php/lang/security/injection/tainted-sql-string.php
@@ -31,6 +31,14 @@ function test4() {
     return $info;
 }
 
+function test5() {
+    // ruleid: tainted-sql-string
+    $query = "
+    SELECT * FROM table WHERE Id = '".$_GET['url']."'";
+    $info = mysql_query($query);
+    return $info;
+}
+
 // True Negatives
 
 function test1() {

--- a/php/lang/security/injection/tainted-sql-string.yaml
+++ b/php/lang/security/injection/tainted-sql-string.yaml
@@ -46,16 +46,16 @@ rules:
           sprintf($SQLSTR, ...)
       - metavariable-regex:
           metavariable: $SQLSTR
-          regex: .*\b(?i)(select|delete|insert|create|update|alter|drop)\b.*
+          regex: (?is).*\b(select|delete|insert|create|update|alter|drop)\b.*
     - patterns:
       - pattern: |
           "...$EXPR..."
       - metavariable-regex:
           metavariable: $EXPR
-          regex: .*\b(?i)(select|delete|insert|create|update|alter|drop)\b.*
+          regex: (?is).*\b(select|delete|insert|create|update|alter|drop)\b.*
     - patterns:
       - pattern: |
           "$SQLSTR".$EXPR
       - metavariable-regex:
           metavariable: $SQLSTR
-          regex: .*\b(?i)(select|delete|insert|create|update|alter|drop)\b.*
+          regex: (?is).*\b(select|delete|insert|create|update|alter|drop)\b.*


### PR DESCRIPTION
add (?s) to allow `.` match '\n'