### PR TITLE
Adjust severity downward for AWS account ID

### DIFF
--- a/generic/secrets/security/detected-aws-account-id.yaml
+++ b/generic/secrets/security/detected-aws-account-id.yaml
@@ -35,7 +35,7 @@ rules:
       to use them and share them carefully. For that reason it would be preferrable avoiding to
       hardcoded it here. Instead, read the value from an environment variable or
       keep the value in a separate, private file.
-    severity: ERROR
+    severity: INFO
     metadata:
       cwe:
         - "CWE-798: Use of Hard-coded Credentials"
@@ -54,4 +54,4 @@ rules:
       subcategory:
         - audit
       likelihood: LOW
-      impact: HIGH
+      impact: LOW


### PR DESCRIPTION
AWS account IDs are not in themselves sensitive (which the rule mentions). Therefore having the severity or impact of the rule be ERROR/HIGH does not seem appropriate. I've lowered it to INFO/LOW.