### PR TITLE
chore: fix ts rule

### DIFF
--- a/javascript/argon2/security/unsafe-argon2-config.yaml
+++ b/javascript/argon2/security/unsafe-argon2-config.yaml
@@ -44,4 +44,3 @@ rules:
   - patterns:
     - pattern: |
         {type: $ARGON.argon2id}
-        ...


### PR DESCRIPTION
the sanitizer wasn't matching what the rule-writer actually wanted. in the new TS parser, this is actually an invalid pattern