### PR TITLE
Docker audit rule for `pip install` with `--extra-index-url`

### DIFF
--- a/dockerfile/audit/dockerfile-pip-extra-index-url.dockerfile
+++ b/dockerfile/audit/dockerfile-pip-extra-index-url.dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.10.1-alpine3.15@sha256:4be65b406f7402b5c4fd5df7173d2fd7ea3fdaa74d9c43b6ebd896197a45c448
+
+RUN pip install model_lstm==${API_MODEL_LSTM_VERSION} \
+    --index-url https://${FURY_TOKEN}@pypi.fury.io/${FURY_USERNAME}/ \
+    --extra-index-url https://pypi.org/simple/
+
+
+RUN --mount=type=secret,id=pip_index_url \
+    pip install --extra-index-url "$(cat /run/secrets/pip_index_url)" -r full_requirements.txt --no-cache-dir
+
+
+RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir \
+                 --extra-index-url https://artifactory.algol60.net/artifactory/csm-python-modules/simple \
+                 --trusted-host artifactory.algol60.net -r requirements.txt

--- a/dockerfile/audit/dockerfile-pip-extra-index-url.dockerfile
+++ b/dockerfile/audit/dockerfile-pip-extra-index-url.dockerfile
@@ -1,14 +1,17 @@
 FROM python:3.10.1-alpine3.15@sha256:4be65b406f7402b5c4fd5df7173d2fd7ea3fdaa74d9c43b6ebd896197a45c448
 
+# ruleid: dockerfile-pip-extra-index-url
 RUN pip install model_lstm==${API_MODEL_LSTM_VERSION} \
     --index-url https://${FURY_TOKEN}@pypi.fury.io/${FURY_USERNAME}/ \
     --extra-index-url https://pypi.org/simple/
 
 
+# ruleid: dockerfile-pip-extra-index-url
 RUN --mount=type=secret,id=pip_index_url \
     pip install --extra-index-url "$(cat /run/secrets/pip_index_url)" -r full_requirements.txt --no-cache-dir
 
 
+# ruleid: dockerfile-pip-extra-index-url
 RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir \
                  --extra-index-url https://artifactory.algol60.net/artifactory/csm-python-modules/simple \
                  --trusted-host artifactory.algol60.net -r requirements.txt

--- a/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
+++ b/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
@@ -20,5 +20,8 @@ rules:
     references:
     category: security
     subcategory: audit
+    confidence: MEDIUM
+    impact: HIGH
+    likelihood: LOW
     technology:
     - docker

--- a/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
+++ b/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
@@ -1,0 +1,23 @@
+rules:
+- id: dockerfile-pip-extra-index-url
+  patterns:
+    - pattern: |
+        RUN ... $PIP install ... --extra-index-url ...
+    - metavariable-regex:
+        metavariable: $PIP
+        regex: pip|pip3
+  message: >- 
+    When `--extra-index-url` is used in a `pip install` command, this is usually meant to 
+    install a package from a package index other than the public one. 
+    However, if a package is added with the same name
+    to the public PyPi repository, and if the version number is high enough, this package will
+    be installed when building this docker image. This package may be a malicious dependency.
+    If using a private package index, prefer to use `--index-url` if possible. 
+  languages:
+  - dockerfile
+  severity: INFO
+  metadata:
+    references:
+    category: best-practice
+    technology:
+    - docker

--- a/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
+++ b/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
@@ -18,6 +18,7 @@ rules:
   severity: INFO
   metadata:
     references:
-    category: best-practice
+    category: security
+    subcategory: audit
     technology:
     - docker

--- a/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
+++ b/dockerfile/audit/dockerfile-pip-extra-index-url.yaml
@@ -12,16 +12,22 @@ rules:
     However, if a package is added with the same name
     to the public PyPi repository, and if the version number is high enough, this package will
     be installed when building this docker image. This package may be a malicious dependency.
+    Such an attack is called a dependency confusion attack.
     If using a private package index, prefer to use `--index-url` if possible. 
   languages:
   - dockerfile
   severity: INFO
   metadata:
     references:
+      - https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-extra-index-url 
+      - https://github.com/semgrep/semgrep-rules/issues/3032
     category: security
-    subcategory: audit
+    subcategory: 
+      - audit
     confidence: MEDIUM
     impact: HIGH
     likelihood: LOW
     technology:
     - docker
+    cwe:
+      - "CWE-427: Uncontrolled Search Path Element"


### PR DESCRIPTION
Fixes https://github.com/semgrep/semgrep-rules/issues/3032