### PR TITLE
Ensure paths.include patterns are as intended ahead of semgrep fixes

### DIFF
--- a/generic/nginx/security/alias-path-traversal.yaml
+++ b/generic/nginx/security/alias-path-traversal.yaml
@@ -14,8 +14,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   fix-regex:
     regex: location\s+([A-Za-z0-9/-_\.]+)
     replacement: location \1/

--- a/generic/nginx/security/dynamic-proxy-host.yaml
+++ b/generic/nginx/security/dynamic-proxy-host.yaml
@@ -4,8 +4,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: WARNING

--- a/generic/nginx/security/dynamic-proxy-scheme.yaml
+++ b/generic/nginx/security/dynamic-proxy-scheme.yaml
@@ -4,8 +4,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: WARNING

--- a/generic/nginx/security/header-injection.yaml
+++ b/generic/nginx/security/header-injection.yaml
@@ -10,8 +10,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: ERROR

--- a/generic/nginx/security/header-redefinition.yaml
+++ b/generic/nginx/security/header-redefinition.yaml
@@ -18,8 +18,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: WARNING

--- a/generic/nginx/security/insecure-redirect.yaml
+++ b/generic/nginx/security/insecure-redirect.yaml
@@ -11,8 +11,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   message: >-
     Detected an insecure redirect in this nginx configuration.
     If no scheme is specified, nginx will forward the request with the

--- a/generic/nginx/security/insecure-ssl-version.yaml
+++ b/generic/nginx/security/insecure-ssl-version.yaml
@@ -10,8 +10,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: WARNING

--- a/generic/nginx/security/missing-internal.yaml
+++ b/generic/nginx/security/missing-internal.yaml
@@ -23,8 +23,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: WARNING

--- a/generic/nginx/security/missing-ssl-version.yaml
+++ b/generic/nginx/security/missing-ssl-version.yaml
@@ -7,8 +7,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: WARNING

--- a/generic/nginx/security/possible-h2c-smuggling.yaml
+++ b/generic/nginx/security/possible-h2c-smuggling.yaml
@@ -41,8 +41,8 @@ rules:
     include:
     - '*.conf'
     - '*.vhost'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   metadata:
     cwe:
     - "CWE-444: Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')"

--- a/generic/nginx/security/request-host-used.yaml
+++ b/generic/nginx/security/request-host-used.yaml
@@ -8,8 +8,8 @@ rules:
     - '*conf*'
     - '*nginx*'
     - '*vhost*'
-    - sites-available/*
-    - sites-enabled/*
+    - '**/sites-available/*'
+    - '**/sites-enabled/*'
   languages:
   - generic
   severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-ajax-no-auth-and-auth-hooks-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-ajax-no-auth-and-auth-hooks-audit.yaml
@@ -11,7 +11,7 @@ rules:
       "wp_ajax_nopriv_$action" hook get fires for non-authenticated users.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-authorisation-checks-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-authorisation-checks-audit.yaml
@@ -10,7 +10,7 @@ rules:
       the authorisation is proper or not.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-code-execution-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-code-execution-audit.yaml
@@ -11,7 +11,7 @@ rules:
       properly before passing it to these functions.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-command-execution-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-command-execution-audit.yaml
@@ -12,7 +12,7 @@ rules:
       properly before passing it to these functions.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-csrf-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-csrf-audit.yaml
@@ -6,7 +6,7 @@ rules:
       cause the script to die, making the check useless.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-file-download-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-file-download-audit.yaml
@@ -11,7 +11,7 @@ rules:
       data properly before passing it to these functions.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-file-inclusion-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-file-inclusion-audit.yaml
@@ -13,7 +13,7 @@ rules:
       properly before passing it to these functions.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - "'**/wp-content/plugins/**/*.php'"
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-file-manipulation-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-file-manipulation-audit.yaml
@@ -9,7 +9,7 @@ rules:
       functions are user controlled. Use these functions carefully.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-open-redirect-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-open-redirect-audit.yaml
@@ -7,7 +7,7 @@ rules:
       vulnerabilities. Use "wp_safe_redirect()" to prevent this kind of attack.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-php-object-injection-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-php-object-injection-audit.yaml
@@ -10,7 +10,7 @@ rules:
       these function with user-supplied input, use JSON functions instead.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-sql-injection-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-sql-injection-audit.yaml
@@ -20,7 +20,7 @@ rules:
       properly.
     paths:
       include:
-        - wp-content/plugins/**/*.php
+        - '**/wp-content/plugins/**/*.php'
     languages:
       - php
     severity: WARNING

--- a/php/wordpress-plugins/security/audit/wp-ssrf-audit.yaml
+++ b/php/wordpress-plugins/security/audit/wp-ssrf-audit.yaml
@@ -28,7 +28,7 @@ rules:
         - pattern: wp_safe_remote_post($URL, ...)
   paths:
     include:
-    - wp-content/plugins/**/*.php
+    - '**/wp-content/plugins/**/*.php'
   metadata:
     cwe: 'CWE-918: Server-Side Request Forgery (SSRF)'
     owasp: A10:2021 - Server-Side Request Forgery (SSRF)

--- a/yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches.yml
+++ b/yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches.yml
@@ -8,7 +8,7 @@ rules:
       - yaml
     paths:
       include:
-        - ".github/workflows/semgrep.yml"
+        - "/.github/workflows/semgrep.yml"
         - "*.test.yml"
     patterns:
       - pattern-either:


### PR DESCRIPTION
We're aligning paths.include/exclude behavior with Semgrepignore v2 which follows the Gitignore spec. In particular:

* The glob patterns found in rules are now applied to the path relative to the project root.
* A glob pattern that contains a slash between two segments is now left-anchored i.e. it's the same as if it were starting with a slash as per the Gitignore spec. In these cases, the leading slash is optional but I'm adding it to make the intention clearer to readers.

Examples of affected patterns include `a/b` and `a/*` but not `a/**`. I identified 4 kinds of rules that had such patterns in this repo:
- Wordpress: include `wp-content/plugins` -> `**/wp-content/plugins`
- Nginx: include `sites-available/*` -> `**/sites-available/*`
- GitHub Actions: include `.github/workflows` -> `/.github/workflows`
- 4 rules that exclude `*/openssl/*.h` -> unchanged (equivalent to `/*/openssl/*.h`)

I'm confident that the GitHub Actions folder is only at the Git project root. I'm not sure about Wordpress or Nginx projects, so I'm erring on the side of caution by prepending `**/` to these include patterns. For exclude patterns, caution means excluding less rather than more and keeping the patterns anchored.

For the record, here's the command I used to find these patterns:
```
find . | grep -P '(\.yml|\.yaml)$' | xargs yq '.rules[].paths.include[]' | grep -P './.'
```

Update: I'm just realizing that `**/sites-available/*` is equivalent to `sites-available/` (but not equivalent to the original `sites-available/*`). Not sure which form should be preferred:

* `**/sites-available/*` is more complicated than needed but more obvious.
* `sites-available/` is the simplest pattern but will become anchored if someone appends `/*` or `/whatever`.
* `**/sites-available/` would work too. This is may be the best form.

:man_shrugging: 

Note that if the intention is to scan `xxx/sites-available/a` but not `xxx/sites-available/a/b`, we also need the exclude pattern `**/sites-available/*/` or equivalent.