### PR TITLE
Disambiguate exclude patterns to avoid upcoming warnings

### DIFF
--- a/generic/secrets/gitleaks/generic-api-key.yaml
+++ b/generic/secrets/gitleaks/generic-api-key.yaml
@@ -38,7 +38,7 @@ rules:
       - "*bundle.js"
       - "*pnpm-lock*"
       - "*Podfile.lock"
-      - "*/openssl/*.h"
+      - "**/*/openssl/*.h"
       - "*.xcscmblueprint"
   patterns:
     # The original regex from gitleaks is in this rule https://semgrep.dev/playground/s/57qk (but its very noisy) even with our entropy analyzer

--- a/generic/secrets/security/detected-artifactory-password.yaml
+++ b/generic/secrets/security/detected-artifactory-password.yaml
@@ -21,7 +21,7 @@ rules:
         - "*bundle.js"
         - "*pnpm-lock*"
         - "*Podfile.lock"
-        - "*/openssl/*.h"
+        - "**/*/openssl/*.h"
         - "*.xcscmblueprint"
     message: Artifactory token detected
     severity: ERROR

--- a/generic/secrets/security/detected-artifactory-token.yaml
+++ b/generic/secrets/security/detected-artifactory-token.yaml
@@ -16,7 +16,7 @@ rules:
       - "*bundle.js"
       - "*pnpm-lock*"
       - "*Podfile.lock"
-      - "*/openssl/*.h"
+      - "**/*/openssl/*.h"
       - "*.xcscmblueprint"
       - "*cargo.lock"
   message: Artifactory token detected

--- a/generic/secrets/security/detected-sonarqube-docs-api-key.yaml
+++ b/generic/secrets/security/detected-sonarqube-docs-api-key.yaml
@@ -16,7 +16,7 @@ rules:
       - "*bundle.js"
       - "*pnpm-lock*"
       - "*Podfile.lock"
-      - "*/openssl/*.h"
+      - "**/*/openssl/*.h"
       - "*.xcscmblueprint"
   metadata:
     cwe:


### PR DESCRIPTION
1. Avoid upcoming warnings about unanchored patterns that will become anchored. These are paths.include and paths.exclude glob patterns containing a middle slash but not starting with `**` or `/`.
2. Ensure we preserve the current behavior when the implementation changes at the end of the deprecation period.

I already submitted a similar PR a few days ago (#3630) but it only took care of the includes. Since then, we've decided to emit a warning for all include and exclude patterns that will become anchored after a deprecation. This PR addresses excludes.