### PR TITLE
Fix csharp-sqli sanitizers

### DIFF
--- a/csharp/lang/security/sqli/csharp-sqli.yaml
+++ b/csharp/lang/security/sqli/csharp-sqli.yaml
@@ -28,9 +28,13 @@ rules:
     pattern-sanitizers:
       - pattern-either:
           - pattern: |
-              $CMD.Parameters.add(...)
+              $CMD.Parameters.Add(...)
           - pattern: |
-              $CMD.Parameters[$IDX] = ...
+              $CMD.Parameters.AddRange(...)
+          - pattern: |
+              $CMD.Parameters.AddWithValue(...)
+          - pattern: |
+              $CMD.Parameters[$IDX].Value = ...
         by-side-effect: true
     message: Detected a formatted string in a SQL statement. This could lead to SQL
       injection if variables in the SQL statement are not properly sanitized.


### PR DESCRIPTION
Hi,

Currently, the `csharp-sqli` pattern-sanitizers do not work correctly.

See existing examples of sanitizer usage:
https://github.com/semgrep/semgrep-rules/blob/develop/csharp/lang/security/sqli/csharp-sqli.cs#L178-L179


Also added additional methods:
https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlparametercollection.addrange
https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlparametercollection.addwithvalue

before fix
<img width="2302" height="1360" alt="1_before" src="https://github.com/user-attachments/assets/2a67820c-2655-42a8-b3b8-cffd58ceb673" />

after fix
<img width="2316" height="1418" alt="2_after" src="https://github.com/user-attachments/assets/6a2d1d15-bf55-44c4-afbc-27e245cc2560" />