### PR TITLE
Fix typo in express-jwt-not-revoked.yaml `asvs: control_id:`

### DIFF
--- a/javascript/express/security/audit/express-jwt-not-revoked.yaml
+++ b/javascript/express/security/audit/express-jwt-not-revoked.yaml
@@ -13,7 +13,7 @@ rules:
     source-rule-url: https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/security/expirejwt.md
     asvs:
       section: 'V3: Session Management Verification Requirements'
-      control_id: 3.5.3 Insecue Stateless Session Tokens
+      control_id: 3.5.3 Insecure Stateless Session Tokens
       control_url: https://github.com/OWASP/ASVS/blob/master/4.0/en/0x12-V3-Session-management.md#v35-token-based-session-management
       version: '4'
     category: security


### PR DESCRIPTION
Simple typofix: `Insecue` > `Insecure`