### PR TITLE
fix(java): formatted-sql-string Java rule had incorrect mvar-focus 

### DIFF
--- a/java/lang/security/audit/formatted-sql-string.java
+++ b/java/lang/security/audit/formatted-sql-string.java
@@ -143,3 +143,13 @@ public class FalsePositiveCase {
         return students;
     }
 }
+
+public class SqlExampleFocusMetavar {
+    public void get(HttpServletRequest req) {
+        Connection c = DB.getConnection();
+        String p = req.getParam("param");
+        PreparedStatement statement = c.prepareStatment("SELECT * FROM " + p);
+        // ruleid: formatted-sql-string
+        ResultSet rs = statement.executeQuery();
+    }
+}

--- a/java/lang/security/audit/formatted-sql-string.yaml
+++ b/java/lang/security/audit/formatted-sql-string.yaml
@@ -46,7 +46,7 @@ rules:
               ...
             }
         - pattern: (String $INPUT)
-    - focus-metavariable: $INPUT
+        - focus-metavariable: $INPUT
     label: INPUT
   - patterns:
     - pattern-either:


### PR DESCRIPTION
The metavariable-focus was not correctly scoped to a `patterns` key, causing it to drop valid findings outside of the either case where the `$INPUT` variable was not present.