### PR TITLE
Add observability rule for metrics name changes

### DIFF
--- a/observability/metrics/metric-name-change.js
+++ b/observability/metrics/metric-name-change.js
@@ -1,0 +1,60 @@
+// Test file for metric-name-change rule
+// This file contains test cases with true positives and true negatives
+
+// ===== TRUE POSITIVES (should trigger the rule) =====
+
+// ruleid: observability.metrics.metric-name-change
+metrics.counter("user_login_count", 1);
+
+// ruleid: observability.metrics.metric-name-change
+prometheus.Counter({name: "http_requests_total", help: "Total HTTP requests"});
+
+// ruleid: observability.metrics.metric-name-change
+statsd.increment("page_views", 1);
+
+// ruleid: observability.metrics.metric-name-change
+statsd.counter("api_calls", 5);
+
+// ruleid: observability.metrics.metric-name-change
+client.increment("user_registrations", 1, {tags: ["success"]});
+
+// ruleid: observability.metrics.metric-name-change
+meter.counter("database_queries", queryCount);
+
+// ===== TRUE NEGATIVES (should NOT trigger the rule) =====
+
+// ok: observability.metrics.metric-name-change
+const userCount = 42;
+
+// ok: observability.metrics.metric-name-change
+logger.info("User logged in successfully");
+
+// ok: observability.metrics.metric-name-change
+const metricName = "user_login_count";
+
+// ok: observability.metrics.metric-name-change
+console.log("Processing metrics");
+
+// ok: observability.metrics.metric-name-change
+function incrementCounter(name, value) {
+  return name + value;
+}
+
+// ok: observability.metrics.metric-name-change
+db.query("SELECT COUNT(*) FROM users");
+
+// ok: observability.metrics.metric-name-change
+const config = {
+  metrics: {
+    enabled: true,
+    port: 9090
+  }
+};
+
+// ok: observability.metrics.metric-name-change
+// This is just a comment about metrics.counter("test")
+
+// ok: observability.metrics.metric-name-change
+const obj = {
+  counter: function(name) { return name; }
+};

--- a/observability/metrics/metric-name-change.yaml
+++ b/observability/metrics/metric-name-change.yaml
@@ -1,0 +1,34 @@
+rules:
+  - id: observability.metrics.metric-name-change
+    message: "Metric name change detected - verify dashboards and alerts are updated before deploying"
+    severity: WARNING
+    languages: [javascript, typescript, python, go]
+    patterns:
+      - pattern-either:
+        - pattern: |
+            metrics.counter("$METRIC_NAME", ...)
+        - pattern: |
+            prometheus.Counter({name: "$METRIC_NAME", ...})
+        - pattern: |
+            statsd.increment("$METRIC_NAME", ...)
+        - pattern: |
+            statsd.counter("$METRIC_NAME", ...)
+        - pattern: |
+            client.increment("$METRIC_NAME", ...)
+        - pattern: |
+            meter.counter("$METRIC_NAME", ...)
+    metadata:
+      category: observability
+      subcategory: metrics
+      impact: dashboard-breaking
+      confidence: MEDIUM
+      likelihood: MEDIUM
+      technology:
+        - metrics
+        - monitoring
+        - observability
+      references:
+        - https://prometheus.io/docs/practices/naming/
+        - https://grafana.com/docs/grafana/latest/dashboards/
+      cwe:
+        - "CWE-778: Insufficient Logging"


### PR DESCRIPTION
 ## Summary
  Add observability rule to detect metric name changes that could break
  production dashboards and alerts.

  ## Rule Details
  - **ID**: `observability.metrics.metric-name-change`
  - **Severity**: WARNING
  - **Languages**: JavaScript, TypeScript, Python, Go
  - **Purpose**: Flags when developers change metric names, requiring
  dashboard/alert updates

  ## Test Cases
  - 6 true positives (detects various metric patterns)
  - 9 true negatives (ignores non-metric code)

  ## Use Case
  Prevents production monitoring breakage when developers refactor metric
  names without updating:
  - Grafana dashboards
  - Alert rules
  - SLA monitoring

  ## Example Detection
  ```javascript
  // This would be flagged for review:
  metrics.counter("user_login_count", 1);
  prometheus.Counter({name: "http_requests_total", help: "..."});
  statsd.increment("page_views", 1);

  Impact

  Helps teams catch observability breaking changes in CI before they reach
  production, preventing monitoring blind spots.