### PR TITLE
Update argo workflow injection rule

### DIFF
--- a/yaml/argo/security/argo-workflow-parameter-command-injection.test.yaml
+++ b/yaml/argo/security/argo-workflow-parameter-command-injection.test.yaml
@@ -39,7 +39,7 @@ spec:
         # ruleid: argo-workflow-parameter-command-injection
         source: |
           print("{{inputs.parameters.message}}")
-      script:
+    - script:
         name: ''
         image: node:9.1-alpine
         command:
@@ -49,7 +49,7 @@ spec:
         source: |
           var rand = Math.floor(Math.random() * 100);
           console.log("{{inputs.parameters.message}}");
-      script:
+    - script:
         name: ''
         image: ruby:3.0
         command:

--- a/yaml/argo/security/argo-workflow-parameter-command-injection.test.yaml
+++ b/yaml/argo/security/argo-workflow-parameter-command-injection.test.yaml
@@ -39,6 +39,25 @@ spec:
         # ruleid: argo-workflow-parameter-command-injection
         source: |
           print("{{inputs.parameters.message}}")
+      script:
+        name: ''
+        image: node:9.1-alpine
+        command:
+          - node
+        resources: {}
+        # ruleid: argo-workflow-parameter-command-injection
+        source: |
+          var rand = Math.floor(Math.random() * 100);
+          console.log("{{inputs.parameters.message}}");
+      script:
+        name: ''
+        image: ruby:3.0
+        command:
+          - ruby
+        resources: {}
+        # ruleid: argo-workflow-parameter-command-injection
+        source: |
+          puts "{{inputs.parameters.message}}"
     - name: print-message-args
       inputs:
         parameters:
@@ -48,6 +67,41 @@ spec:
         command: [sh, -c]
         # ruleid: argo-workflow-parameter-command-injection
         args: ["echo result was: {{inputs.parameters.message}}"]
+    - name: print-message-python
+      inputs:
+        parameters:
+          - name: message
+      outputs: {}
+      metadata: {}
+      containerSet:
+        containers:
+          - name: main
+            image: python:alpine3.6
+            command:
+              - python
+              - '-c'
+            # ruleid: argo-workflow-parameter-command-injection
+            args: ["echo result was: {{inputs.parameters.message}}"]
+            resources: {}
+    - name: print-message-python2
+      inputs:
+        parameters:
+          - name: message
+      outputs: {}
+      metadata: {}
+      containerSet:
+        containers:
+          - name: main
+            image: python:alpine3.6
+            command:
+              - python
+              - '-c'
+            args:
+            # ruleid: argo-workflow-parameter-command-injection
+              - |
+                print("hi")
+                print("{{inputs.parameters.message}}")
+            resources: {}
     - name: print-message-secure
       inputs:
         parameters:
@@ -73,3 +127,4 @@ spec:
         command: [sh, -c]
         # ok: argo-workflow-parameter-command-injection
         args: ["echo result was: $MESSAGE"]
+

--- a/yaml/argo/security/argo-workflow-parameter-command-injection.yaml
+++ b/yaml/argo/security/argo-workflow-parameter-command-injection.yaml
@@ -33,60 +33,43 @@ rules:
             - pattern-inside: |
                 command:
                   ...
-                  - python
-                  ...
-                ...
-                source: 
-                  $SCRIPT
-            - focus-metavariable: $SCRIPT
-            - metavariable-pattern:
-                metavariable: $SCRIPT
-                language: python
-                patterns: 
-                  - pattern: |
-                      $FUNC(..., $PARAM, ...)
-                  - metavariable-pattern:
-                      metavariable: $PARAM
-                      pattern-either: 
-                        - pattern-regex: (.*{{.*inputs.parameters.*}}.*)
-                        - pattern-regex: (.*{{.*workflow.parameters.*}}.*)
-          - patterns:
-            - pattern-inside: |
-                command:
-                  ...
                   - $LANG
                   ...
                 ...
-                source: 
+                source:
                   $SCRIPT
             - metavariable-regex:
                 metavariable: $LANG
-                regex: (bash|sh)
-            - focus-metavariable: $SCRIPT
+                regex: .*(sh|bash|ksh|csh|tcsh|zsh|python|python3|node|perl|ruby|php|lua|awk|sed|powershell|fish|dash|R|grooby|scala|clj|elixir|coffee|dart|haskell|ocaml).*
             - metavariable-pattern:
                 metavariable: $SCRIPT
-                language: bash
-                patterns: 
-                  - pattern: |
-                      $CMD ... $PARAM  ...
-                  - metavariable-pattern:
-                      metavariable: $PARAM
-                      pattern-either: 
-                        - pattern-regex: (.*{{.*inputs.parameters.*}}.*)
-                        - pattern-regex: (.*{{.*workflow.parameters.*}}.*)
+                pattern-either:
+                  - pattern-regex: (.*{{.*inputs.parameters.*}}.*)
+                  - pattern-regex: (.*{{.*workflow.parameters.*}}.*)
+            - focus-metavariable: $SCRIPT
           - patterns:
-            - pattern-inside: |
-                container:
-                  ...
-                  command: $LANG
-                  ...
-                  args: $PARAM
+            - pattern-either:
+              - pattern-inside: |
+                  container:
+                    ...
+                    command: $LANG
+                    ...
+                    args: $PARAM
+              - pattern-inside: |
+                  containerSet:
+                    ...
+                    containers:
+                      - ...
+                        command: $LANG
+                        ...
+                        args: $PARAM
             - metavariable-regex:
                 metavariable: $LANG
-                regex: .*(sh|bash|ksh|csh|tcsh|zsh).*
+                regex: .*(sh|bash|ksh|csh|tcsh|zsh|python|python3|node|perl|ruby|php|lua|awk|sed|powershell|fish|dash|R|grooby|scala|clj|elixir|coffee|dart|haskell|ocaml).*
             - metavariable-pattern:
                 metavariable: $PARAM
-                pattern-either: 
+                pattern-either:
                   - pattern-regex: (.*{{.*inputs.parameters.*}}.*)
                   - pattern-regex: (.*{{.*workflow.parameters.*}}.*)
             - focus-metavariable: $PARAM
+


### PR DESCRIPTION
The YAML linter in the pre-commit threw an error. But the rule is valid and works.

```
security (update-argo-injection-rule*) » git commit -m "Update argo workflow injection rule"                                                                                                                              ~/repos/semgrep-rules/yaml/argo/security
Check for case conflicts.................................................Passed
Check for added large files..............................................Passed
Check that executables have shebangs.................(no files to check)Skipped
Check for merge conflicts................................................Passed
Check for broken symlinks............................(no files to check)Skipped
Check Yaml...............................................................Failed
- hook id: check-yaml
- exit code: 1

while constructing a mapping
  in "yaml/argo/security/argo-workflow-parameter-command-injection.test.yaml", line 32, column 7
found duplicate key "script" with value "{}" (original value: "{}")
  in "yaml/argo/security/argo-workflow-parameter-command-injection.test.yaml", line 42, column 7

To suppress this check see:
    http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys

Check Yaml (Multi-documents).........................(no files to check)Skipped
security (update-argo-injection-rule*) » vim argo-workflow-parameter-command-injection.yaml                                                                                                                            ~/repos/semgrep-rules/yaml/argo/security 1 ↵
security (update-argo-injection-rule*) » semgrep test                                                                                                                                                                     ~/repos/semgrep-rules/yaml/argo/security
[00.20][ERROR]: bug: no valid target roots
security (update-argo-injection-rule*) » semgrep test .                                                                                                                                                                ~/repos/semgrep-rules/yaml/argo/security 2 ↵
1/1: ✓ All tests passed
No tests for fixes found.
security (update-argo-injection-rule*) » semgrep --config argo-workflow-parameter-command-injection.yaml argo-workflow-parameter-command-injection.test.yaml                                                              ~/repos/semgrep-rules/yaml/argo/security

┌──── ○○○ ────┐
│ Semgrep CLI │
└─────────────┘

/Users/p/.local/pipx/venvs/semgrep/lib/python3.12/site-packages/opentelemetry/instrumentation/dependencies.py:4: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import (

Scanning 1 file (only git-tracked) with 1 Code rule:

  CODE RULES
  Scanning 1 file.

  SUPPLY CHAIN RULES

  💎 Run `semgrep ci` to find dependency
     vulnerabilities and advanced cross-file findings.


  PROGRESS

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00


┌─────────────────┐
│ 8 Code Findings │
└─────────────────┘

    argo-workflow-parameter-command-injection.test.yaml
   ❯❯❱ argo-workflow-parameter-command-injection
          Using input or workflow parameters in here-scripts can lead to command injection or code injection.
          Convert the parameters to env variables instead.

           19┆ source: |
           20┆   echo {{inputs.parameters.message}}
            ⋮┆----------------------------------------
           30┆ source: |
           31┆   echo {{inputs.parameters.message}}
            ⋮┆----------------------------------------
           40┆ source: |
           41┆   print("{{inputs.parameters.message}}")
            ⋮┆----------------------------------------
           49┆ source: |
           50┆   var rand = Math.floor(Math.random() * 100);
           51┆   console.log("{{inputs.parameters.message}}");
            ⋮┆----------------------------------------
           59┆ source: |
           60┆   puts "{{inputs.parameters.message}}"
            ⋮┆----------------------------------------
           69┆ args: ["echo result was: {{inputs.parameters.message}}"]
            ⋮┆----------------------------------------
           84┆ args: ["echo result was: {{inputs.parameters.message}}"]
            ⋮┆----------------------------------------
          101┆ - |
          102┆   print("hi")
          103┆   print("{{inputs.parameters.message}}")



┌──────────────┐
│ Scan Summary │
└──────────────┘
✅ Scan completed successfully.
 • Findings: 8 (8 blocking)
 • Rules run: 1
 • Targets scanned: 1
 • Parsed lines: ~100.0%
 • No ignore information available
Ran 1 rule on 1 file: 8 findings.
```