### PR TITLE
Add rule to detect debuggable Android apps

### DIFF
--- a/java/android/best-practice/manifest-debuggable-true.xml
+++ b/java/android/best-practice/manifest-debuggable-true.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.manifest-test" >
+    <application
+        <!-- ruleid: manifest-debuggable-true -->
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:fullBackupContent="false"
+        android:debuggable="true"
+        tools:ignore="GoogleAppIndexingWarning">
+
+        <activity
+            android:name="com.example.networksecurity.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.manifest-test" >
+    <application
+        <!-- ok: manifest-debuggable-true -->
+        android:usesCleartextTraffic="true"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:fullBackupContent="false"
+        android:debuggable="false"
+        tools:ignore="GoogleAppIndexingWarning">
+
+        <activity
+            android:name="com.example.networksecurity.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.manifest-test" >
+    <application
+        <!-- ok: manifest-debuggable-true -->
+        android:usesCleartextTraffic="true"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme"
+        android:fullBackupContent="false"
+        tools:ignore="GoogleAppIndexingWarning">
+
+        <activity
+            android:name="com.example.networksecurity.MainActivity"
+            android:label="@string/app_name"
+            android:theme="@style/AppTheme.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/java/android/best-practice/manifest-debuggable-true.yml
+++ b/java/android/best-practice/manifest-debuggable-true.yml
@@ -1,0 +1,22 @@
+  - id: manifest-debuggable-true
+    languages:
+      - generic
+    message: >-
+      The Android manifest is configured to allow debugging the application, making
+      it easier for attackers to gain more access to the application than intended.
+      Evaluate if this is necessary for your app, and disable it if appropriate.
+    metadata:
+      category: best-practice
+      technology:
+        - android
+      references:
+        - https://developer.android.com/privacy-and-security/risks/android-debuggable
+    patterns:
+      - pattern: |
+          android:debuggable="true"
+      - pattern-not-inside: |
+          <!-- ... -->
+    severity: INFO
+    paths:
+      include:
+        - "*.xml"


### PR DESCRIPTION
This PR adds a rule to detect whether Android apps have the `android:debuggable` manifest flag set to `true`.