### PR TITLE
Add nextjs-images-wildcard-hostname security rule

### DIFF
--- a/javascript/nextjs/security/nextjs-images-wildcard-hostname.js
+++ b/javascript/nextjs/security/nextjs-images-wildcard-hostname.js
@@ -1,0 +1,130 @@
+// Test cases for nextjs-images-wildcard-hostname rule
+
+// BAD: Using wildcard hostname - should trigger the rule
+const badConfig1 = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**', // ERROR: Wildcard hostname
+        port: '',
+        pathname: '/account123/**',
+      },
+    ],
+  },
+};
+
+// BAD: Another wildcard hostname pattern - should trigger the rule
+const badConfig2 = {
+  images: {
+    remotePatterns: [
+      {
+        hostname: '**', // ERROR: Wildcard hostname
+      },
+    ],
+  },
+};
+
+// BAD: Wildcard in nested structure - should trigger the rule
+const badConfig3 = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**', // ERROR: Wildcard hostname
+        port: '8080',
+        pathname: '/images/**',
+      },
+    ],
+  },
+};
+
+// GOOD: Specific domain - should not trigger the rule
+const goodConfig1 = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'example.com', // OK: Specific domain
+        port: '',
+        pathname: '/account123/**',
+      },
+    ],
+  },
+};
+
+// GOOD: Multiple specific domains - should not trigger the rule
+const goodConfig2 = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'cdn.example.com', // OK: Specific subdomain
+        port: '',
+        pathname: '/images/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'assets.example.com', // OK: Another specific subdomain
+        port: '',
+        pathname: '/public/**',
+      },
+    ],
+  },
+};
+
+// GOOD: Using subdomain wildcard (more restrictive) - should not trigger the rule
+const goodConfig3 = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.example.com', // OK: Subdomain wildcard (more restrictive)
+        port: '',
+        pathname: '/images/**',
+      },
+    ],
+  },
+};
+
+// GOOD: Localhost and specific IP - should not trigger the rule
+const goodConfig4 = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'localhost', // OK: Localhost
+        port: '3000',
+        pathname: '/uploads/**',
+      },
+      {
+        protocol: 'https',
+        hostname: '192.168.1.100', // OK: Specific IP
+        port: '',
+        pathname: '/media/**',
+      },
+    ],
+  },
+};
+
+// GOOD: Empty remotePatterns - should not trigger the rule
+const goodConfig5 = {
+  images: {
+    remotePatterns: [], // OK: Empty array
+  },
+};
+
+// GOOD: No images config - should not trigger the rule
+const goodConfig6 = {
+  // No images configuration
+  experimental: {
+    appDir: true,
+  },
+};
+
+// GOOD: Images config without remotePatterns - should not trigger the rule
+const goodConfig7 = {
+  images: {
+    domains: ['example.com'], // OK: Using domains instead of remotePatterns
+  },
+};

--- a/javascript/nextjs/security/nextjs-images-wildcard-hostname.yaml
+++ b/javascript/nextjs/security/nextjs-images-wildcard-hostname.yaml
@@ -1,0 +1,40 @@
+rules:
+  - id: nextjs-images-wildcard-hostname
+    message: >-
+      Avoid using '**' for images.remotePatterns.hostname (overly permissive, security risk).
+      Using wildcard hostnames allows loading images from any domain, which can lead to:
+      - Image injection attacks
+      - Data exfiltration through image requests
+      - Potential SSRF vulnerabilities
+      Instead, specify exact domains or use more restrictive patterns.
+    languages:
+      - javascript
+      - typescript
+    severity: ERROR
+    patterns:
+      - pattern: |
+          {
+            hostname: "**"
+          }
+      - pattern-inside: |
+          images: {
+            remotePatterns: [
+              ...
+            ]
+          }
+    metadata:
+      category: security
+      technology:
+        - nextjs
+      subcategory:
+        - vuln
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: MEDIUM
+      cwe:
+        - "CWE-200: Exposure of Sensitive Information to an Unauthorized Actor"
+      owasp:
+        - A05:2021 - Security Misconfiguration
+      references:
+        - https://nextjs.org/docs/app/api-reference/next-config-js/images#remotepatterns
+        - https://nextjs.org/docs/pages/api-reference/next-config-js/images#remotepatterns


### PR DESCRIPTION
## Summary
Adds a security rule to detect overly permissive wildcard hostnames in Next.js `images.remotePatterns` configuration.

## Security Issue
Using `hostname: "**"` in Next.js image configuration allows loading images from any domain, which can lead to:
- Image injection attacks
- Data exfiltration through image requests  
- Potential SSRF vulnerabilities

## Solution
The rule detects wildcard hostname patterns and suggests using specific domains or more restrictive patterns.

## Files Added
- `javascript/nextjs/security/nextjs-images-wildcard-hostname.yaml` - Rule definition
- `javascript/nextjs/security/nextjs-images-wildcard-hostname.js` - Test cases

## Metadata
- **Category**: security
- **CWE**: CWE-200 (Exposure of Sensitive Information)
- **OWASP**: A05:2021 (Security Misconfiguration)
- **Languages**: javascript, typescript
- **Severity**: ERROR

## Test Coverage
- 3 negative test cases (should trigger rule)
- 7 positive test cases (should not trigger rule)