### PR TITLE
Update formatted-sql-string rule message with better guidance

### DIFF
--- a/java/lang/security/audit/formatted-sql-string.yaml
+++ b/java/lang/security/audit/formatted-sql-string.yaml
@@ -32,8 +32,10 @@ rules:
   message: >-
     Detected a formatted string in a SQL statement. This could lead to SQL
     injection if variables in the SQL statement are not properly sanitized.
-    Use a prepared statements (java.sql.PreparedStatement) instead. You
-    can obtain a PreparedStatement using 'connection.prepareStatement'.
+    To prevent this vulnerability, use prepared statements that do not 
+    concatenate user-controllable strings and use parameterized queries where 
+    SQL commands and user data are strictly separated. You can obtain a 
+    PreparedStatement using 'connection.prepareStatement'.
   mode: taint
   pattern-sources:
   - patterns:


### PR DESCRIPTION
The formatted-slq-string java rule looks for concatenated strings that are used as arguments in prepareStatement functions but the rule message made is seem like if you were already using prepared statements then you were safe from SQL injection, which made some findings appear initially as false positives. Updating the rule message to specifying that prepared statements should not be used with concatenated strings that contain user-controlled input.