### PR TITLE
Improve OCaml rule protecting against stray Not_founds

### DIFF
--- a/ocaml/lang/best-practice/hashtbl.ml
+++ b/ocaml/lang/best-practice/hashtbl.ml
@@ -5,16 +5,36 @@ let test1 xs =
   else 2
 
 let test2 xs =
- (* ok *)
- try
-   if Hashtbl.find h 1
-   then 1
-   else 2
- with Not_found -> 3
+  (* ok *)
+  try Hashtbl.find h 1
+  with Not_found -> 3
+
+let test2 xs =
+  (* ok *)
+  try
+    if Hashtbl.find h 1
+    then 1
+    else 2
+  with Not_found -> 3
 
 let test3 xs =
- (* ok *)
- match Hashtbl.find h 1 with
- | true -> 1
- | false -> 2
- | exception Not_found -> 3
+  try
+    (* ruleid:hashtbl-find-outside-try *)
+    if Hashtbl.find h 1
+    then failwith "error"
+    else 2
+  with Failure _ -> 3
+
+let test4 xs =
+  (* ruleid:hashtbl-find-outside-try *)
+  match Hashtbl.find h 1 with
+  | true -> 1
+  | false -> 2
+
+let test5 xs =
+  (* false positive, needs fixing. See notes in the rule. *)
+  (* ruleid:hashtbl-find-outside-try *)
+  match Hashtbl.find h 1 with
+  | true -> 1
+  | false -> 2
+  | exception Not_found -> 3

--- a/ocaml/lang/best-practice/hashtbl.yaml
+++ b/ocaml/lang/best-practice/hashtbl.yaml
@@ -4,16 +4,22 @@ rules:
       - pattern: |
           Hashtbl.find ...
       - pattern-not-inside: |
-          try ... with ... -> ...
-      # TODO:
-      # We should restrict this to match-with plus exception pattern:
-      #
-      #     match ... with | exception ... -> ... | ... -> ...
-      #
-      # But first we need to switch to tree-sitter-ocaml for parsing patterns.
-      - pattern-not-inside: |
-          match ... with | ... -> ...
-    message: You should not use Hashtbl.find outside of a try, or you should use Hashtbl.find_opt
+          try ... with Not_found -> ...
+      # TODO: add support for the syntax match ... with | exception ... -> ...
+      # First, we'd need to switch to tree-sitter-ocaml for parsing
+      # patterns.
+      # - pattern-not-inside: |
+      #    match Hashtbl.find ... with exception Not_found -> ...
+    message: >-
+      'Hashtbl.find' raises the 'Not_found' exception.
+      Handle the exception or use 'Hashtbl.find_opt' instead.
+      If you have proof that the key exists in the table,
+      use 'assert false' as the exception handler to demonstrate awareness
+      of the issue.
+      If your code uses the syntax 'match Hashtbl.find ... with
+      exception Not_found -> ...', it's fine and we apologize for not
+      detecting it. Consider using 'Hashtbl.find_opt' to please
+      Semgrep and stay safe.
     languages: [ocaml]
     severity: WARNING
     metadata:


### PR DESCRIPTION
## Link to an issue, if relevant

(internal Slack thread)

### ~~Adding a new~~ Revising a rule? Look over this PR checklist

- The issue or PR has links, references, or examples.
- The rule has **true positive** and **true negative** test cases in a file that matches the rule name.

> If the rule is `my-rule`, the test file name should be `my-rule.js`.
>
> True positives are marked by comments with `ruleid: <my-rule>` and true negatives are marked by comments with `ok: <my-rule>`.

- The rule has a good message. A good message includes:

> 1. A description of the pattern (e.g., missing parameter, dangerous flag, out-of-order function calls).
> 1. A description of why this pattern was detected (e.g., logic bug, introduces a security vulnerability, bad practice).
> 1. An alternative that resolves the issue (e.g., use another function, validate data first, discard the dangerous flag).
