### PR TITLE
Update aws-cloudfront-insecure-tls rule

### DIFF
--- a/terraform/aws/security/aws-cloudfront-insecure-tls.yaml
+++ b/terraform/aws/security/aws-cloudfront-insecure-tls.yaml
@@ -39,11 +39,31 @@ rules:
         }
         ...
       }
+  - pattern-not-inside: |
+      resource "aws_cloudfront_distribution" $ANYTHING {
+        ...
+        viewer_certificate {
+          ...
+          minimum_protocol_version = "TLSv1.2_2025"
+          ...
+        }
+        ...
+      }
+  - pattern-not-inside: |
+      resource "aws_cloudfront_distribution" $ANYTHING {
+        ...
+        viewer_certificate {
+          ...
+          minimum_protocol_version = "TLSv1.3_2025"
+          ...
+        }
+        ...
+      }
   message: >-
     Detected an AWS CloudFront Distribution with an insecure TLS version.
     TLS versions less than 1.2 are considered insecure because they
     can be broken. To fix this, set your `minimum_protocol_version` to
-    `"TLSv1.2_2018", "TLSv1.2_2019" or "TLSv1.2_2021"`.
+    `"TLSv1.2_2018", "TLSv1.2_2019", "TLSv1.2_2021", "TLSv1.2_2025" or "TLSv1.3_2025"`.
   metadata:
     category: security
     technology:


### PR DESCRIPTION
This updates the `aws-cloudfront-insecure-tls` Semgrep rule to account for the recent addition of AWS Cloudfront `TLSv1.2_2025` and `TLSv1.3_2025`.

These rule modifications make it such that TF entries where the `viewer_certificate` block contains `minimum_protocol_version = "TLSv1.2_2025"` or `minimum_protocol_version = "TLSv1.3_2025"` will no longer be flagged as a security issue (false positive).

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html