### PR TITLE
New Rules Proposal: Detect exposure to log injection in java.

### DIFF
--- a/java/lang/security/audit/java-logging-from-string-parameter.java
+++ b/java/lang/security/audit/java-logging-from-string-parameter.java
@@ -1,0 +1,37 @@
+package com.test;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
+public class Cases {
+
+    private static final Logger logger = LoggerFactory.getLogger(Cases.class);    
+
+    public void case1(String param, long x) {
+        //ruleid: java-logging-from-string-parameter
+        logger.trace("Msg {}",param);
+        //ruleid: java-logging-from-string-parameter
+        logger.debug("Msg {}",param);
+        //ruleid: java-logging-from-string-parameter
+        logger.info("Msg {}",param);                
+        //ruleid: java-logging-from-string-parameter
+        logger.warn("Msg {}",param);        
+        //ruleid: java-logging-from-string-parameter
+        logger.error("Msg {}",param);        
+    }
+
+    public void case2(String param, long x) {
+        String param_clean = param.replace("<","").replace(">","");
+        param_clean = param_clean.replace("\n","");
+        //ok: java-logging-from-string-parameter
+        logger.trace("Msg {}",param_clean);
+        //ok: java-logging-from-string-parameter
+        logger.debug("Msg {}",param_clean);
+        //ok: java-logging-from-string-parameter
+        logger.info("Msg {}",param_clean);                
+        //ok: java-logging-from-string-parameter
+        logger.warn("Msg {}",param_clean);        
+        //ok: java-logging-from-string-parameter
+        logger.error("Msg {}",param_clean);        
+    }
+}

--- a/java/lang/security/audit/java-logging-from-string-parameter.java
+++ b/java/lang/security/audit/java-logging-from-string-parameter.java
@@ -1,12 +1,13 @@
 package com.test;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.slf4j.*;
+import org.springframework.web.bind.annotation.*;
 
 public class Cases {
 
     private static final Logger logger = LoggerFactory.getLogger(Cases.class);    
 
+    @GetMapping
     public void case1(String param, long x) {
         //ruleid: java-logging-from-string-parameter
         logger.trace("Msg {}",param);
@@ -20,6 +21,7 @@ public class Cases {
         logger.error("Msg {}",param);        
     }
 
+    @PostMapping
     public void case2(String param, long x) {
         String param_clean = param.replace("<","").replace(">","");
         param_clean = param_clean.replace("\n","");
@@ -34,4 +36,17 @@ public class Cases {
         //ok: java-logging-from-string-parameter
         logger.error("Msg {}",param_clean);        
     }
+
+    public void case3(String param, long x) {
+        //ok: java-logging-from-string-parameter
+        logger.trace("Msg {}",param);
+        //ok: java-logging-from-string-parameter
+        logger.debug("Msg {}",param);
+        //ok: java-logging-from-string-parameter
+        logger.info("Msg {}",param);                
+        //ok: java-logging-from-string-parameter
+        logger.warn("Msg {}",param);        
+        //ok: java-logging-from-string-parameter
+        logger.error("Msg {}",param);        
+    }    
 }

--- a/java/lang/security/audit/java-logging-from-string-parameter.yaml
+++ b/java/lang/security/audit/java-logging-from-string-parameter.yaml
@@ -3,16 +3,21 @@ rules:
     languages:
       - java
     severity: WARNING
-    message: An unsanitized String method parameter is used as an argument to a logger call, which could lead to a log injection vulnerability.
+    message: An unsanitized String method parameter is used as an argument to a
+      logger call, which could lead to a log injection vulnerability.
     patterns:
       - pattern-inside: |
-              $TYPE $METHOD(..., String $PARAM, ...) {
-                ...
-              }
-      - pattern: $LOGGER.$LEVEL($FORMAT_STRING, $PARAM, ...)
-    metavariable-regex:
-      $LEVEL: 'trace|debug|info|warn|error'          
-    fix: Ensure that a validation is in place prior to use a user-controller information to create a log event.
+          $TYPE $METHOD(..., String $PARAM, ...) {
+            ...
+          }
+      - pattern-either:        
+          - pattern: $LOGGER.trace($FORMAT_STRING, $PARAM, ...)
+          - pattern: $LOGGER.debug($FORMAT_STRING, $PARAM, ...)
+          - pattern: $LOGGER.info($FORMAT_STRING, $PARAM, ...)
+          - pattern: $LOGGER.warn($FORMAT_STRING, $PARAM, ...)
+          - pattern: $LOGGER.error($FORMAT_STRING, $PARAM, ...)
+    fix: Ensure that a validation is in place prior to use a user-controller
+      information to create a log event.
     paths:
       include:
         - "**/*.java"

--- a/java/lang/security/audit/java-logging-from-string-parameter.yaml
+++ b/java/lang/security/audit/java-logging-from-string-parameter.yaml
@@ -3,21 +3,19 @@ rules:
     languages:
       - java
     severity: WARNING
-    message: An unsanitized String method parameter is used as an argument to a
-      logger call, which could lead to a log injection vulnerability.
+    message: An unsanitized String method parameter is used as an argument to a logger call, which could lead to a log injection vulnerability.
     patterns:
       - pattern-inside: |
           $TYPE $METHOD(..., String $PARAM, ...) {
             ...
           }
-      - pattern-either:        
+      - pattern-either:
           - pattern: $LOGGER.trace($FORMAT_STRING, $PARAM, ...)
           - pattern: $LOGGER.debug($FORMAT_STRING, $PARAM, ...)
           - pattern: $LOGGER.info($FORMAT_STRING, $PARAM, ...)
           - pattern: $LOGGER.warn($FORMAT_STRING, $PARAM, ...)
           - pattern: $LOGGER.error($FORMAT_STRING, $PARAM, ...)
-    fix: Ensure that a validation is in place prior to use a user-controller
-      information to create a log event.
+    fix: Ensure that a validation is in place prior to use a user-controller information to create a log event.
     paths:
       include:
         - "**/*.java"

--- a/java/lang/security/audit/java-logging-from-string-parameter.yaml
+++ b/java/lang/security/audit/java-logging-from-string-parameter.yaml
@@ -1,0 +1,37 @@
+rules:
+  - id: java-logging-from-string-parameter
+    languages:
+      - java
+    severity: WARNING
+    message: An unsanitized String method parameter is used as an argument to a logger call, which could lead to a log injection vulnerability.
+    patterns:
+      - pattern-inside: |
+              $TYPE $METHOD(..., String $PARAM, ...) {
+                ...
+              }
+      - pattern: $LOGGER.$LEVEL($FORMAT_STRING, $PARAM, ...)
+    metavariable-regex:
+      $LEVEL: 'trace|debug|info|warn|error'          
+    fix: Ensure that a validation is in place prior to use a user-controller information to create a log event.
+    paths:
+      include:
+        - "**/*.java"
+    metadata:
+      category: security
+      owasp:
+        - A03:2021 Injection
+      technology:
+        - java
+      references:
+        - https://capec.mitre.org/data/definitions/93.html
+        - https://vulncat.fortify.com/en/weakness?q=log%20forging
+        - https://learn.snyk.io/lesson/logging-vulnerabilities/?ecosystem=java
+        - https://owasp.org/www-project-java-encoder/
+        - https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
+      cwe:
+        - "CWE-117: Improper Output Neutralization for Logs"
+      likelihood: LOW
+      impact: LOW
+      confidence: LOW
+      subcategory:
+        - audit

--- a/java/lang/security/audit/java-logging-from-string-parameter.yaml
+++ b/java/lang/security/audit/java-logging-from-string-parameter.yaml
@@ -3,12 +3,16 @@ rules:
     languages:
       - java
     severity: WARNING
-    message: An unsanitized String method parameter is used as an argument to a logger call, which could lead to a log injection vulnerability.
+    message: An unsanitized string parameter is passed to a web controller method and subsequently used in a logger call, which could lead to a log injection vulnerability.
     patterns:
       - pattern-inside: |
+          @$ANNO(...)
           $TYPE $METHOD(..., String $PARAM, ...) {
             ...
           }
+      - metavariable-pattern:
+          metavariable: $ANNO
+          pattern-regex: "(GetMapping|PostMapping|PutMapping|DeleteMapping|PatchMapping|RequestMapping|GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|WebMethod)"          
       - pattern-either:
           - pattern: $LOGGER.trace($FORMAT_STRING, $PARAM, ...)
           - pattern: $LOGGER.debug($FORMAT_STRING, $PARAM, ...)


### PR DESCRIPTION
Hello,

This rule, for java language, is intended to detect and raise a warning when an unsanitized String method parameter is used as an argument to a logger call. The goal is to allow to detect such situation and perform a manual control that a validation is in place.

💡 To limit the false positives, I updated the rule to only trigger for methods that are exposed as a "web service". I added annotations used by Spring Web, JAX-RS and JAX-WS frameworks.

I tested the rule against the sample code using the online rule editor:

<img width="1697" height="915" alt="image" src="https://github.com/user-attachments/assets/5e99b7cd-a2da-45e5-9baf-c47fe6ab05f0" />



Thank you very much for your feedback 😉