### PR TITLE
New Rules Proposal: Detect usage of SHA1PRNG in java. 

### DIFF
--- a/java/lang/security/audit/crypto/use-of-sha1prng.java
+++ b/java/lang/security/audit/crypto/use-of-sha1prng.java
@@ -1,0 +1,20 @@
+package com.test;
+
+import java.security.SecureRandom
+
+public class Cases {
+
+    public void case1(String param, long x) {
+        //ruleid: use-of-sha1prng
+        SecureRandom sr0 = SecureRandom.getInstance("SHA1PRNG")
+    }
+
+    public void case2(String param, long x) {
+        //ok: use-of-sha1prng
+        SecureRandom sr1 = SecureRandom.getInstance("NativePRNG");
+        //ok: use-of-sha1prng
+        SecureRandom sr2 = new SecureRandom();     
+        //ok: use-of-sha1prng
+        SecureRandom sr3 = SecureRandom.getInstanceStrong();
+    }
+}

--- a/java/lang/security/audit/crypto/use-of-sha1prng.yaml
+++ b/java/lang/security/audit/crypto/use-of-sha1prng.yaml
@@ -5,7 +5,7 @@ rules:
     severity: WARNING
     message: Detected usage of SHA1PRNG, a pseudo random number generator algorithm which is considered insecure.
     pattern: SecureRandom.getInstance("SHA1PRNG")
-    fix: Use 'SecureRandom.getInstanceStrong()' to obtain a secure random instance using a pseudo random number generator algorithm suited for security related processing.
+    fix: On Java 8- use 'SecureRandom.getInstanceStrong()' and on Java 9+ use 'new SecureRandom()' to obtain a secure random instance using a pseudo random number generator algorithm suited for security related processing.
     paths:
       include:
         - "**/*.java"

--- a/java/lang/security/audit/crypto/use-of-sha1prng.yaml
+++ b/java/lang/security/audit/crypto/use-of-sha1prng.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: use-of-sha1prng
+    languages:
+      - java
+    severity: WARNING
+    message: Detected usage of SHA1PRNG, a pseudo random number generator algorithm which is considered insecure.
+    pattern: SecureRandom.getInstance("SHA1PRNG")
+    fix: Use 'SecureRandom.getInstanceStrong()' to obtain a secure random instance using a pseudo random number generator algorithm suited for security related processing.
+    paths:
+      include:
+        - "**/*.java"
+    metadata:
+      category: security
+      owasp:
+        - A02:2021 Cryptographic Failures
+      technology:
+        - java
+      references:
+        - https://precli.readthedocs.io/0.5.9/rules/java/stdlib/java-security-weak-random/
+        - https://thesecurityvault.com/weak-random/
+        - https://android-developers.googleblog.com/2016/06/security-crypto-provider-deprecated-in.html
+        - https://docs.oracle.com/en/java/javase/21/docs/specs/security/standard-names.html#securerandom-number-generation-algorithms
+        - https://github.com/OWASP/mastg/issues/1685
+        - https://metebalci.com/blog/everything-about-javas-securerandom/
+      cwe:
+        - "CWE-327: Use of a Broken or Risky Cryptographic Algorithm"
+      likelihood: LOW
+      impact: LOW
+      confidence: LOW
+      subcategory:
+        - audit


### PR DESCRIPTION
Hello,

This rule, for java language, is intended to detect and raise a warning when **SHA1PRNG**, a pseudo random number generator algorithm which is considered insecure, is used.

I tested the rule against the sample code using the online rule editor:

<img width="1695" height="912" alt="image" src="https://github.com/user-attachments/assets/43385a23-8bac-435b-9712-0400d20db20c" />

<img width="846" height="296" alt="image" src="https://github.com/user-attachments/assets/d58b89a2-a32c-414d-8583-75583c418428" />


Thank you very much for your feedback 😉
