### PR TITLE
New Rules Proposal: Detect usage in java of an XML canonicalization method that excludes XML comments.

### DIFF
--- a/java/lang/security/audit/crypto/use-of-xml-canonicalization-method-excluding-comments.java
+++ b/java/lang/security/audit/crypto/use-of-xml-canonicalization-method-excluding-comments.java
@@ -1,0 +1,21 @@
+package com.test;
+
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.CanonicalizationMethod;
+
+public class Cases {
+
+    public void case1(XMLSignatureFactory signatureFactory) {
+        //ruleid: use-of-xml-canonicalization-method-excluding-comments
+        CanonicalizationMethod c14nMethod = signatureFactory.newCanonicalizationMethod(CanonicalizationMethod.EXCLUSIVE,null);
+        //ruleid: use-of-xml-canonicalization-method-excluding-comments
+        c14nMethod = signatureFactory.newCanonicalizationMethod("http://www.w3.org/2001/10/xml-exc-c14n#",null);        
+    }
+
+    public void case2(XMLSignatureFactory signatureFactory) {
+        //ok: use-of-xml-canonicalization-method-excluding-comments
+        CanonicalizationMethod c14nMethod = signatureFactory.newCanonicalizationMethod(CanonicalizationMethod.EXCLUSIVE_WITH_COMMENTS,null);
+        //ok: use-of-xml-canonicalization-method-excluding-comments
+        CanonicalizationMethod c14nMethod = signatureFactory.newCanonicalizationMethod("http://www.w3.org/2001/10/xml-exc-c14n#WithComments",null);
+    }
+}

--- a/java/lang/security/audit/crypto/use-of-xml-canonicalization-method-excluding-comments.yaml
+++ b/java/lang/security/audit/crypto/use-of-xml-canonicalization-method-excluding-comments.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: use-of-xml-canonicalization-method-excluding-comments
+    languages:
+      - java
+    severity: INFO
+    message: Detected usage of an XML canonicalization method that excludes XML comments from the computation of Digest and Signature.
+    pattern-either:
+      - pattern: $XML_SIGNATURE_FACTORY_OBJ.newCanonicalizationMethod(CanonicalizationMethod.EXCLUSIVE,$PARAM)
+      - pattern: $XML_SIGNATURE_FACTORY_OBJ.newCanonicalizationMethod("http://www.w3.org/2001/10/xml-exc-c14n#",$PARAM)      
+    fix: The canonicalization method "xml-exc-c14n#WithComments" should be used for Digest and Signature to include comments into their computation.
+    paths:
+      include:
+        - "**/*.java"
+    metadata:
+      category: security
+      owasp:
+        - A02:2021 Cryptographic Failures
+      technology:
+        - java
+      references:
+        - https://nvd.nist.gov/vuln/detail/CVE-2025-29775
+        - https://www.w3.org/TR/2002/REC-xml-exc-c14n-20020718/#WithComments
+        - https://www.nccgroup.com/research-blog/saml-xml-injection/
+        - https://workos.com/blog/samlstorm
+      cwe:
+        - "CWE-347: Improper Verification of Cryptographic Signature"
+      likelihood: LOW
+      impact: LOW
+      confidence: LOW
+      subcategory:
+        - audit


### PR DESCRIPTION
Hello,

This rule, for java language, is intended to detect and inform when an XML canonicalization method that excludes XML comments from the computation of Digest and Signature is used.

I tested the rule against the sample code using the online rule editor:

<img width="1692" height="913" alt="image" src="https://github.com/user-attachments/assets/8d13d5aa-cfc4-4582-b2d1-56757ae073e5" />

Thank you very much for your feedback 😉
