### PR TITLE
Add pattern for new Random() in weak-random.yaml

### DIFF
--- a/java/lang/security/audit/crypto/weak-random.yaml
+++ b/java/lang/security/audit/crypto/weak-random.yaml
@@ -28,3 +28,4 @@ rules:
       new java.util.Random(...).$FUNC(...)
   - pattern: |
       java.lang.Math.random(...)
+  - pattern: new Random(...)


### PR DESCRIPTION
Add a pattern to match the commonly used `Random random = new Random();` in java.