### PR TITLE
Add additional GitHub shell injections patterns

### DIFF
--- a/yaml/github-actions/security/run-shell-injection.test.yaml
+++ b/yaml/github-actions/security/run-shell-injection.test.yaml
@@ -137,3 +137,33 @@ jobs:
         # ok: run-shell-injection
         run: |
           echo "${{ steps.shell_command.outputs.some_value }}"
+
+      # ruleid: run-shell-injection
+      - run: echo "${{ github.head_ref || 'default' }}"
+
+      # ruleid: run-shell-injection
+      - run: echo "${{ foo && github.head_ref }}"
+
+      # ruleid: run-shell-injection
+      - run: echo "${{ foo && github.head_ref || 'default' }}"
+
+      # ruleid: run-shell-injection
+      - run: echo "${{ foo || github.head_ref }}"
+
+      # ruleid: run-shell-injection
+      - run: echo "${{ foo || github.head_ref || bar }}"
+
+      # ok: run-shell-injection
+      - run: echo "${{ github.head_ref && 'yes' }}"
+
+      # ok: run-shell-injection
+      - run: echo "${{ github.head_ref && foo || bar }}"
+
+      # ok: run-shell-injection
+      - run: echo "${{ foo || github.head_ref && bar }}"
+
+      # ok: run-shell-injection
+      - run: echo "${{ github.sha }}"
+
+      # ok: run-shell-injection
+      - run: echo "${{ github.repository }}"

--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -37,25 +37,43 @@ rules:
       metavariable: $SHELL
       patterns:
       - pattern-either:
-        - pattern: ${{ github.event.issue.title }}
-        - pattern: ${{ github.event.issue.body }}
-        - pattern: ${{ github.event.pull_request.title }}
-        - pattern: ${{ github.event.pull_request.body }}
-        - pattern: ${{ github.event.comment.body }}
-        - pattern: ${{ github.event.review.body }}
-        - pattern: ${{ github.event.review_comment.body }}
-        - pattern: ${{ github.event.pages. ... .page_name}}
-        - pattern: ${{ github.event.head_commit.message }}
-        - pattern: ${{ github.event.head_commit.author.email }}
-        - pattern: ${{ github.event.head_commit.author.name }}
-        - pattern: ${{ github.event.commits ... .author.email }}
-        - pattern: ${{ github.event.commits ... .author.name }}
-        - pattern: ${{ github.event.pull_request.head.ref }}
-        - pattern: ${{ github.event.pull_request.head.label }}
-        - pattern: ${{ github.event.pull_request.head.repo.default_branch }}
-        - pattern: ${{ github.head_ref }}
-        - pattern: ${{ github.event.inputs ... }}
-        - pattern: ${{ github.event.discussion.title }}
-        - pattern: ${{ github.event.discussion.body }}
-        - pattern: ${{ inputs ... }}
+        - pattern: ${{ ... github.event.issue.title ... }}
+        - pattern: ${{ ... github.event.issue.body ... }}
+        - pattern: ${{ ... github.event.pull_request.title ... }}
+        - pattern: ${{ ... github.event.pull_request.body ... }}
+        - pattern: ${{ ... github.event.comment.body ... }}
+        - pattern: ${{ ... github.event.review.body ... }}
+        - pattern: ${{ ... github.event.review_comment.body ... }}
+        - pattern: ${{ ... github.event.pages ... .page_name ... }}
+        - pattern: ${{ ... github.event.head_commit.message ... }}
+        - pattern: ${{ ... github.event.head_commit.author.email ... }}
+        - pattern: ${{ ... github.event.head_commit.author.name ... }}
+        - pattern: ${{ ... github.event.commits ... .author.email ... }}
+        - pattern: ${{ ... github.event.commits ... .author.name ... }}
+        - pattern: ${{ ... github.event.pull_request.head.ref ... }}
+        - pattern: ${{ ... github.event.pull_request.head.label ... }}
+        - pattern: ${{ ... github.event.pull_request.head.repo.default_branch ... }}
+        - pattern: ${{ ... github.head_ref ... }}
+        - pattern: ${{ ... github.event.inputs ... }}
+        - pattern: ${{ ... github.event.discussion.title ... }}
+        - pattern: ${{ ... github.event.discussion.body ... }}
+        - pattern: ${{ ... inputs ... }}
+      # Exclude safe patterns where variable is only checked for truthiness (left of &&)
+      # e.g., ${{ github.head_ref && 'literal' }} is safe - value not interpolated
+      - pattern-not: ${{ ... github.event.issue.title && ... }}
+      - pattern-not: ${{ ... github.event.issue.body && ... }}
+      - pattern-not: ${{ ... github.event.pull_request.title && ... }}
+      - pattern-not: ${{ ... github.event.pull_request.body && ... }}
+      - pattern-not: ${{ ... github.event.comment.body && ... }}
+      - pattern-not: ${{ ... github.event.review.body && ... }}
+      - pattern-not: ${{ ... github.event.review_comment.body && ... }}
+      - pattern-not: ${{ ... github.event.head_commit.message && ... }}
+      - pattern-not: ${{ ... github.event.head_commit.author.email && ... }}
+      - pattern-not: ${{ ... github.event.head_commit.author.name && ... }}
+      - pattern-not: ${{ ... github.event.pull_request.head.ref && ... }}
+      - pattern-not: ${{ ... github.event.pull_request.head.label && ... }}
+      - pattern-not: ${{ ... github.event.pull_request.head.repo.default_branch && ... }}
+      - pattern-not: ${{ ... github.head_ref && ... }}
+      - pattern-not: ${{ ... github.event.discussion.title && ... }}
+      - pattern-not: ${{ ... github.event.discussion.body && ... }}
   severity: ERROR


### PR DESCRIPTION
A GitHub Action may still be vulnerable when a more complicated pattern is used, like an `||` operator.