### PR TITLE
[go] Add CWE-502 unsafe deserialization rule

### DIFF
--- a/go/lang/security/deserialization/unsafe-deserialization-interface.go
+++ b/go/lang/security/deserialization/unsafe-deserialization-interface.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"encoding/xml"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Vulnerable patterns - should be flagged
+
+func vulnerableJSON(data []byte) {
+	// ruleid: go-unsafe-deserialization-interface
+	var result interface{}
+	json.Unmarshal(data, &result)
+}
+
+func vulnerableYAML(data []byte) {
+	// ruleid: go-unsafe-deserialization-interface
+	var result interface{}
+	yaml.Unmarshal(data, &result)
+}
+
+func vulnerableXML(data []byte) {
+	// ruleid: go-unsafe-deserialization-interface
+	var result interface{}
+	xml.Unmarshal(data, &result)
+}
+
+// Safe patterns - should NOT be flagged
+
+type User struct {
+	ID    int    `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+func safeJSON(data []byte) {
+	// ok: go-unsafe-deserialization-interface
+	var user User
+	json.Unmarshal(data, &user)
+}
+
+func safeYAML(data []byte) {
+	// ok: go-unsafe-deserialization-interface
+	var user User
+	yaml.Unmarshal(data, &user)
+}
+
+func safeXML(data []byte) {
+	// ok: go-unsafe-deserialization-interface
+	var user User
+	xml.Unmarshal(data, &user)
+}
+
+type Config struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+func safeConfigJSON(data []byte) {
+	// ok: go-unsafe-deserialization-interface
+	var config Config
+	json.Unmarshal(data, &config)
+}
+

--- a/go/lang/security/deserialization/unsafe-deserialization-interface.yaml
+++ b/go/lang/security/deserialization/unsafe-deserialization-interface.yaml
@@ -1,0 +1,41 @@
+rules:
+  - id: go-unsafe-deserialization-interface
+    languages:
+      - go
+    message: >-
+      Deserializing into `interface{}` allows arbitrary data structures and types,
+      which can lead to security vulnerabilities (CWE-502). Use a concrete struct
+      type instead. Consider using github.com/ravisastryk/go-safeinput/safedeserialize
+      for automatic protection.
+    severity: WARNING
+    metadata:
+      cwe:
+        - "CWE-502: Deserialization of Untrusted Data"
+      owasp:
+        - A08:2017 - Insecure Deserialization
+        - A08:2021 - Software and Data Integrity Failures
+      category: security
+      technology:
+        - go
+      confidence: HIGH
+      likelihood: MEDIUM
+      impact: HIGH
+      subcategory:
+        - vuln
+      references:
+        - https://cwe.mitre.org/data/definitions/502.html
+        - https://github.com/ravisastryk/go-safeinput
+    patterns:
+      - pattern-either:
+          - pattern: |
+              var $VAR interface{}
+              ...
+              json.Unmarshal($DATA, &$VAR)
+          - pattern: |
+              var $VAR interface{}
+              ...
+              yaml.Unmarshal($DATA, &$VAR)
+          - pattern: |
+              var $VAR interface{}
+              ...
+              xml.Unmarshal($DATA, &$VAR)


### PR DESCRIPTION
# Semgrep Rule: Go Unsafe Deserialization

## Summary

Addition of a security rule to detect CWE-502 (Deserialization of Untrusted Data) vulnerabilities in Go code.

## Rule Added

| Rule ID | Severity | File |
|---------|----------|------|
| `go-unsafe-deserialization-interface` | WARNING | `go/lang/security/deserialization/unsafe-deserialization-interface.yaml` |

## What It Detects

Deserializing JSON, YAML, or XML data into `interface{}` type:

```go
// DETECTED - vulnerable pattern
var data interface{}
json.Unmarshal(untrustedInput, &data)
```

## Why This Matters

When deserializing into `interface{}`:
- Attacker controls the data structure
- No type validation occurs
- Can lead to unexpected behavior, DoS, or in some cases RCE
- Violates principle of least privilege

**Impact:**
- CWE-502 is ranked 15 in [MITRE CWE Top 25 (2023)](https://cwe.mitre.org/top25/archive/2023/2023_stubborn_weaknesses.html)
- Affects thousands of Go repositories on GitHub
- Simple fix available (use concrete structs)

## The Fix

```go
// SAFE - concrete struct
type User struct {
    ID    int    `json:"id"`
    Name  string `json:"name"`
}

var user User
json.Unmarshal(input, &user)
```

Or use [go-safeinput](https://github.com/ravisastryk/go-safeinput) for automatic protection:

```go
import "github.com/ravisastryk/go-safeinput/safedeserialize"

var user User
err := safedeserialize.JSON(input, &user)
```

## Testing

```bash

brew install semgrep <--- This works on mac
cd go/lang/security/deserialization
semgrep --test
```

## References

- CWE-502: https://cwe.mitre.org/data/definitions/502.html
- OWASP: https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/
- Fix library: https://github.com/ravisastryk/go-safeinput

## Checklist

- [x] Rule follows Semgrep best practices
- [x] Test file with true positives (`ruleid:`) and negatives (`ok:`)
- [x] Metadata includes CWE, OWASP, severity
- [x] Clear message with fix suggestion
- [x] References to documentation
