### PR TITLE
Update deprecation message for bnot operator

### DIFF
--- a/elixir/lang/best-practice/deprecated-bnot-operator.yaml
+++ b/elixir/lang/best-practice/deprecated-bnot-operator.yaml
@@ -1,7 +1,7 @@
 rules:
   - id: deprecated_bnot_operator
     message: >-
-      The bitwise operator (`^^^`) is already deprecated. Please use `Bitwise.bnot($VAL)` instead.
+      The bitwise operator (`~~~`) is already deprecated. Please use `Bitwise.bnot($VAL)` instead.
     severity: WARNING
     languages:
       - elixir


### PR DESCRIPTION
Looks like a copy and paste job gone wrong, easily done and equally easy fix :D