### PR TITLE
New Published Rules - preprocess SSTI in thymeleaf

### DIFF
--- a/java/spring/security/injection/thymeleaf-preprocess-ssti.html
+++ b/java/spring/security/injection/thymeleaf-preprocess-ssti.html
@@ -5,10 +5,11 @@
     <title>SSTI DEMO</title>
   </head>
   <body>
-    <!-- True positive: preprocessing pattern with SSTI -->
+    <!-- ruleid: spring-thymeleaf-preprocess-ssti -->
     <h1 th:text="@{'/login?redirectAfterLogin=__${Referer}__'}"></h1>
 
-    <!-- True negative: normal expression without preprocessing -->
+    <!-- normal expression without preprocessing -->
+    <!-- ok: spring-thymeleaf-preprocess-ssti -->
     <h1 th:text="@{'/login?redirectAfterLogin=${Referer}'}"></h1>
   </body>
 </html>

--- a/java/spring/security/injection/thymeleaf-preprocess-ssti.html
+++ b/java/spring/security/injection/thymeleaf-preprocess-ssti.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>SSTI DEMO</title>
+  </head>
+  <body>
+    <!-- True positive: preprocessing pattern with SSTI -->
+    <h1 th:text="@{'/login?redirectAfterLogin=__${Referer}__'}"></h1>
+
+    <!-- True negative: normal expression without preprocessing -->
+    <h1 th:text="@{'/login?redirectAfterLogin=${Referer}'}"></h1>
+  </body>
+</html>

--- a/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
+++ b/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
@@ -2,7 +2,7 @@ rules:
   - id: thymeleaf-preprocess-ssti
     languages: 
       - html
-    severity: ERROR
+    severity: HIGH
     message: >
       Thymeleaf template contains a double-evaluation marker (__${...}__).
       This enables expression preprocessing and may allow Server-Side Template Injection (SSTI),

--- a/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
+++ b/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: thymeleaf-preprocess-ssti
+    languages: 
+      - html
+    severity: ERROR
+    message: >
+      Thymeleaf template contains a double-evaluation marker (__${...}__).
+      This enables expression preprocessing and may allow Server-Side Template Injection (SSTI),
+      potentially leading to arbitrary code execution depending on classpath and context.
+
+    metadata:
+      cwe: "CWE-1336: Improper Neutralization of Special Elements Used in a Template Engine"
+      category: "security"
+      confidence: "high"
+      likelihood: "medium"
+      impact: "high"
+      references:
+        - https://modzero.com/en/blog/spring_boot_ssti/
+
+    patterns:
+      - pattern-regex: '@\{[^}]*__\$\{[^}]+\}__[^}]*\}'

--- a/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
+++ b/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
@@ -18,4 +18,4 @@ rules:
         - https://modzero.com/en/blog/spring_boot_ssti/
 
     patterns:
-      - pattern-regex: '@\{[^}]*__\$\{[^}]+\}__[^}]*\}'
+      - pattern-regex: '[$*#@~]\{[^}]*__\$\{[^}]+\}__[^}]*\}'

--- a/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
+++ b/java/spring/security/injection/thymeleaf-preprocess-ssti.yaml
@@ -1,11 +1,11 @@
 rules:
-  - id: thymeleaf-preprocess-ssti
+  - id: spring-thymeleaf-preprocess-ssti
     languages: 
       - html
     severity: HIGH
     message: >
       Thymeleaf template contains a double-evaluation marker (__${...}__).
-      This enables expression preprocessing and may allow Server-Side Template Injection (SSTI),
+      This enables expression preprocessing and may allow SSTI if user input is included in the expression,
       potentially leading to arbitrary code execution depending on classpath and context.
 
     metadata:
@@ -14,8 +14,14 @@ rules:
       confidence: "high"
       likelihood: "medium"
       impact: "high"
+      subcategory:
+        - vuln
+      technology:
+        - spring
+        - thymeleaf
       references:
         - https://modzero.com/en/blog/spring_boot_ssti/
+        - https://www.acunetix.com/blog/web-security-zone/exploiting-ssti-in-thymeleaf/
 
     patterns:
       - pattern-regex: '[$*#@~]\{[^}]*__\$\{[^}]+\}__[^}]*\}'


### PR DESCRIPTION
Hello!

This PR introduces a new semgrep rule detecting dangerous Thymeleaf expressions that use the preprocessing marker `__${...}__`

This rule is based on security researches:
- https://modzero.com/en/blog/spring_boot_ssti/
- https://www.acunetix.com/blog/web-security-zone/exploiting-ssti-in-thymeleaf/ 

<img width="1009" height="173" alt="image" src="https://github.com/user-attachments/assets/d152cd80-f189-4f8c-8362-0a1392693f10" />

<img width="1489" height="560" alt="image" src="https://github.com/user-attachments/assets/80139363-44ea-4b9c-87ba-106f7e6df354" />
