### PR TITLE
#3678 - Lower severity of MemoryMarshal CreateSpan rule to INFO due to unavoidable false positives

### DIFF
--- a/csharp/lang/security/memory/memory-marshal-create-span.yaml
+++ b/csharp/lang/security/memory/memory-marshal-create-span.yaml
@@ -1,6 +1,6 @@
 rules:
 - id: memory-marshal-create-span
-  severity: WARNING
+  severity: INFO
   languages:
   - C#
   metadata:


### PR DESCRIPTION
This PR lowers the severity of the `memory-marshal-create-span` rule from **WARNING** to **INFO**.

`MemoryMarshal.CreateSpan` and `MemoryMarshal.CreateReadOnlySpan` can be unsafe if misused, but are not inherently unsafe APIs. The Microsoft documentation highlights potential risk, yet correct usage with explicit bounds validation is common and idiomatic in C#.

The current rule flags all usages unconditionally. Since Semgrep cannot reason about surrounding validation logic, this produces unavoidable false positives with no actionable remediation.

For teams using Semgrep in formal security audits or compliance contexts, non-actionable warning-level findings reduce signal quality. Marking this rule as **INFO** preserves its audit value without overstating risk.

This change addresses the issue raised in #3678.