### PR TITLE
New Rules Proposal: Detect usage of RemoteIPHeader directive in an apache configuration.

### DIFF
--- a/generic/apache/security/apache-remoteipheader.conf
+++ b/generic/apache/security/apache-remoteipheader.conf
@@ -1,0 +1,10 @@
+# ruleid: apache-remoteipheader
+RemoteIPHeader X-Forwarded-For
+<VirtualHost *:80>        
+    ServerAdmin webmaster1@localhost
+    DocumentRoot /var/www/html1
+    ErrorLog ${APACHE_LOG_DIR}/error1.log
+    CustomLog ${APACHE_LOG_DIR}/access1.log combined
+    # ruleid: apache-remoteipheader
+    RemoteIPHeader X-Forwarded-For
+</VirtualHost>

--- a/generic/apache/security/apache-remoteipheader.yaml
+++ b/generic/apache/security/apache-remoteipheader.yaml
@@ -1,0 +1,31 @@
+rules:
+  - id: apache-remoteipheader
+    message: The "RemoteIPHeader" directive is configured, this can lead to unexpected DNS queries.
+    severity: INFO
+    languages:
+      - generic
+    patterns:
+      - pattern: |
+          RemoteIPHeader $HEADER
+      - metavariable-regex:
+          metavariable: $HEADER
+          regex: "[A-Za-z0-9-]+"
+    fix: >
+      Verify that a rewrite rule "RewriteCond" is present to ensure that
+      the specified header contains a valid IPv4 or IPv6 address, and
+      reject the HTTP request if this is not the case.
+    references:
+      - https://httpd.apache.org/docs/current/mod/mod_remoteip.html
+      - https://httpd.apache.org/docs/current/mod/mod_rewrite.html
+    paths:
+      include:
+        - "**/*.conf"
+    cwe:
+      - "CWE-610: Externally Controlled Reference to a Resource in Another Sphere"
+    likelihood: LOW
+    impact: LOW
+    confidence: LOW
+    subcategory:
+      - audit
+    technology:
+    - apache


### PR DESCRIPTION
Hello,

This generic rule for apache is intended to detect when the directive [RemoteIPHeader](https://httpd.apache.org/docs/current/mod/mod_remoteip.html#remoteipheader) is used. The goal is for inform about the potential risks of unexpected DNS queries if the value of the header is not checked via for example a [rewrite rule](https://httpd.apache.org/docs/current/mod/mod_rewrite.html).

I tested the rule against the sample code using the online rule editor:

<img width="1844" height="760" alt="image" src="https://github.com/user-attachments/assets/9dabeb5f-a608-465d-aa89-b8498f26b6e3" />


Thank you very much for your feedback 😉
