### PR TITLE
csharp: Fix test mass-assignment example code

### DIFF
--- a/csharp/dotnet/security/audit/mass-assignment.cs
+++ b/csharp/dotnet/security/audit/mass-assignment.cs
@@ -7,7 +7,7 @@ public IActionResult Create(UserModel model)
     return View("Index", model);
 }
 
-public IActionResult Create([Bind(nameof(UserModel.Name))] UserModel model)
+public IActionResult Create1([Bind(nameof(UserModel.Name))] UserModel model)
 {
     context.SaveChanges();
     // ok: mass-assignment


### PR DESCRIPTION
It is not valid in C# to have two `Create` methods with the same type signature, and this makes the test bad when it comes to test Pro where these details matter.