### PR TITLE
test: add test cases for python lambda implicit return false positives

### DIFF
--- a/python/lang/correctness/return-in-init.py
+++ b/python/lang/correctness/return-in-init.py
@@ -76,6 +76,16 @@ class H:
         # ok:return-in-init
         return None
 
+class Lambda:
+    def __init__(self):
+        # ok:return-in-init
+        self.silly = lambda: 42
+
+class LambdaWithArg:
+    def __init__(self):
+        # ok:return-in-init
+        self.fn = lambda x: x + 1
+
 class Odd:
     def __init__(self, numbers):
         def is_odd(n):

--- a/python/lang/maintainability/return.py
+++ b/python/lang/maintainability/return.py
@@ -32,5 +32,8 @@ def resolve(key: str) -> str:
     # ok: code-after-unconditional-return
     return key, key
 
+# ok: return-not-in-function
+magic = lambda: 13
+
 # ruleid: return-not-in-function
 return (a, b)


### PR DESCRIPTION
## Summary

- Add `ok:return-in-init` test cases for lambdas inside `__init__`
- Add `ok:return-not-in-function` test case for top-level lambda expression

These test cases cover the fix in semgrep/semgrep-proprietary#5704 — Python lambdas were falsely triggering `return-in-init` and `return-not-in-function` rules.

Fixes https://github.com/semgrep/semgrep/issues/11520

## Test plan

- [x] Tests pass with the corresponding engine fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)