### PR TITLE
fix: Remove duplicate names from test files

### DIFF
--- a/go/lang/correctness/use-filepath-join.go
+++ b/go/lang/correctness/use-filepath-join.go
@@ -17,7 +17,7 @@ func a() {
 	path.Join("/", path.Base(p))
 }
 
-func a() {
+func a2() {
 	url, err := url.Parse("http://foo:666/bar")
 	if err != nil {
 		panic(err)
@@ -27,7 +27,7 @@ func a() {
 	fmt.Println(path.Join(url.Path, "baz"))
 }
 
-func a(p string) {
+func a3(p string) {
 	// ruleid: use-filepath-join
 	fmt.Println(path.Join(p, "baz"))
 

--- a/go/lang/security/injection/tainted-sql-string.go
+++ b/go/lang/security/injection/tainted-sql-string.go
@@ -110,7 +110,7 @@ func SelectHandler3(db *sql.DB) func(w http.ResponseWriter, req *http.Request) {
     }
 }
 
-func SelectHandler3(db *sql.DB) func(w http.ResponseWriter, req *http.Request) {
+func SelectHandler3ok(db *sql.DB) func(w http.ResponseWriter, req *http.Request) {
     return func(w http.ResponseWriter, req *http.Request) {
         del := req.URL.Query().Get("del")
         id := req.URL.Query().Get("Id")

--- a/java/lang/security/audit/formatted-sql-string.java
+++ b/java/lang/security/audit/formatted-sql-string.java
@@ -66,7 +66,7 @@ public class SqlExample2 {
         ResultSet rs = c.createStatement().execute(sql);
     }
 
-    public List<AccountDTO> findAccountsById(String id) {
+    public List<AccountDTO> findAccountsById(String id, String unused) {
         String jql = "from Account where id = '" + id + "'";
         EntityManager em = emfactory.createEntityManager();
         // ruleid:formatted-sql-string
@@ -92,7 +92,7 @@ public class SQLExample3 {
         ResultSet rs = c.createStatement().execute(sql);
     }
 
-    public List<AccountDTO> findAccountsById(String id) {
+    public List<AccountDTO> findAccountsById(String id, String unused) {
         String jql = String.format("from Account where id = '%s'", id);
         EntityManager em = emfactory.createEntityManager();
         // ruleid: formatted-sql-string

--- a/java/lang/security/audit/sqli/tainted-sql-from-http-request.java
+++ b/java/lang/security/audit/sqli/tainted-sql-from-http-request.java
@@ -251,7 +251,7 @@ public class bad5 extends HttpServlet {
 }
 
 @WebServlet(value = "/sqli-00/BenchmarkTest00008")
-public class bad1 extends HttpServlet {
+public class bad6 extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 

--- a/java/lang/security/audit/tainted-env-from-http-request.java
+++ b/java/lang/security/audit/tainted-env-from-http-request.java
@@ -71,8 +71,8 @@ public class bad2 extends HttpServlet {
     }
 }
 
-@WebServlet(value = "/cmdi-00/BenchmarkTest00007")
-public class bad2 extends HttpServlet {
+@WebServlet(value = "/cmdi-00/BenchmarkTest00007ok")
+public class bad2ok extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
@@ -110,7 +110,7 @@ public class bad2 extends HttpServlet {
             org.owasp.benchmark.helpers.Utils.printOSCommandResults(p, response);
 
             // ok: tainted-env-from-http-request
-            Process p = r.exec(param, argsEnv);
+            Process p2 = r.exec(param, argsEnv);
         } catch (IOException e) {
             System.out.println("Problem executing cmdi - TestCase");
             response.getWriter()

--- a/java/lang/security/audit/tainted-ldapi-from-http-request.java
+++ b/java/lang/security/audit/tainted-ldapi-from-http-request.java
@@ -302,8 +302,8 @@ public class BenchmarkTest00630 extends HttpServlet {
     }
 }
 
-@WebServlet(value = "/ldapi-00/BenchmarkTest00021")
-public class BenchmarkTest00021 extends HttpServlet {
+@WebServlet(value = "/ldapi-00/BenchmarkTest00021ok")
+public class BenchmarkTest00021ok extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 

--- a/java/lang/security/audit/tainted-session-from-http-request.java
+++ b/java/lang/security/audit/tainted-session-from-http-request.java
@@ -120,8 +120,8 @@ public class BenchmarkTest00321 extends HttpServlet {
     }
 }
 
-@WebServlet(value = "/trustbound-00/BenchmarkTest00004")
-public class BenchmarkTest00004 extends HttpServlet {
+@WebServlet(value = "/trustbound-00/BenchmarkTest00004ok")
+public class BenchmarkTest00004ok extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 

--- a/java/lang/security/audit/tainted-xpath-from-http-request.java
+++ b/java/lang/security/audit/tainted-xpath-from-http-request.java
@@ -185,8 +185,8 @@ public class BenchmarkTest01223 extends HttpServlet {
     } // end innerclass Test
 } // end DataflowThruInnerClass
 
-@WebServlet(value = "/xpathi-00/BenchmarkTest00207")
-public class BenchmarkTest00207 extends HttpServlet {
+@WebServlet(value = "/xpathi-00/BenchmarkTest00207ok")
+public class BenchmarkTest00207ok extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 

--- a/java/spring/security/injection/tainted-html-string.java
+++ b/java/spring/security/injection/tainted-html-string.java
@@ -284,7 +284,7 @@ public class XSSInImgTagAttribute {
             value = LevelConstants.LEVEL_7,
             variant = Variant.SECURE,
             htmlTemplate = "LEVEL_1/XSS")
-    public ResponseEntity<String> getVulnerablePayloadLevelSecure3(
+    public ResponseEntity<String> getVulnerablePayloadLevelSecure3ok(
             @RequestParam(PARAMETER_NAME) String imageLocation) {
         String vulnerablePayloadWithPlaceHolder = "not html";
 

--- a/java/spring/security/injection/tainted-sql-string.java
+++ b/java/spring/security/injection/tainted-sql-string.java
@@ -72,8 +72,8 @@ public class TestController {
         return rs;
     }
 
-    @RequestMapping(value = "/test5", method = RequestMethod.POST, produces = "plain/text")
-    ResultSet test5(@RequestBody String name) {
+    @RequestMapping(value = "/test5ok", method = RequestMethod.POST, produces = "plain/text")
+    ResultSet test5ok(@RequestBody String name) {
         try {
             // ok: tainted-sql-string
             throw new Exception(String.format("Update request from %s to %s isn't allowed",


### PR DESCRIPTION
Several Java and Go test files for rules had duplicate names where they weren't actually allowed by the language. This caused issues for naming in Semgrep, which assumes that this should be impossible.

This commit replaces those duplicate names with distinct names, or adds parameters to make method signatures non-overlapping.