### PR TITLE
Add additional GitHub properties

### DIFF
--- a/yaml/github-actions/security/run-shell-injection.yaml
+++ b/yaml/github-actions/security/run-shell-injection.yaml
@@ -54,7 +54,11 @@ rules:
         - pattern: ${{ ... github.event.pull_request.head.ref ... }}
         - pattern: ${{ ... github.event.pull_request.head.label ... }}
         - pattern: ${{ ... github.event.pull_request.head.repo.default_branch ... }}
+        - pattern: ${{ ... github.ref ... }}
+        - pattern: ${{ ... github.base_ref ... }}
         - pattern: ${{ ... github.head_ref ... }}
+        - pattern: ${{ ... github.ref_name ... }}
+        - pattern: ${{ ... github.workflow ... }}
         - pattern: ${{ ... github.event.inputs ... }}
         - pattern: ${{ ... github.event.discussion.title ... }}
         - pattern: ${{ ... github.event.discussion.body ... }}
@@ -74,7 +78,11 @@ rules:
       - pattern-not: ${{ ... github.event.pull_request.head.ref && ... }}
       - pattern-not: ${{ ... github.event.pull_request.head.label && ... }}
       - pattern-not: ${{ ... github.event.pull_request.head.repo.default_branch && ... }}
+      - pattern-not: ${{ ... github.ref && ... }}
+      - pattern-not: ${{ ... github.base_ref && ... }}
       - pattern-not: ${{ ... github.head_ref && ... }}
+      - pattern-not: ${{ ... github.ref_name && ... }}
+      - pattern-not: ${{ ... github.workflow && ... }}
       - pattern-not: ${{ ... github.event.discussion.title && ... }}
       - pattern-not: ${{ ... github.event.discussion.body && ... }}
   severity: ERROR


### PR DESCRIPTION
If `head_ref` is deemed untrustworthy, we should include the other properties that reference a branch name. We should also include workflow names, which can be attacker controlled when used with `pull_request_target`.

Source: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context