### PR TITLE
fix: Remove duplicate function names from test files

### DIFF
--- a/javascript/deno/security/audit/deno-dangerous-run.js
+++ b/javascript/deno/security/audit/deno-dangerous-run.js
@@ -17,7 +17,7 @@ async function test1(userInput) {
   await p.status();
 }
 
-async function test1(userInput) {
+async function test2(userInput) {
   const p = Deno.run({
     // ruleid: deno-dangerous-run
     cmd: ["bash", "-c", userInput],

--- a/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.js
+++ b/javascript/lang/security/audit/path-traversal/path-join-resolve-traversal.js
@@ -11,7 +11,7 @@ function test1() {
 }
 
 function test2() {
-    function someFunc(val) {
+    function someFunc2(val) {
         createFile({
             // ruleid:path-join-resolve-traversal
             filePath: path.resolve(opts.path, val)

--- a/javascript/lang/security/detect-child-process.js
+++ b/javascript/lang/security/detect-child-process.js
@@ -8,7 +8,7 @@ function a(args) {
   });
 }
 
-function a(userInput) {
+function a2(userInput) {
   // ruleid:detect-child-process
   cp.spawnSync(userInput);
 }

--- a/python/django/security/audit/avoid-insecure-deserialization.py
+++ b/python/django/security/audit/avoid-insecure-deserialization.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 import datetime
 
-def current_datetime(request):
+def current_datetime_ok(request):
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -11,7 +11,7 @@ def current_datetime(request):
 
 # pickle tests
 
-def current_datetime(request):
+def current_datetime_pickle_b64(request):
     user_obj = b64decode(request.cookies.get('uuid'))
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -19,7 +19,7 @@ def current_datetime(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(user_obj))
 
-def current_datetime(request):
+def current_datetime_pickle(request):
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -27,7 +27,7 @@ def current_datetime(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(user_obj))
 
-def current_datetime(request):
+def current_datetime_pickle_nested_b64(request):
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -35,13 +35,13 @@ def current_datetime(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(b64decode(user_obj)))
 
-def current_datetime(request):
+def current_datetime_pickle_inline(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(pickle.loads(b64decode(request.cookies.get('uuid'))))
 
 # Other libraries
 
-def current_datetime(request):
+def current_datetime_underscore_pickle(request):
     user_obj = b64decode(request.cookies.get('uuid'))
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -49,7 +49,7 @@ def current_datetime(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(_pickle.loads(user_obj))
 
-def current_datetime(request):
+def current_datetime_cpickle(request):
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -57,7 +57,7 @@ def current_datetime(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(cPickle.loads(user_obj))
 
-def current_datetime(request):
+def current_datetime_dill(request):
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -65,7 +65,7 @@ def current_datetime(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(dill.loads(b64decode(user_obj)))
 
-def current_datetime(request):
+def current_datetime_shelve(request):
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now
@@ -73,7 +73,7 @@ def current_datetime(request):
     # ruleid:avoid-insecure-deserialization
     return "Hey there! {}!".format(shelve.loads(user_obj))
 
-def current_datetime(request):
+def current_datetime_yaml(request):
     user_obj = request.cookies.get('uuid')
     now = datetime.datetime.now()
     html = "<html><body>It is now %s.</body></html>" % now

--- a/python/flask/security/injection/raw-html-concat.py
+++ b/python/flask/security/injection/raw-html-concat.py
@@ -83,8 +83,8 @@ def ok():
     # ok: raw-html-format
     return "<a href='https://example.com'>Click me!</a>"
 
-@app.route("/post_param_branch", methods=["POST"])
-def post_param_branch():
+@app.route("/post_param_branch_ok", methods=["POST"])
+def post_param_branch_ok():
     param = flask.request.form['param']
     part = flask.render_template("link.html", data=param)
     if True:

--- a/python/flask/security/injection/tainted-sql-string.py
+++ b/python/flask/security/injection/tainted-sql-string.py
@@ -55,7 +55,7 @@ def insert_person():
     engine.execute(query, {"x":"%@aol.com", "y":name}).fetchall()
 
 @app.route("/insert/person/path")
-def insert_person(path):
+def insert_person_path(path):
     name = path
     lastname = "you don't get to pick >:)"
 

--- a/python/flask/security/injection/tainted-url-host.py
+++ b/python/flask/security/injection/tainted-url-host.py
@@ -115,7 +115,7 @@ def load_model(model):
 
 # Real world example
 @app.route('/models/<model>')
-def load_model(model):
+def load_model_ok(model):
     # ok: tainted-url-host
     htmlpage = '''
     <body style='margin : 0px; overflow: hidden;'>

--- a/python/lang/security/audit/dangerous-subinterpreters-run-string-tainted-env-args.py
+++ b/python/lang/security/audit/dangerous-subinterpreters-run-string-tainted-env-args.py
@@ -8,7 +8,7 @@ def run_payload(payload: str) -> None:
     _xxsubinterpreters.run_string(_xxsubinterpreters.create(), payload)
 
 
-def run_payload(payload: str) -> None:
+def run_payload_param(payload: str) -> None:
     # fn: dangerous-subinterpreters-run-string-tainted-env-args
     _xxsubinterpreters.run_string(_xxsubinterpreters.create(), payload)
 

--- a/ruby/lang/security/dangerous-exec.rb
+++ b/ruby/lang/security/dangerous-exec.rb
@@ -57,24 +57,24 @@ def test_calls(user_input)
     exec(["ls", "-lah", "/tmp"])
   end
 
-  def test_params()
+  def test_params2()
     user_input = params['some_key']
   # ruleid: dangerous-exec
     exec("ls -lah #{user_input}")
-  
+
   # ruleid: dangerous-exec
     Process.spawn([user_input, "smth"])
-  
+
   # ruleid: dangerous-exec
     output = exec(["sh", "-c", user_input])
-  
+
   # ruleid: dangerous-exec
     pid = spawn(["bash", user_input])
-  
+
     commands = "ls -lah /raz/dva"
   # ok: dangerous-exec
     system(commands)
-  
+
     cmd_name = "sh"
   # ok: dangerous-exec
     Process.exec([cmd_name, "ls", "-la"])

--- a/ruby/rails/security/brakeman/check-regex-dos.rb
+++ b/ruby/rails/security/brakeman/check-regex-dos.rb
@@ -4,13 +4,13 @@ def some_rails_controller
   Regexp.new(foo).match("some_string")
 end
 
-def some_rails_controller
+def some_rails_controller2
   foo = Record[something]
   #ruleid: check-regex-dos
   Regexp.new(foo).match("some_string")
 end
 
-def some_rails_controller
+def some_rails_controller3
   foo = Record.read_attribute("some_attribute")
   #ruleid: check-regex-dos
   Regexp.new(foo).match("some_string")

--- a/ruby/rails/security/brakeman/check-render-local-file-include.rb
+++ b/ruby/rails/security/brakeman/check-render-local-file-include.rb
@@ -16,7 +16,7 @@
     render file: "/some/path/#{page}"
   end
 
-  def test_render_with_modern_param
+  def test_render_with_modern_param_sanitized
     page = params[:page]
     #ok: check-render-local-file-include
     render file: File.basename("/some/path/#{page}")

--- a/ruby/rails/security/injection/raw-html-format.rb
+++ b/ruby/rails/security/injection/raw-html-format.rb
@@ -44,7 +44,7 @@ class ActionPackAssertionsController < ActionController::Base
     render inline: Kernel::sprintf("<div>%s</div>", name)
   end
 
-  def render_url
+  def render_url_ok
     # ok: raw-html-format
     render html: "boo, %s" % params[:name]
   end

--- a/typescript/react/security/audit/react-href-var.tsx
+++ b/typescript/react/security/audit/react-href-var.tsx
@@ -22,7 +22,7 @@ let zzz = <Foo className={"foobar"} href={SEMGREP_REPO} />;
 // ok: react-href-var
 let zzz = <Foo className={"foobar"} href={SEMGREP_REPO1} />;
 
-function test1(input) {
+function test1_ok(input) {
 // ok: react-href-var
   if(input.startsWith("https:")) {
     const params = {href: input};
@@ -36,7 +36,7 @@ function test2(input) {
   return React.createElement("a", params);
 }
 
-function test2(input) {
+function test2_ok(input) {
   // ok: react-href-var
   const params = {href: "#"+input};
   return React.createElement("a", params);


### PR DESCRIPTION
Disambiguate duplicate function/method names that lead to odd shadowing of results. All the actual matches are preserved.