### PR TITLE
Add exception patterns to update rule on H2C smuggling in Nginx config

### DIFF
--- a/generic/nginx/security/possible-h2c-smuggling.yaml
+++ b/generic/nginx/security/possible-h2c-smuggling.yaml
@@ -20,6 +20,10 @@ rules:
         proxy_http_version 1.1 ...;
         ...
         proxy_set_header Connection ...;
+  - pattern-not: |
+      proxy_set_header Upgrade websocket;
+  - pattern-not: |
+      proxy_set_header Upgrade "websocket";
   - pattern-inside: |
       location ... {
         ...


### PR DESCRIPTION
The rule's own mitigation advice (set Upgrade: websocket) was not excluded by the pattern, causing a false positive even after remediation. Added pattern-not clauses for both quoted and unquoted websocket literal values.

Closes #3768 