### PR TITLE
fix(c): improve insecure-use-strtok-fn message

### DIFF
--- a/c/lang/security/insecure-use-strtok-fn.c
+++ b/c/lang/security/insecure-use-strtok-fn.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <string.h>
 
 int DST_BUFFER_SIZE = 120;
 

--- a/c/lang/security/insecure-use-strtok-fn.yaml
+++ b/c/lang/security/insecure-use-strtok-fn.yaml
@@ -2,9 +2,13 @@ rules:
 - id: insecure-use-strtok-fn
   pattern: strtok(...)
   message: >-
-    Avoid using 'strtok()'. This function directly modifies the first argument buffer,
-    permanently erasing the
-    delimiter character. Use 'strtok_r()' instead.
+    Avoid using 'strtok()'. This function is not thread-safe because it uses
+    internal static state to track parsing position. Concurrent or nested calls
+    to 'strtok()' on different strings will corrupt each other's state, leading
+    to incorrect parsing or undefined behavior. It also modifies the input buffer
+    in place by overwriting delimiter characters with null bytes.
+    Use 'strtok_r()' (POSIX) or 'strtok_s()' (C11 Annex K) instead, which take
+    an explicit save pointer and are safe for both threaded and nested use.
   metadata:
     cwe:
     - 'CWE-676: Use of Potentially Dangerous Function'


### PR DESCRIPTION
  The current message says strtok "permanently erases the delimiter character", which is strtok's normal documented behavior, not a security issue.

So we updated the message to describe the **actual risks**:                                                                                 
  - Non-thread-safe internal static state (concurrent/nested calls corrupt parsing)
  - Input buffer mutation (secondary, but worth noting)                                                                                 
  - Recommends both `strtok_r()` (POSIX) and `strtok_s()` (C11) as alternatives                                                         

Found while scanning [Vim](https://github.com/vim/vim) (~400k LOC) with `--config auto` — all 21 strtok findings were false positives. The inaccurate message made triage harder since the stated risk wasn't the real concern.