### PR TITLE
Fix false positive with usedforsecurity flag in hashlib.sha1 (python)

### DIFF
--- a/python/lang/security/insecure-hash-algorithms.py
+++ b/python/lang/security/insecure-hash-algorithms.py
@@ -7,4 +7,7 @@ import hashlib
 hashlib.sha1(1)
 
 # ok:insecure-hash-algorithm-sha1
+hashlib.sha1(1,usedforsecurity=False)
+
+# ok:insecure-hash-algorithm-sha1
 hashlib.sha256(1)

--- a/python/lang/security/insecure-hash-algorithms.yaml
+++ b/python/lang/security/insecure-hash-algorithms.yaml
@@ -1,6 +1,8 @@
 rules:
 - id: insecure-hash-algorithm-sha1
-  pattern: hashlib.sha1(...)
+  patterns: 
+    - pattern: hashlib.sha1(...)
+    - pattern-not: hashlib.sha1(..., usedforsecurity=False, ...)
   fix-regex:
     regex: sha1
     replacement: sha256


### PR DESCRIPTION
Hello together,

similar to https://github.com/semgrep/semgrep-rules/pull/3077

I want to propose that `usedforsecurity` is also considered as false positive for `hashlib.sha1` in the python rules

So that 
```python
# ruleid:insecure-hash-algorithm-sha1
hashlib.sha1(1)

# ok:insecure-hash-algorithm-sha1
hashlib.sha1(1,usedforsecurity=False)
```