### PR TITLE
feat(netsuite): add best practices SAST governance rules

### DIFF
--- a/javascript/contributions/netsuite/best-practices.yaml
+++ b/javascript/contributions/netsuite/best-practices.yaml
@@ -121,26 +121,6 @@ rules:
           - pattern: $SEARCH.create(...)
           - pattern: $QUERY.run(...)
 
-  - id: netsuite-query-injection
-    languages: [javascript, typescript]
-    severity: WARNING
-    metadata:
-      technology: [netsuite]
-      type: Security
-      category: Injection
-      author: Joshua Meiri (Origami Precision, LLC)
-      references: [https://www.origamiprecision.com/]
-      origami-rationale: Concatenating variables into query strings can lead to SuiteQL injection. Using parameter binding with `params` ensures that variables are safely escaped, preventing malicious data extraction or manipulation.
-    message: "**Injection Risk:** Potential SuiteQL injection via string concatenation. Use the `params` property in `query.runSuiteQL()` to safely bind variables."
-    patterns:
-      - pattern-either:
-          - pattern: |
-              query.runSuiteQL({ query: ... + $VAR + ..., ... })
-          - pattern: |
-              query.runSuiteQL({ query: ... + $VAR, ... })
-          - pattern: |
-              query.runSuiteQL({ query: $VAR + ..., ... })
-
   - id: netsuite-enforce-sri-cdn
     languages: [javascript, typescript, html]
     severity: WARNING

--- a/javascript/contributions/netsuite/best-practices.yaml
+++ b/javascript/contributions/netsuite/best-practices.yaml
@@ -13,6 +13,7 @@ rules:
       risk: Console
       license: commons
       author: Joshua Meiri (Origami Precision, LLC)
+      origami-rationale: console.log is transient and doesn't write to the Execution Log. Using it in production leaves zero audit trail for troubleshooting.
       technology:
         - netsuite
       references:
@@ -33,6 +34,7 @@ rules:
       risk: Blow-up
       license: commons
       author: Joshua Meiri (Origami Precision, LLC)
+      origami-rationale: Standard O(n) operations become O(n^2) governance killers when inside loops.
       references:
         - https://www.origamiprecision.com/
       technology:
@@ -60,6 +62,7 @@ rules:
       risk: Try/Catch
       license: commons
       author: Joshua Meiri (Origami Precision, LLC)
+      origami-rationale: Prevents silent crashes that leave integrations or related records in an inconsistent state.
       technology:
         - netsuite
       source_rule_url:
@@ -69,6 +72,7 @@ rules:
     message: "**NetSuite Reliability Risk:** Root try-catch missing in afterSubmit. 
              While NetSuite handles uncaught exceptions, explicit error handling allows for better logging, notification of admins, and graceful recovery of side-effects
              (like integrations or related record updates) that occur post-save."
+    # Removed $(SOMETHING) at the end, makes it trully function level 
     patterns:
       - pattern-inside: |
           function afterSubmit($CONTEXT) {
@@ -82,4 +86,125 @@ rules:
               ...
             }
           }
-      - pattern: $SOMETHING(...)
+
+  # Add-ons
+  - id: netsuite-unbounded-search
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      technology: [netsuite]
+      type: Scalability
+      author: Based on feedback from r/netsuite
+      origami-rationale: Searches that work in Sandbox with 10 records will timeout in Prod with 10k+ records. Enforcing paged searches prevents this common scalability pitfall.
+    message: "**Scalability Risk:** Unbounded search detected. Always use `.getRange()` or `runPaged()` to prevent script timeouts as the dataset grows in Production."
+    patterns:
+      - pattern-either:
+          - pattern: $SEARCH.run().each(...)
+          - pattern: $SEARCH.run().get(...)
+      - pattern-not: $SEARCH.run().getRange(...)
+      - pattern-not: $SEARCH.runPaged(...)
+
+  - id: netsuite-no-query-search-in-loop
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      technology: [netsuite]
+      type: Performance
+      author: Joshua Meiri (Origami Precision, LLC) and feedback from r/netsuite
+      references: [https://www.origamiprecision.com/]
+      origami-rationale: Search and Query setup have high fixed costs. Running them inside loops creates O(n) performance that can be refactored to O(1) with an 'anyof' filter.
+    message: "**Performance Warning:** N/search or N/query execution detected inside a loop. Consider refactoring to a single search with an 'anyof' filter to save governance."
+    patterns:
+      - pattern-inside: |
+          for (...) { ... }
+      - pattern-either:
+          - pattern: $SEARCH.create(...)
+          - pattern: $QUERY.run(...)
+
+  - id: netsuite-query-injection
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      technology: [netsuite]
+      type: Security
+      category: Injection
+      author: Joshua Meiri (Origami Precision, LLC)
+      references: [https://www.origamiprecision.com/]
+      origami-rationale: Concatenating variables into query strings can lead to SuiteQL injection. Using parameter binding with `params` ensures that variables are safely escaped, preventing malicious data extraction or manipulation.
+    message: "**Injection Risk:** Potential SuiteQL injection via string concatenation. Use the `params` property in `query.runSuiteQL()` to safely bind variables."
+    patterns:
+      - pattern-either:
+          - pattern: |
+              query.runSuiteQL({ query: ... + $VAR + ..., ... })
+          - pattern: |
+              query.runSuiteQL({ query: ... + $VAR, ... })
+          - pattern: |
+              query.runSuiteQL({ query: $VAR + ..., ... })
+
+  - id: netsuite-enforce-sri-cdn
+    languages: [javascript, typescript, html]
+    severity: WARNING
+    metadata:
+      technology: [netsuite]
+      type: Security
+      category: best-practice
+      author: Based on feedback from Simon Camilleri
+      origami-rationale: CDN compromises are increasingly common. Subresource Integrity (SRI) allows browsers to verify that the fetched resource has not been tampered with. Enforcing SRI on CDN imports is a critical security measure to protect NetSuite Portals from compromised 3rd-party CDNs injecting malicious JS.
+    message: "**Security Risk:** CDN import missing Subresource Integrity (SRI). Always include 'integrity' and 'crossorigin' attributes for external libraries."
+    patterns:
+      - pattern-regex: '<script[^>]+src=["''](http|https)://[^"'']+["''](?![^>]*integrity=)[^>]*>'
+
+  - id: netsuite-no-generic-custom-ids
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      technology: [netsuite]
+      type: Maintainability
+      author: Joshua Meiri (Origami Precision, LLC) and feedback from Craig Silk
+      references: [https://www.origamiprecision.com/]
+      origami-rationale: Generic IDs are "technical debt" that make the codebase unreadable for future devs. Descriptive slugs improve readability and maintainability, making it clear what each record represents without needing to cross-reference the NetSuite UI.
+    message: "**Architecture Risk:** Generic NetSuite ID detected ('$ID'). Avoid auto-generated IDs like 'custrecord123'. Use descriptive slugs (e.g., custrecord_op_vendor_tier)."
+    patterns:
+      - pattern-regex: '(?i)cust(record|body|item|entity|script|entry)\d+'
+
+  - id: netsuite-hardcoded-internal-id
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      technology: [netsuite]
+      type: Reliability
+      author: Joshua Meiri (Origami Precision, LLC)
+      references: [https://www.origamiprecision.com/]
+      origami-rationale: Hardcoded Internal IDs are the No. 1 reason scripts fail during deployment to new environments. Using Script Parameters or descriptive Script IDs ensures that your code is portable and doesn't break when moving from Sandbox to Production, where Internal IDs often differ.
+    message: "**Portability Risk:** Hardcoded Internal ID detected. Internal IDs change across environments (Sandbox to Prod). Use Script Parameters or descriptive Script IDs instead."
+    patterns:
+      - pattern-either:
+          - pattern: "record.load({..., id: $ID, ...})"
+          - pattern: "$V: $ID"
+      - metavariable-regex:
+          metavariable: $ID
+          # Refined regex: strictly 4+ digits to avoid flagging 0, 1, 10, etc.
+          regex: '^\d{4,10}$'
+      - pattern-not: "{..., start: $ID, ...}"
+      - pattern-not: "{..., end: $ID, ...}"
+
+  - id: netsuite-prefer-submit-fields
+    languages: [javascript, typescript]
+    severity: WARNING
+    metadata:
+      technology: [netsuite]
+      type: Performance
+      author: Joshua Meiri (Origami Precision, LLC) and based on feedback from Stephen Lemp
+      origami-rationale: Loading a full object when only a single field needs updating is high-overhead.
+    message: "**Optimization Opportunity:** record.load/save detected for body field updates. If you are only updating body fields (no sublists), use `record.submitFields()` instead to save 10-20x governance units and CPU time."
+    patterns:
+      - pattern: |
+          var $REC = record.load(...);
+          ...
+          $REC.setValue(...);
+          ...
+          $REC.save();
+      - pattern-not: |
+          ...
+          $REC.insertLine(...)
+          ...

--- a/javascript/contributions/netsuite/best-practices.yaml
+++ b/javascript/contributions/netsuite/best-practices.yaml
@@ -66,9 +66,9 @@ rules:
         - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
       references:
         - https://www.origamiprecision.com/
-    message: "**NetSuite Reliability Risk:** afterSubmit function lacks a root
-      `try/catch` block. Unhandled errors here will block the record from
-      saving."
+    message: "**NetSuite Reliability Risk:** Root try-catch missing in afterSubmit. 
+             While NetSuite handles uncaught exceptions, explicit error handling allows for better logging, notification of admins, and graceful recovery of side-effects
+             (like integrations or related record updates) that occur post-save."
     patterns:
       - pattern-inside: |
           function afterSubmit($CONTEXT) {

--- a/javascript/contributions/netsuite/best-practices.yaml
+++ b/javascript/contributions/netsuite/best-practices.yaml
@@ -2,7 +2,7 @@ rules:
   - id: netsuite-no-console-log
     languages:
       - javascript
-    severity: ERROR
+    severity: WARNING
     message: "**NetSuite Disclosure/Audit Risk:** Use NetSuite's native `N/log`
       module (`log.debug, log.audit, log.error`) instead of `console.log` for
       persistent audit trails. Bad if left in Production."

--- a/javascript/contributions/netsuite/best-practices.yaml
+++ b/javascript/contributions/netsuite/best-practices.yaml
@@ -1,0 +1,85 @@
+rules:
+  - id: netsuite-no-console-log
+    languages:
+      - javascript
+    severity: ERROR
+    message: "**NetSuite Disclosure/Audit Risk:** Use NetSuite's native `N/log`
+      module (`log.debug, log.audit, log.error`) instead of `console.log` for
+      persistent audit trails. Bad if left in Production."
+    pattern: console.log(...)
+    metadata:
+      type: Security
+      category: best-practice
+      risk: Console
+      license: commons
+      author: Joshua Meiri (Origami Precision, LLC)
+      technology:
+        - netsuite
+      references:
+        - https://www.origamiprecision.com/
+
+  - id: netsuite-no-record-load-save-in-loop
+    languages:
+      - javascript
+      - typescript
+    message: >
+      **NetSuite Governance Trap:** Database call (`load/save`) detected inside
+      a loop. This leads to O(n^2) performance and will cause
+      `SSS_USAGE_LIMIT_EXCEEDED`. Use `N/search` or `N/query` instead.
+    severity: ERROR
+    metadata:
+      type: Governance
+      category: best-practice
+      risk: Blow-up
+      license: commons
+      author: Joshua Meiri (Origami Precision, LLC)
+      references:
+        - https://www.origamiprecision.com/
+      technology:
+        - netsuite
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              for (...) { ... }
+          - pattern-inside: |
+              while (...) { ... }
+          - pattern-inside: |
+              $ARRAY.forEach(...)
+      - pattern-either:
+          - pattern: $RECORD.load(...)
+          - pattern: $RECORD.save(...)
+
+  - id: netsuite-unhandled-aftersubmit-try-catch
+    languages:
+      - javascript
+      - typescript
+    severity: WARNING
+    metadata:
+      type: Reliability
+      category: best-practice
+      risk: Try/Catch
+      license: commons
+      author: Joshua Meiri (Origami Precision, LLC)
+      technology:
+        - netsuite
+      source_rule_url:
+        - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
+      references:
+        - https://www.origamiprecision.com/
+    message: "**NetSuite Reliability Risk:** afterSubmit function lacks a root
+      `try/catch` block. Unhandled errors here will block the record from
+      saving."
+    patterns:
+      - pattern-inside: |
+          function afterSubmit($CONTEXT) {
+            ...
+          }
+      - pattern-not-inside: |
+          function afterSubmit($CONTEXT) {
+            try {
+              ...
+            } catch ($E) {
+              ...
+            }
+          }
+      - pattern: $SOMETHING(...)

--- a/javascript/contributions/netsuite/best-practices.yaml
+++ b/javascript/contributions/netsuite/best-practices.yaml
@@ -23,10 +23,10 @@ rules:
       - javascript
       - typescript
     message: >
-      **NetSuite Governance Trap:** Database call (`load/save`) detected inside
-      a loop. This leads to O(n^2) performance and will cause
-      `SSS_USAGE_LIMIT_EXCEEDED`. Use `N/search` or `N/query` instead.
-    severity: ERROR
+      **NetSuite Governance Trap:** Performance Risk: Database call (load/save/submit) detected inside a loop. 
+      While small loops in Suitelets with usage-limit checks may be valid, this pattern often leads to SSS_USAGE_LIMIT_EXCEEDED. 
+      Ensure you are either using N/search or have explicit logic to offload to Map/Reduce if governance is low.
+    severity: WARNING
     metadata:
       type: Governance
       category: best-practice

--- a/javascript/contributions/netsuite/best-practices_test.js
+++ b/javascript/contributions/netsuite/best-practices_test.js
@@ -1,23 +1,118 @@
+/**
+ * Semgrep Test File for NetSuite Gatekeeper
+ */
+
 // --- SHOULD FAIL ---
+// ruleid: netsuite-enforce-sri-cdn
+const badCdn = '<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>';
+
+// --- SHOULD PASS ---
+// ok: netsuite-enforce-sri-cdn
+const goodCdn = '<script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-abc" crossorigin="anonymous"></script>';
+
+// ==========================================
+// --- SHOULD FAIL (Architectural Risks) ---
+// ==========================================
+
+// ruleid: netsuite-unhandled-aftersubmit-try-catch
 function afterSubmit(context) {
-    
     const rec = context.newRecord;
     
+    // ruleid: netsuite-hardcoded-internal-id 
+    let heavyRec = record.load({ type: 'salesorder', id: 7899 });
+
     for (let i = 0; i < 10; i++) {
+      
         // ruleid: netsuite-no-record-load-save-in-loop
-        // ruleid: netsuite-unhandled-aftersubmit-try-catch
         const otherRec = record.load({ type: 'customer', id: i });
+        
+        // ruleid: netsuite-no-record-load-save-in-loop
+        otherRec.save();
     }
     
     // ruleid: netsuite-no-console-log
     console.log('Testing...');
+
+    // ruleid: netsuite-no-generic-custom-ids
+    const fieldId = 'custbody123'; 
+    
+    // ruleid: netsuite-query-injection
+    query.runSuiteQL({ query: 'SELECT * FROM x WHERE id = ' + userId });
+
 }
 
-// --- SHOULD PASS ---
+// ==========================================
+// --- SHOULD PASS (ABCD Standards) ---
+// ==========================================
+// ok: netsuite-unhandled-aftersubmit-try-catch
 function afterSubmit(context) {
     try {
-        log.debug('Safe execution');
+        // ok: netsuite-hardcoded-internal-id
+        // ok: netsuite-unbounded-search
+        const results = mySearch.run().getRange({ start: 0, end: 10 });
+
+        // ok: netsuite-query-injection
+        query.runSuiteQL({
+            query: 'SELECT * FROM employee WHERE id = ?',
+            params: ['123']
+        });
     } catch (e) {
-        log.error('Error handled', e);
+        log.error('Error', e);
     }
+}
+
+/**
+ * Semgrep Test File for NetSuite Gatekeeper
+ */
+
+// ==========================================
+// --- SHOULD FAIL (Optimization Risk) ---
+// ==========================================
+
+function updateMemo(recordId) {
+    // ruleid: netsuite-prefer-submit-fields
+    var rec = record.load({
+        type: record.Type.SALES_ORDER,
+        id: recordId
+    });
+    rec.setValue({
+        fieldId: 'memo',
+        value: 'Updated via Gatekeeper'
+    });
+    rec.save();
+}
+
+// ==========================================
+// --- SHOULD PASS (Valid Load/Save) ---
+// ==========================================
+
+function addLineItem(recordId) {
+    // ok: netsuite-prefer-submit-fields
+    // This is valid because we are modifying a sublist (insertLine)
+    var rec = record.load({
+        type: record.Type.SALES_ORDER,
+        id: recordId
+    });
+    rec.insertLine({
+        sublistId: 'item',
+        line: 0
+    });
+    rec.setCurrentSublistValue({
+        sublistId: 'item',
+        fieldId: 'item',
+        value: 123
+    });
+    rec.save();
+}
+
+function optimizedUpdate(recordId) {
+    // ok: netsuite-prefer-submit-fields
+    // This is the ABCD-approved way to update a single field
+    record.submitFields({
+        type: record.Type.SALES_ORDER,
+        id: recordId,
+        values: {
+            'memo': 'Optimized Update'
+        }
+    });
 }

--- a/javascript/contributions/netsuite/best-practices_test.js
+++ b/javascript/contributions/netsuite/best-practices_test.js
@@ -1,0 +1,23 @@
+// --- SHOULD FAIL ---
+function afterSubmit(context) {
+    
+    const rec = context.newRecord;
+    
+    for (let i = 0; i < 10; i++) {
+        // ruleid: netsuite-no-record-load-save-in-loop
+        // ruleid: netsuite-unhandled-aftersubmit-try-catch
+        const otherRec = record.load({ type: 'customer', id: i });
+    }
+    
+    // ruleid: netsuite-no-console-log
+    console.log('Testing...');
+}
+
+// --- SHOULD PASS ---
+function afterSubmit(context) {
+    try {
+        log.debug('Safe execution');
+    } catch (e) {
+        log.error('Error handled', e);
+    }
+}


### PR DESCRIPTION
### **Title: feat(javascript): Add NetSuite SAST governance and best practices ruleset**

### **Description:**

This PR introduces the first foundational SAST ruleset for **Oracle NetSuite (SuiteScript)** to the Semgrep registry. 

NetSuite runs on a proprietary JavaScript API (SuiteScript 2.x) executed via a GraalVM backend. Because it is a multi-tenant cloud ERP, it enforces strict "Governance Limits" (usage units) on database operations. Standard JavaScript linting cannot catch these platform-specific governance traps, which often lead to fatal `SSS_USAGE_LIMIT_EXCEEDED` errors in production. 

With the rapid adoption of AI-generated code (Copilot, Claude), this problem is escalating. AI models frequently write naive "Happy Path" JavaScript that works syntactically but violently violates NetSuite's database governance. This ruleset acts as a gatekeeper to prevent architectural anti-patterns from reaching production.

**Rules Included in this PR:**
1. `netsuite-no-record-load-save-in-loop`: 
   * **The Risk:** Loading or saving a NetSuite record inside a `for/while/for each` loop creates an $O(n^2)$ performance bottleneck and rapidly burns through script governance units.
   * **The Fix:** Forces developers to rethink the architecture and use bulk-fetch mechanisms like `N/search` or `N/query` outside the loop.
2. `netsuite-unhandled-aftersubmit-try-catch`: 
   * **The Risk:** NetSuite User Event `afterSubmit` triggers execute *after* the 'database' commit but before the user's UI resolves. An unhandled exception here can cause data inconsistency or block the user from saving the record entirely.
   * **The Fix:** Enforces a root-level `try/catch` block for mission-critical entry points.
3. `netsuite-no-console-log`: 
   * **The Risk:** Using standard browser `console.log` in backend SuiteScript is an audit and execution risk. 
   * **The Fix:** Enforces the use of NetSuite's native telemetry module (`N/log`).

**Testing:**
* Added comprehensive `_test.js` files covering `ruleid` hits and `ok` passes for all patterns.
* Passed local `semgrep --validate` checks.

**About the Author:**
My name is Joshua Meiri, and I specialize in AI-Native NetSuite Engineering. I am the creator of the **ABCD (Always Be Continuously Deliberate)** methodology, which transitions NetSuite teams from legacy, UI-based scripting into modern, testable, MVC-driven DevOps lifecycles. I have over 20 years of experience in CRM and ERP systems and the creator of [origami lens](http://origamilens.com/) of NetSuite metadata exploration. 

I built these rules because the ecosystem currently lacks a standardized, automated defense against AI-generated hallucinations and legacy messy code. By contributing this to the official registry, I hope to establish a true "financial primitive" of platform-wide safety for NetSuite developers globally. 

More rules to come! 

