### PR TITLE
Added support for calloc as allocator function for heap security rules.

### DIFF
--- a/c/lang/security/double-free.yaml
+++ b/c/lang/security/double-free.yaml
@@ -19,6 +19,10 @@ rules:
                 pattern-either:
                   - pattern: malloc
                   - pattern: calloc
+                  - pattern: realloc
+                  - pattern: reallocarray
+                  - pattern: strdup
+                  - pattern: strndup
   - pattern-inside: |
       free($VAR);
       ...

--- a/c/lang/security/double-free.yaml
+++ b/c/lang/security/double-free.yaml
@@ -7,12 +7,18 @@ rules:
       $VAR = NULL;
       ...
       free($VAR);
-  - pattern-not: |
-      free($VAR);
-      ...
-      $VAR = malloc(...);
-      ...
-      free($VAR);
+  - pattern-not:
+        patterns:
+            - pattern-inside: |
+                free($VAR);
+                ...
+                $VAR = $ALLOC(...);
+                ...
+            - metavariable-pattern:
+                metavariable: $ALLOC
+                pattern-either:
+                  - pattern: malloc
+                  - pattern: calloc
   - pattern-inside: |
       free($VAR);
       ...

--- a/c/lang/security/function-use-after-free.yaml
+++ b/c/lang/security/function-use-after-free.yaml
@@ -29,6 +29,10 @@ rules:
                 pattern-either:
                   - pattern: malloc
                   - pattern: calloc
+                  - pattern: realloc
+                  - pattern: reallocarray
+                  - pattern: strdup
+                  - pattern: strndup
     message: Variable '$VAR' was passed to a function after being freed. This can lead to undefined behavior.
     metadata:
       cwe:

--- a/c/lang/security/function-use-after-free.yaml
+++ b/c/lang/security/function-use-after-free.yaml
@@ -17,11 +17,18 @@ rules:
           ...
           $VAR = NULL;
           ...
-      - pattern-not-inside:
-          free($VAR);
-          ...
-          $VAR = malloc(...);
-          ...
+      - pattern-not:
+          patterns:
+            - pattern-inside: |
+                free($VAR);
+                ...
+                $VAR = $ALLOC(...);
+                ...
+            - metavariable-pattern:
+                metavariable: $ALLOC
+                pattern-either:
+                  - pattern: malloc
+                  - pattern: calloc
     message: Variable '$VAR' was passed to a function after being freed. This can lead to undefined behavior.
     metadata:
       cwe:

--- a/c/lang/security/use-after-free.c
+++ b/c/lang/security/use-after-free.c
@@ -187,3 +187,14 @@ int bad_code7() {
     strcpy(buf, var);
     return 0;
 }
+
+int bad_code8() {
+    int *var;
+    var = (int *)calloc(sizeof(int), 5);
+    free(var);
+    // ruleid: use-after-free
+    *var = 256;
+    // ruleid: use-after-free
+    *var + 2 = 64;
+    return 0;
+}

--- a/c/lang/security/use-after-free.yaml
+++ b/c/lang/security/use-after-free.yaml
@@ -24,6 +24,10 @@ rules:
                 pattern-either:
                   - pattern: malloc
                   - pattern: calloc
+                  - pattern: realloc
+                  - pattern: reallocarray
+                  - pattern: strdup
+                  - pattern: strndup
     message: >-
       Variable '$VAR' was used after being freed. This can lead to undefined behavior.
     metadata:

--- a/c/lang/security/use-after-free.yaml
+++ b/c/lang/security/use-after-free.yaml
@@ -5,17 +5,25 @@ rules:
         - pattern: $VAR->$ACCESSOR
         - pattern: (*$VAR).$ACCESSOR
         - pattern: $VAR[$NUM]
+        - pattern: (*$VAR)
       - pattern-inside:
           free($VAR);
           ...
       - pattern-not-inside:
           $VAR = NULL;
           ...
-      - pattern-not-inside:
-          free($VAR);
-          ...
-          $VAR = malloc(...);
-          ...
+      - pattern-not:
+          patterns:
+            - pattern-inside: |
+                free($VAR);
+                ...
+                $VAR = $ALLOC(...);
+                ...
+            - metavariable-pattern:
+                metavariable: $ALLOC
+                pattern-either:
+                  - pattern: malloc
+                  - pattern: calloc
     message: >-
       Variable '$VAR' was used after being freed. This can lead to undefined behavior.
     metadata:


### PR DESCRIPTION
Fix: use-after-free rule for the C language gives a false positive when `calloc()` is used as only `malloc()` is supported.

All rules for heap based vulnerabilities for the C language now support the `calloc()` instead of just `malloc().`
Additionally other allocator functions can be easily added to the list.  

Additional Fix: Rule use-after-free didn't consider accessing memory as `*var = ...` vulnerable.
So a pattern to detect direct access to pointed memory was added.