### PR TITLE
Add GitHub Actions `secrets: inherit` detection rule

### DIFF
--- a/yaml/github-actions/security/secrets-inherit.test.yaml
+++ b/yaml/github-actions/security/secrets-inherit.test.yaml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  call-reusable-inherit:
+    uses: octo-org/example-repo/.github/workflows/reusable.yml@main
+    # ruleid: secrets-inherit
+    secrets: inherit
+
+  call-reusable-inherit-no-with:
+    uses: ./.github/workflows/local-reusable.yml
+    # ruleid: secrets-inherit
+    secrets: inherit
+
+  call-reusable-inherit-with-inputs:
+    uses: octo-org/example-repo/.github/workflows/reusable.yml@v1
+    with:
+      config-path: .github/labeler.yml
+    # ruleid: secrets-inherit
+    secrets: inherit
+
+  call-reusable-explicit-secrets:
+    uses: octo-org/example-repo/.github/workflows/reusable.yml@main
+    # ok: secrets-inherit
+    secrets:
+      MY_SECRET: ${{ secrets.MY_SECRET }}
+
+  call-reusable-no-secrets:
+    uses: octo-org/example-repo/.github/workflows/reusable.yml@main
+    with:
+      config-path: .github/labeler.yml
+
+  normal-job-no-secrets-keyword:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Hello"

--- a/yaml/github-actions/security/secrets-inherit.yaml
+++ b/yaml/github-actions/security/secrets-inherit.yaml
@@ -1,0 +1,36 @@
+rules:
+  - id: secrets-inherit
+    languages:
+      - yaml
+    severity: ERROR
+    message: >-
+      This workflow uses `secrets: inherit` to pass all of the calling
+      workflow's secrets to a reusable workflow. This violates the principle
+      of least privilege because the called workflow receives access to every
+      secret in the repository, not just the ones it needs. If the called
+      workflow is compromised or sourced from a third party, an attacker
+      gains access to all repository secrets. Instead, explicitly pass only
+      the secrets that the called workflow requires using the `secrets:` map,
+      e.g. `secrets: { MY_SECRET: ${{ secrets.MY_SECRET }} }`.
+    metadata:
+      category: security
+      cwe:
+        - "CWE-250: Execution with Unnecessary Privileges"
+      owasp:
+        - A01:2021 - Broken Access Control
+        - A01:2025 - Broken Access Control
+      references:
+        - https://docs.github.com/en/actions/sharing-automations/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow
+        - https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
+      technology:
+        - github-actions
+      subcategory:
+        - vuln
+      likelihood: MEDIUM
+      impact: HIGH
+      confidence: HIGH
+    patterns:
+      - pattern-inside: |
+          jobs:
+            ...
+      - pattern: "secrets: inherit"


### PR DESCRIPTION
## Summary
Adds a new rule (`secrets-inherit`) to the `github-actions` security policy set that detects use of `secrets: inherit` in reusable workflow calls.
## Motivation
When a workflow calls a reusable workflow with `secrets: inherit`, every secret in the repository is automatically forwarded to the called workflow. This violates the principle of least privilege — if the called workflow is compromised (especially third-party reusable workflows), an attacker gains access to all repository secrets rather than just the ones the workflow actually needs.

GitHub's own [security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions) recommends passing only the minimum required secrets explicitly.
## Rule details
| Field | Value |
|---|---|
| **ID** | `secrets-inherit` |
| **Severity** | `ERROR` (High) |
| **CWE** | CWE-250: Execution with Unnecessary Privileges |
| **OWASP** | A01:2021 / A01:2025 – Broken Access Control |
| **Impact** | HIGH |
| **Likelihood** | MEDIUM |
| **Confidence** | HIGH |
### Matches (true positives)
- `secrets: inherit` on a reusable workflow call (`uses:` at the job level)
- Works with both remote (`org/repo/.github/workflows/x.yml@ref`) and local (`./.github/workflows/x.yml`) reusable workflows
- Works regardless of whether `with:` inputs are also present
### Does not match (true negatives)
- Explicit secret passthrough via `secrets: { NAME: ${{ secrets.NAME }} }`
- Reusable workflow calls with no `secrets:` key at all
- Normal jobs with `runs-on:` / `steps:` (not reusable workflow calls)

Rule was validated with semgrep against the included test file — 3/3 true positives fired, 0/3 true negatives fired.