### PR TITLE
Package manager cooldown

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/package_managers/bun/bun-missing-minimum-release-age.test.toml
+++ b/package_managers/bun/bun-missing-minimum-release-age.test.toml
@@ -1,0 +1,44 @@
+---
+# ruleid: bun-missing-minimum-release-age
+[install]
+production = true
+
+---
+[install]
+# ok: bun-missing-minimum-release-age
+minimumReleaseAge = 604800
+
+---
+[install]
+# ok: bun-missing-minimum-release-age
+minimumReleaseAge = 1000000
+
+---
+[install]
+# ruleid: bun-missing-minimum-release-age
+minimumReleaseAge = 86400
+
+---
+[install]
+# ruleid: bun-missing-minimum-release-age
+minimumReleaseAge = 0
+
+---
+[install]
+# ruleid: bun-missing-minimum-release-age
+minimumReleaseAge = "7 days"
+
+---
+[install]
+# ruleid: bun-missing-minimum-release-age
+minimumReleaseAge =
+
+---
+[install]
+# ok: bun-missing-minimum-release-age
+minimumReleaseAge = 604800 # 7 days in seconds
+
+---
+[install]
+# ruleid: bun-missing-minimum-release-age
+minimumReleaseAge = 604799 # 7 days in seconds

--- a/package_managers/bun/bun-missing-minimum-release-age.yaml
+++ b/package_managers/bun/bun-missing-minimum-release-age.yaml
@@ -33,14 +33,7 @@ rules:
       Newly published packages can be malicious or unstable. Add
       `minimumReleaseAge = 604800` under the `[install]` section to wait 7 days
       before resolving newly published package versions.
-
-      Example:
-        [install]
-        minimumReleaseAge = 604800
-
-      Added in: v1.3
-
-      Reference: https://bun.sh/docs/runtime/bunfig
+      Added in: v1.3 Reference: https://bun.sh/docs/runtime/bunfig
     languages:
       - generic
     severity: MEDIUM

--- a/package_managers/bun/bun-missing-minimum-release-age.yaml
+++ b/package_managers/bun/bun-missing-minimum-release-age.yaml
@@ -1,0 +1,68 @@
+---
+rules:
+  - id: bun-missing-minimum-release-age
+    pattern-either:
+      # Branch 1: Missing minimumReleaseAge in [install]
+      - patterns:
+          - pattern-regex: '(?ms)\[install\](?P<TARGET>[^\[]*?)(?=\[|\z)'
+          - metavariable-regex:
+              metavariable: $TARGET
+              regex: '^(?![\s\S]*minimumReleaseAge)'
+          - focus-metavariable: $TARGET
+
+      # Branch 2: Value too low
+      - patterns:
+          - pattern-regex: 'minimumReleaseAge\s*=\s*\d+'
+          - pattern-regex: '=\s*(?P<AGE>\d+)'
+          - metavariable-comparison:
+              metavariable: $AGE
+              comparison: int($AGE) < 604800
+          - focus-metavariable: $AGE
+
+      # Branch 3: Invalid format (non-numeric)
+      - patterns:
+          - pattern-regex: '(?m)minimumReleaseAge[ \t]*=[ \t]*(?P<VAL>[^\s\d][^\n]*)'
+          - focus-metavariable: $VAL
+
+      # Branch 4: Empty value
+      - patterns:
+          - pattern-regex: '(?m)minimumReleaseAge\s*=\s*$'
+
+    message: >-
+      This bunfig.toml does not set a minimum release age or sets it too low.
+      Newly published packages can be malicious or unstable. Add
+      `minimumReleaseAge = 604800` under the `[install]` section to wait 7 days
+      before resolving newly published package versions.
+
+      Example:
+        [install]
+        minimumReleaseAge = 604800
+
+      Added in: v1.3
+
+      Reference: https://bun.sh/docs/runtime/bunfig
+    languages:
+      - generic
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/bunfig.toml"
+        - "**/.bunfig.toml"
+    metadata:
+      category: security
+      technology:
+        - bun
+        - javascript
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://bun.sh/docs/runtime/bunfig

--- a/package_managers/dependabot/dependabot-missing-cooldown.test.yaml
+++ b/package_managers/dependabot/dependabot-missing-cooldown.test.yaml
@@ -1,0 +1,117 @@
+---
+version: 2
+updates:
+  # ok: dependabot-missing-cooldown
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+---
+version: 2
+updates:
+  # ok: dependabot-missing-cooldown
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # ok: dependabot-missing-cooldown
+  - package-ecosystem: "docker"
+    directory: "/"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+---
+version: 2
+updates:
+  # ok: dependabot-missing-cooldown
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # ruleid: dependabot-missing-cooldown
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+---
+version: 2
+updates:
+  # ruleid: dependabot-missing-cooldown
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+---
+version: 2
+updates:
+  # ok: dependabot-missing-cooldown
+  - package-ecosystem: "pip"
+    cooldown:
+      default-days: 7
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+---
+version: 2
+updates:
+  # ok: dependabot-missing-cooldown
+  - package-ecosystem: "pip"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+
+---
+version: 2
+updates:
+  # ok: dependabot-missing-cooldown
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+---
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    cooldown:
+      # ruleid: dependabot-missing-cooldown
+      default-days: 3
+
+---
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    cooldown:
+      # ruleid: dependabot-missing-cooldown
+      default-days: null
+
+---
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    cooldown:
+      # ruleid: dependabot-missing-cooldown
+      default-days: "banana"

--- a/package_managers/dependabot/dependabot-missing-cooldown.yaml
+++ b/package_managers/dependabot/dependabot-missing-cooldown.yaml
@@ -1,0 +1,86 @@
+---
+rules:
+  - id: dependabot-missing-cooldown
+    pattern-either:
+      # Branch 1: Missing cooldown
+      - patterns:
+          - pattern-inside: |
+              updates:
+                ...
+          - pattern: |
+              - package-ecosystem: $ECOSYSTEM
+                ...
+          - pattern-not: |
+              - package-ecosystem: $ECOSYSTEM
+                ...
+                cooldown:
+                  ...
+                ...
+
+      # Branch 2: default-days too low
+      - patterns:
+          - pattern-inside: |
+              updates:
+                ...
+          - pattern-regex: 'default-days\s*:\s*(?P<DAYS>\d+)'
+          - metavariable-comparison:
+              metavariable: $DAYS
+              comparison: int($DAYS) < 7
+          - focus-metavariable: $DAYS
+
+      # Branch 3: Invalid default-days value
+      - patterns:
+          - pattern-inside: |
+              updates:
+                ...
+          - pattern: |
+              cooldown:
+                default-days: $DAYS
+          - metavariable-regex:
+              metavariable: $DAYS
+              regex: '^\D'
+          - focus-metavariable: $DAYS
+
+    message: >-
+      This Dependabot configuration does not set a cooldown period. Newly
+      published packages can be malicious or unstable. Add a `cooldown` block
+      with `default-days: 7` to each entry under `updates` to wait 7 days
+      before proposing updates to newly published package versions.
+
+      Example:
+
+      ```yaml
+      updates:
+        - package-ecosystem: "npm"
+          directory: "/"
+          schedule:
+            interval: "weekly"
+          cooldown:
+            default-days: 7
+      ```
+
+      Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown
+    languages:
+      - yaml
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/.github/dependabot.yml"
+        - "**/.github/dependabot.yaml"
+    metadata:
+      category: security
+      technology:
+        - dependabot
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown

--- a/package_managers/dependabot/dependabot-missing-cooldown.yaml
+++ b/package_managers/dependabot/dependabot-missing-cooldown.yaml
@@ -44,21 +44,8 @@ rules:
     message: >-
       This Dependabot configuration does not set a cooldown period. Newly
       published packages can be malicious or unstable. Add a `cooldown` block
-      with `default-days: 7` to each entry under `updates` to wait 7 days
+      with `default-days: 7` to each `package-ecosystem` entry under `updates` to wait 7 days
       before proposing updates to newly published package versions.
-
-      Example:
-
-      ```yaml
-      updates:
-        - package-ecosystem: "npm"
-          directory: "/"
-          schedule:
-            interval: "weekly"
-          cooldown:
-            default-days: 7
-      ```
-
       Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown
     languages:
       - yaml

--- a/package_managers/npm/npm-missing-minimum-release-age.test.npmrc
+++ b/package_managers/npm/npm-missing-minimum-release-age.test.npmrc
@@ -1,0 +1,83 @@
+---
+# ruleid: npm-missing-minimum-release-age
+production = true
+
+---
+# ok: npm-missing-minimum-release-age
+min-release-age=7 # days
+
+---
+# ok: npm-missing-minimum-release-age
+min-release-age=7
+
+---
+# ok: npm-missing-minimum-release-age
+min-release-age=1000
+
+---
+# ruleid: npm-missing-minimum-release-age
+min-release-age = 6
+
+---
+# ruleid: npm-missing-minimum-release-age
+min-release-age = 0
+
+---
+# ruleid: npm-missing-minimum-release-age
+min-release-age = "7 days"
+
+---
+# ruleid: npm-missing-minimum-release-age
+min-release-age =
+
+---
+# ruleid: npm-missing-minimum-release-age
+min-release-age = null
+
+---
+# ok: npm-missing-minimum-release-age
+min-release-age = 604800 # 7 days in seconds, ironically okay
+
+---
+# ruleid: npm-missing-minimum-release-age
+min-release-age=3d
+
+---
+# ruleid: npm-missing-minimum-release-age
+min-release-age=-1
+
+---
+# ruleid: npm-missing-minimum-release-age
+registry=https://registry.npmjs.org/
+save-exact=true
+audit=true
+fund=false
+
+---
+# ok: npm-missing-minimum-release-age
+registry=https://registry.npmjs.org/
+save-exact=true
+min-release-age=7
+audit=true
+fund=false
+
+---
+@myorg:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+save-exact=true
+# ruleid: npm-missing-minimum-release-age
+min-release-age=3
+
+---
+@myorg:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
+save-exact=true
+# ruleid: npm-missing-minimum-release-age
+min-release-age=
+---
+# ruleid: npm-missing-minimum-release-age
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+@myorg:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+node-version=20

--- a/package_managers/npm/npm-missing-minimum-release-age.test.npmrc
+++ b/package_managers/npm/npm-missing-minimum-release-age.test.npmrc
@@ -74,6 +74,7 @@ min-release-age=3
 save-exact=true
 # ruleid: npm-missing-minimum-release-age
 min-release-age=
+
 ---
 # ruleid: npm-missing-minimum-release-age
 registry=https://registry.npmjs.org/

--- a/package_managers/npm/npm-missing-minimum-release-age.yaml
+++ b/package_managers/npm/npm-missing-minimum-release-age.yaml
@@ -1,0 +1,62 @@
+---
+rules:
+  - id: npm-missing-minimum-release-age
+    pattern-either:
+      # Branch 1: Missing min-release-age
+      - patterns:
+          - pattern-regex: '(?:(?:^---\n)(?:[^\n]*\n)|^)(?P<TARGET>(?:(?!\n---)[\s\S])*)'
+          - metavariable-regex:
+              metavariable: $TARGET
+              regex: '^(?![\s\S]*min-release-age)'
+          - focus-metavariable: $TARGET
+
+      # Branch 2: Value too low (< 7 days)
+      - patterns:
+          - pattern-regex: 'min-release-age\s*=\s*\d+'
+          - pattern-regex: '=\s*(?P<AGE>\d+)'
+          - metavariable-comparison:
+              metavariable: $AGE
+              comparison: int($AGE) < 7
+          - focus-metavariable: $AGE
+
+      # Branch 3: Invalid format (non-numeric)
+      - patterns:
+          - pattern-regex: '(?m)min-release-age[ \t]*=[ \t]*(?P<VAL>[^\s\d][^\n]*)'
+          - focus-metavariable: $VAL
+
+      # Branch 4: Empty value
+      - patterns:
+          - pattern-regex: '(?m)min-release-age\s*=\s*$'
+
+    message: >-
+      This .npmrc does not set a minimum release age or sets it too low.
+      Newly published packages can be malicious or unstable. Add
+      `min-release-age = 7` to wait 7 days before resolving newly
+      published package versions.
+      Added in: v11.10
+      Reference: https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/
+    languages:
+      - generic
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/.npmrc"
+    metadata:
+      category: security
+      technology:
+        - npm
+        - javascript
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://github.blog/changelog/2026-02-18-npm-bulk-trusted-publishing-config-and-script-security-now-generally-available/
+        - https://github.com/npm/cli/pull/8965

--- a/package_managers/npm/npm-missing-minimum-release-age.yaml
+++ b/package_managers/npm/npm-missing-minimum-release-age.yaml
@@ -4,11 +4,9 @@ rules:
     pattern-either:
       # Branch 1: Missing min-release-age
       - patterns:
-          - pattern-regex: '(?:(?:^---\n)(?:[^\n]*\n)|^)(?P<TARGET>(?:(?!\n---)[\s\S])*)'
-          - metavariable-regex:
-              metavariable: $TARGET
-              regex: '^(?![\s\S]*min-release-age)'
-          - focus-metavariable: $TARGET
+        - pattern-regex: '(?:(?:^---\n)(?:[^\n]*\n)|^)(?P<TARGET>(?:(?!\n---)[\s\S])*\S(?:(?!\n---)[\s\S])*)'
+        - pattern-not-regex: 'min-release-age'
+        - focus-metavariable: $TARGET
 
       # Branch 2: Value too low (< 7 days)
       - patterns:

--- a/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.test.yaml
+++ b/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.test.yaml
@@ -1,0 +1,39 @@
+---
+# ruleid: pnpm-block-exotic-sub-dependencies
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-block-exotic-sub-dependencies
+packages:
+  - "apps/*"
+blockExoticSubdeps: true
+
+---
+# ok: pnpm-block-exotic-sub-dependencies
+blockExoticSubdeps: true
+packages:
+  - "apps/*"
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-block-exotic-sub-dependencies
+blockExoticSubdeps: none
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-block-exotic-sub-dependencies
+blockExoticSubdeps: false
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-block-exotic-sub-dependencies
+blockExoticSubdeps:
+
+---
+# ruleid: pnpm-block-exotic-sub-dependencies
+catalog:
+  react: ^19.0.0

--- a/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.yaml
+++ b/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.yaml
@@ -4,9 +4,7 @@ rules:
     message: >-
       Missing or incorrect blockExoticSubdeps. Set `blockExoticSubdeps: true`
       to transitive dependencies from being installed from untrusted sources.
-
       Added in: v10.26.0
-
       Reference: https://pnpm.io/settings#blockexoticsubdeps
     languages:
       - yaml

--- a/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.yaml
+++ b/package_managers/pnpm/pnpm-block-exotic-sub-dependencies.yaml
@@ -1,0 +1,51 @@
+---
+rules:
+  - id: pnpm-block-exotic-sub-dependencies
+    message: >-
+      Missing or incorrect blockExoticSubdeps. Set `blockExoticSubdeps: true`
+      to transitive dependencies from being installed from untrusted sources.
+
+      Added in: v10.26.0
+
+      Reference: https://pnpm.io/settings#blockexoticsubdeps
+    languages:
+      - yaml
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/pnpm-workspace.yaml"
+    pattern-either:
+      # Branch 1: Missing entirely
+      - patterns:
+          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^blockExoticSubdeps\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog)\s*:)(?:(?!^blockExoticSubdeps\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
+          - focus-metavariable: $TARGET
+
+      # Branch 2: Wrong value (not no-downgrade)
+      - patterns:
+          - pattern: |
+              blockExoticSubdeps: $VAL
+          - metavariable-regex:
+              metavariable: $VAL
+              regex: '^(?!true$).+'
+          - focus-metavariable: $VAL
+
+      # Branch 3: Empty value
+      - patterns:
+          - pattern-regex: '(?m)^\s*blockExoticSubdeps\s*:\s*$'
+    metadata:
+      category: security
+      technology:
+        - pnpm
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://pnpm.io/settings#blockexoticsubdeps

--- a/package_managers/pnpm/pnpm-missing-minimum-release-age.test.yaml
+++ b/package_managers/pnpm/pnpm-missing-minimum-release-age.test.yaml
@@ -1,0 +1,53 @@
+---
+# ok: pnpm-minimum-release-age
+minimumReleaseAge: 10080
+
+---
+# ok: pnpm-minimum-release-age
+minimumReleaseAge: 20160
+
+---
+# ruleid: pnpm-minimum-release-age
+minimumReleaseAge: 10079
+
+---
+# ruleid: pnpm-minimum-release-age
+minimumReleaseAge: 1440
+
+---
+# ruleid: pnpm-minimum-release-age
+minimumReleaseAge: 0
+
+---
+packages:
+  - "apps/*"
+# ok: pnpm-minimum-release-age
+minimumReleaseAge: 10080
+catalog:
+  react: ^19.0.0
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-minimum-release-age
+minimumReleaseAge: 9999
+catalog:
+  react: ^19.0.0
+
+---
+# ruleid: pnpm-minimum-release-age
+packages:
+  - "apps/*"
+
+---
+# ruleid: pnpm-minimum-release-age
+catalog:
+  react: ^19.0.0
+  typescript: ^5.0.0
+
+---
+# ruleid: pnpm-minimum-release-age
+packages:
+  - "apps/*"
+catalog:
+  react: ^19.0.0

--- a/package_managers/pnpm/pnpm-missing-minimum-release-age.yaml
+++ b/package_managers/pnpm/pnpm-missing-minimum-release-age.yaml
@@ -6,9 +6,7 @@ rules:
       Newly published packages can be malicious or unstable. Add
       `minimumReleaseAge: 10080` (minutes) to wait at least seven days before
       installing newly published package versions.
-
       Added in: v10.16.0
-
       Reference: https://pnpm.io/settings#minimumreleaseage
     languages:
       - yaml

--- a/package_managers/pnpm/pnpm-missing-minimum-release-age.yaml
+++ b/package_managers/pnpm/pnpm-missing-minimum-release-age.yaml
@@ -1,0 +1,60 @@
+---
+rules:
+  - id: pnpm-minimum-release-age
+    message: >-
+      This pnpm workspace configuration does not set a minimum release age.
+      Newly published packages can be malicious or unstable. Add
+      `minimumReleaseAge: 10080` (minutes) to wait at least seven days before
+      installing newly published package versions.
+
+      Added in: v10.16.0
+
+      Reference: https://pnpm.io/settings#minimumreleaseage
+    languages:
+      - yaml
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/pnpm-workspace.yaml"
+    pattern-either:
+      # Branch 1: Missing minimumReleaseAge
+      - patterns:
+          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^minimumReleaseAge\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog)\s*:)(?:(?!^minimumReleaseAge\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
+          - focus-metavariable: $TARGET
+
+      # Branch 2: Value too low
+      - patterns:
+          - pattern-regex: '^\s*minimumReleaseAge\s*:\s*(?P<AGE>\d+)'
+          - metavariable-comparison:
+              metavariable: $AGE
+              comparison: int($AGE) < 10080
+          - focus-metavariable: $AGE
+
+      # Branch 3: Invalid format (non-numeric)
+      - patterns:
+          - pattern: |
+              minimumReleaseAge: $AGE
+          - metavariable-regex:
+              metavariable: $AGE
+              regex: '^\D'
+          - focus-metavariable: $AGE
+      # Branch 4: Empty value
+      - patterns:
+          - pattern-regex: '(?m)^\s*minimumReleaseAge\s*:\s*$'
+    metadata:
+      category: security
+      technology:
+        - pnpm
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://pnpm.io/settings#minimumreleaseage

--- a/package_managers/pnpm/pnpm-trust-policy.test.yaml
+++ b/package_managers/pnpm/pnpm-trust-policy.test.yaml
@@ -1,0 +1,39 @@
+---
+# ruleid: pnpm-trust-policy
+packages:
+  - "apps/*"
+
+---
+# ok: pnpm-trust-policy
+packages:
+  - "apps/*"
+trustPolicy: no-downgrade
+
+---
+# ok: pnpm-trust-policy
+trustPolicy: no-downgrade
+packages:
+  - "apps/*"
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-trust-policy
+trustPolicy: allow-scripts
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-trust-policy
+trustPolicy: false
+
+---
+packages:
+  - "apps/*"
+# ruleid: pnpm-trust-policy
+trustPolicy:
+
+---
+# ruleid: pnpm-trust-policy
+catalog:
+  react: ^19.0.0

--- a/package_managers/pnpm/pnpm-trust-policy.yaml
+++ b/package_managers/pnpm/pnpm-trust-policy.yaml
@@ -4,9 +4,7 @@ rules:
     message: >-
       Missing or incorrect trustPolicy. Set `trustPolicy: no-downgrade`
       to prevent malicious package updates from downgrading security settings.
-
       Added in: v10.21.0
-
       Reference: https://pnpm.io/settings#trustpolicy
     languages:
       - yaml

--- a/package_managers/pnpm/pnpm-trust-policy.yaml
+++ b/package_managers/pnpm/pnpm-trust-policy.yaml
@@ -1,0 +1,51 @@
+---
+rules:
+  - id: pnpm-trust-policy
+    message: >-
+      Missing or incorrect trustPolicy. Set `trustPolicy: no-downgrade`
+      to prevent malicious package updates from downgrading security settings.
+
+      Added in: v10.21.0
+
+      Reference: https://pnpm.io/settings#trustpolicy
+    languages:
+      - yaml
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/pnpm-workspace.yaml"
+    pattern-either:
+      # Branch 1: Missing entirely
+      - patterns:
+          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^trustPolicy\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:packages|catalog)\s*:)(?:(?!^trustPolicy\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
+          - focus-metavariable: $TARGET
+
+      # Branch 2: Wrong value (not no-downgrade)
+      - patterns:
+          - pattern: |
+              trustPolicy: $VAL
+          - metavariable-regex:
+              metavariable: $VAL
+              regex: '^(?!no-downgrade$).+'
+          - focus-metavariable: $VAL
+
+      # Branch 3: Empty value
+      - patterns:
+          - pattern-regex: '(?m)^\s*trustPolicy\s*:\s*$'
+    metadata:
+      category: security
+      technology:
+        - pnpm
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://pnpm.io/settings#minimumreleaseage

--- a/package_managers/renovate/renovate-missing-minimum-release-age.test.json
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.test.json
@@ -1,0 +1,197 @@
+{
+  "packageRules": [
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      "minimumReleaseAge": "14 days"
+    },
+    // ruleid: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      "minimumReleaseAge": "13 days"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "minimumReleaseAge": "13 days",
+      "groupName": "Webpack build system"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "minimumReleaseAge": "13 days",
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      "minimumReleaseAge": "99 days"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      "minimumReleaseAge": "999 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "banana days"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      "minimumReleaseAge": "15 days"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "minimumReleaseAge": "7 days",
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system"
+    },
+    {
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "6 days",
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "6 days",
+      "groupName": "Webpack build system"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "6 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "5 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "4 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "2 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "1 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "null"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "banana"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      "minimumReleaseAge": "14 days"
+    },
+    // ruleid: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["eslint"],
+      "groupName": "Linting"
+    },
+    // ruleid: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["eslint"],
+      "groupName": "Linting"
+    },
+    // ok: renovate-missing-minimum-release-age
+    {
+      "matchPackageNames": ["webpack"],
+      "groupName": "Webpack build system",
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "1 day"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": ""
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "7"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "-1 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "7.5 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+    // ok: renovate-missing-minimum-release-age
+    "minimumReleaseAge": "07 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+    // ruleid: renovate-missing-minimum-release-age
+    "minimumReleaseAge": " 7 days"
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ruleid: renovate-missing-minimum-release-age
+      "minimumReleaseAge": "7 days "
+    }
+  ]
+}

--- a/package_managers/renovate/renovate-missing-minimum-release-age.yaml
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.yaml
@@ -1,0 +1,82 @@
+---
+rules:
+  - id: renovate-missing-minimum-release-age
+    pattern-either:
+      # Branch 1: Missing entirely
+      - patterns:
+          - pattern-inside: |
+              "packageRules": [
+                ...
+              ]
+          - pattern-either:
+              - pattern: |
+                  { ..., "matchPackageNames": [...], ... }
+              - pattern: |
+                  { ..., "matchPackagePatterns": [...], ... }
+              - pattern: |
+                  { ..., "matchDepTypes": [...], ... }
+          - pattern-not: |
+              {
+                ...,
+                "minimumReleaseAge": $AGE,
+                ...
+              }
+      # Branch 2: Present but too low
+      - patterns:
+          - pattern-inside: |
+              "packageRules": [
+                ...
+              ]
+          - pattern-regex: '"minimumReleaseAge":\s*"(?P<AGE>\d+) days?"'
+          - metavariable-comparison:
+              metavariable: $AGE
+              comparison: int($AGE) < 7
+          - focus-metavariable: $AGE
+      # Branch 3: Invalid format (not matching "N days")
+      - patterns:
+          - pattern-inside: |
+              "packageRules": [
+                ...
+              ]
+          - pattern: |
+              "minimumReleaseAge": "$AGE"
+          - metavariable-regex:
+              metavariable: $AGE
+              regex: '^(?!\d+ days?$)'
+          - focus-metavariable: $AGE
+    message: >-
+      This Renovate configuration does not set a minimum release age.
+      Newly published packages can be malicious or unstable.
+      Add `"minimumReleaseAge": "7 days"` within a `packageRules`
+      entry to wait 7 days before proposing updates to newly
+      published package versions.
+
+      Added in: v42
+
+      Reference: https://docs.renovatebot.com/configuration-options/#minimumreleaseage
+    languages:
+      - json
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/renovate.json"
+        - "**/.renovaterc"
+        - "**/.renovaterc.json"
+        - "**/renovate.json5"
+    metadata:
+      category: security
+      technology:
+        - renovate
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://docs.renovatebot.com/configuration-options/#minimumreleaseage

--- a/package_managers/renovate/renovate-missing-minimum-release-age.yaml
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.yaml
@@ -50,9 +50,7 @@ rules:
       Add `"minimumReleaseAge": "7 days"` within a `packageRules`
       entry to wait 7 days before proposing updates to newly
       published package versions.
-
       Added in: v42
-
       Reference: https://docs.renovatebot.com/configuration-options/#minimumreleaseage
     languages:
       - json

--- a/package_managers/uv/uv-missing-dependency-cooldown.test.toml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.test.toml
@@ -1,0 +1,31 @@
+# ruleid: uv-missing-dependency-cooldown
+[tool.uv]
+dev-dependencies = ["pytest"]
+
+# ruleid: uv-missing-dependency-cooldown
+[tool.uv]
+
+# ruleid: uv-missing-dependency-cooldown
+[tool.uv]
+dev-dependencies = ["pytest"]
+
+# ok: uv-missing-dependency-cooldown
+[tool.uv]
+exclude-newer = "7 days"
+dev-dependencies = ["pytest"]
+
+# ok: uv-missing-dependency-cooldown
+[tool.uv]
+exclude-newer = "7 days"
+
+[tool.uv]
+# ruleid: uv-missing-dependency-cooldown
+exclude-newer = "3 days"
+
+[tool.uv]
+# ruleid: uv-missing-dependency-cooldown
+exclude-newer = "banana"
+
+[tool.uv]
+# ok: uv-missing-dependency-cooldown
+exclude-newer = "2025-01-15T00:00:00Z"

--- a/package_managers/uv/uv-missing-dependency-cooldown.yaml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.yaml
@@ -1,0 +1,67 @@
+---
+rules:
+  - id: uv-missing-dependency-cooldown
+    pattern-either:
+      # Branch 1a: pyproject.toml missing exclude-newer in [tool.uv]
+      - patterns:
+          - pattern-regex: '(?ms)\[tool\.uv\](?P<TARGET>[^\[]*?)(?=\[|\z)'
+          - metavariable-regex:
+              metavariable: $TARGET
+              regex: '^(?![\s\S]*exclude-newer)'
+          - focus-metavariable: $TARGET
+
+      # Branch 2: Value too low (< 7 days)
+      - patterns:
+          - pattern-regex: 'exclude-newer\s*=\s*"(?P<DAYS>\d+) days?"'
+          - metavariable-comparison:
+              metavariable: $DAYS
+              comparison: int($DAYS) < 7
+          - focus-metavariable: $DAYS
+
+      # Branch 3: Invalid format (not days, date, or timestamp)
+      - patterns:
+          - pattern-regex: 'exclude-newer\s*=\s*"(?P<VAL>[^"]+)"'
+          - metavariable-regex:
+              metavariable: $VAL
+              regex: '^(?!\d+ days?$)(?!\d{4}-\d{2}-\d{2}$)(?!\d{4}-\d{2}-\d{2}T)'
+          - focus-metavariable: $VAL
+    message: >-
+      This pyproject.toml configures uv but does not set a dependency cooldown.
+      Newly published packages can be malicious or unstable. Add
+      `exclude-newer = "7 days"` under the `[tool.uv]` section to wait 7 days
+      before resolving newly published package versions.
+
+      Example:
+      ```toml
+      [tool.uv]
+      exclude-newer = "7 days"
+      ```
+
+      Added in: 0.9.17
+
+      Reference: https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns
+    languages:
+      - generic
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/pyproject.toml"
+        - "**/uv.toml"
+    metadata:
+      category: security
+      technology:
+        - uv
+        - python
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns

--- a/package_managers/uv/uv-missing-dependency-cooldown.yaml
+++ b/package_managers/uv/uv-missing-dependency-cooldown.yaml
@@ -28,17 +28,9 @@ rules:
     message: >-
       This pyproject.toml configures uv but does not set a dependency cooldown.
       Newly published packages can be malicious or unstable. Add
-      `exclude-newer = "7 days"` under the `[tool.uv]` section to wait 7 days
+      `exclude-newer = "7 days"` under `[tool.uv]` to wait 7 days
       before resolving newly published package versions.
-
-      Example:
-      ```toml
-      [tool.uv]
-      exclude-newer = "7 days"
-      ```
-
       Added in: 0.9.17
-
       Reference: https://docs.astral.sh/uv/concepts/resolution/#dependency-cooldowns
     languages:
       - generic

--- a/package_managers/yarn/yarn-missing-minimal-age-gate.test.yaml
+++ b/package_managers/yarn/yarn-missing-minimal-age-gate.test.yaml
@@ -1,0 +1,141 @@
+---
+# ruleid: yarn-missing-minimal-age-gate
+nodeLinker: node-modules
+
+---
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "7d"
+
+---
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: 7d
+
+---
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "14d"
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "3d"
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "0d"
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "7 days"
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: banana
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate:
+
+---
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "7d"
+enableGlobalCache: false
+
+---
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "14d"
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+
+---
+nodeLinker: node-modules
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: 30d
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+enableGlobalCache: false
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+enableGlobalCache: false
+
+---
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "3d"
+enableGlobalCache: false
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "6d"
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+
+---
+nodeLinker: node-modules
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: 0d
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+
+---
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "7 days"
+enableGlobalCache: false
+
+---
+nodeLinker: node-modules
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: 7
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+
+---
+nodeLinker: node-modules
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate:
+enableGlobalCache: false
+
+---
+enableGlobalCache: false
+nodeLinker: node-modules
+npmRegistryServer: "https://registry.npmjs.org"
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "7d"
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+enableGlobalCache: false
+nodeLinker: node-modules
+npmRegistryServer: "https://registry.npmjs.org"
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+
+---
+nodeLinker: node-modules
+# ok: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "10d"
+npmScopes:
+  mycompany:
+    npmRegistryServer: "https://npm.mycompany.com"
+    npmAuthToken: "${NPM_TOKEN}"
+
+---
+# ruleid: yarn-missing-minimal-age-gate
+nodeLinker: node-modules
+npmScopes:
+  mycompany:
+    npmRegistryServer: "https://npm.mycompany.com"
+    npmAuthToken: "${NPM_TOKEN}"
+yarnPath: .yarn/releases/yarn-4.0.0.cjs
+
+---
+nodeLinker: node-modules
+# ruleid: yarn-missing-minimal-age-gate
+npmMinimalAgeGate: "1d"
+npmScopes:
+  mycompany:
+    npmRegistryServer: "https://npm.mycompany.com"

--- a/package_managers/yarn/yarn-missing-minimal-age-gate.yaml
+++ b/package_managers/yarn/yarn-missing-minimal-age-gate.yaml
@@ -1,0 +1,66 @@
+---
+rules:
+  - id: yarn-missing-minimal-age-gate
+    pattern-either:
+
+      # Branch 1: Missing entirely
+      - patterns:
+          - pattern-regex: '(?ms)(?:\A|^---$\n)(?:(?!^npmMinimalAgeGate\s*:)(?!^---$)[\s\S])*?(?P<TARGET>^(?:nodeLinker|yarnPath|enableGlobalCache|npmScopes|npmRegistryServer)\s*:)(?:(?!^npmMinimalAgeGate\s*:)(?!^---$)[\s\S])*?(?=^---$|\z)'
+          - focus-metavariable: $TARGET
+
+      # Branch 2: Value too low (< 7 days) - valid format, number too small
+      - patterns:
+          - pattern-regex: '(?m)npmMinimalAgeGate\s*:\s*[''"]?(?P<DAYS>\d+)d[''"]?'
+          - metavariable-comparison:
+              metavariable: $DAYS
+              comparison: int($DAYS) < 7
+          - focus-metavariable: $DAYS
+
+      # Branch 3: Invalid format (not Nd pattern)
+      - patterns:
+          - pattern-regex: '(?m)npmMinimalAgeGate[ \t]*:[ \t]*(?P<VAL>\S+)'
+          - metavariable-regex:
+              metavariable: $VAL
+              regex: '^(?![''"]?\d+d[''"]?$)'
+          - focus-metavariable: $VAL
+
+      # Branch 4: Empty value
+      - patterns:
+          - pattern-regex: '(?m)^npmMinimalAgeGate\s*:\s*$'
+
+    message: >-
+      This .yarnrc.yml does not set a minimal age gate or sets it too low.
+      Newly published packages can be malicious or unstable. Add
+      `npmMinimalAgeGate: "7d"` to wait 7 days before resolving newly
+      published package versions.
+
+      Example:
+        npmMinimalAgeGate: "7d"
+
+      Added in: 4.10
+
+      Reference: https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate
+    languages:
+      - yaml
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/.yarnrc.yml"
+    metadata:
+      category: security
+      technology:
+        - yarn
+        - javascript
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - A08:2021 - Software and Data Integrity Failures
+      confidence: HIGH
+      likelihood: LOW
+      impact: HIGH
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate

--- a/package_managers/yarn/yarn-missing-minimal-age-gate.yaml
+++ b/package_managers/yarn/yarn-missing-minimal-age-gate.yaml
@@ -33,12 +33,7 @@ rules:
       Newly published packages can be malicious or unstable. Add
       `npmMinimalAgeGate: "7d"` to wait 7 days before resolving newly
       published package versions.
-
-      Example:
-        npmMinimalAgeGate: "7d"
-
       Added in: 4.10
-
       Reference: https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate
     languages:
       - yaml


### PR DESCRIPTION

Inspired by recent events and this PR:
https://github.com/semgrep/semgrep-rules/pull/3791

Several rules added, all revolving around package managers and their configuration.

Cooldown/Minimum Age for:
NPM: bun, pnpm, renovate, yarn
Python: uv

For pnpm also add rules for block exotic subdependencies and trust policy, both related settings to help avoid installing malicious packages.

Rules have been tested in our environment with good success.

~One semi-false positive is because pyproject.toml can be used by other package managers (Poetry for example), it'll flag it as missing the setting~ (see comment below). Also, if the repo is on too old a version of a package manager, it still flags it. Neither of these are easily solved in the context of the rule running.

In both cases I think there's still a strong argument for raising the finding, as it highlights a security gap in the environment.