### PR TITLE
Allow multi-document YAML in all .test.yaml/.test.yml files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,9 @@ repos:
       - id: check-yaml
         exclude: |
           (?x)^(
-            # These are multi-document
-            yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches\.test\.yml|
-            yaml/kubernetes/security/.*\.test\.yaml
+            # Semgrep rule test files may use multi-document YAML
+            # to separate test cases
+            .*\.test\.ya?ml
           )$
   # Exception case - multi-document YAML OK - still check YAML
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -27,7 +27,7 @@ repos:
         args: [--allow-multiple-documents]
         files: |
           (?x)^(
-            # These are multi-document
-            yaml/github-actions/semgrep-configuration/semgrep-github-action-push-without-branches\.test\.yml|
-            yaml/kubernetes/security/.*\.test\.yaml
+            # Semgrep rule test files may use multi-document YAML
+            # to separate test cases
+            .*\.test\.ya?ml
           )$


### PR DESCRIPTION
## Summary

- Generalizes the pre-commit `check-yaml` hook to allow multi-document YAML (`---` separators) in **all** `*.test.yaml` / `*.test.yml` files, replacing the previous explicit allowlist of specific paths
- Test files are still validated for well-formedness via the `--allow-multiple-documents` hook

## Context

The current config maintains a hardcoded list of test files allowed to use multi-document YAML. This breaks when contributors add new rule test files that use `---` to separate test cases (e.g. #3805, #3791). Multi-document YAML is a natural way to express multiple test cases for semgrep rules, and `semgrep test` handles it correctly.

## Test plan

- [x] Verified the new regex matches all previously allowed files
- [x] Verified regular `.yaml` rule files are NOT matched (still get strict single-doc validation)

Made with [Cursor](https://cursor.com)