### PR TITLE
Adapt to the new gemini sdk in the ai-best-practices rules

### DIFF
--- a/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-javascript.js
+++ b/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-javascript.js
@@ -1,17 +1,18 @@
-const { GoogleGenerativeAI } = require("@google/generative-ai");
+import { GoogleGenAI } from "@google/genai";
 
-const genAI = new GoogleGenerativeAI("api-key");
-const model = genAI.getGenerativeModel({ model: "gemini-pro" });
+const ai = new GoogleGenAI({});
 
 async function test() {
     // ruleid: gemini-missing-safety-settings-javascript
-    const response = await model.generateContent({
-        contents: [{ role: "user", parts: [{ text: "Hello" }] }]
+    const response = await ai.models.generateContent({
+        model: "gemini-3-flash-preview",
+        contents: "Hello",
     });
 
     // ok: gemini-missing-safety-settings-javascript
-    const response2 = await model.generateContent({
-        contents: [{ role: "user", parts: [{ text: "Hello" }] }],
-        safetySettings: safetyConfig
+    const response2 = await ai.models.generateContent({
+        model: "gemini-3-flash-preview",
+        contents: "Hello",
+        config: { safetySettings: safetyConfig }
     });
 }

--- a/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-javascript.yaml
+++ b/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-javascript.yaml
@@ -17,5 +17,18 @@ rules:
       references:
         - https://ai.google.dev/gemini-api/docs/safety-settings
     patterns:
+      - pattern-either:
+        - pattern-inside: |
+            import { ... } from '@google/genai';
+            ...
+        - pattern-inside: |
+            import $ANY from '@google/genai';
+            ...
+        - pattern-inside: |
+            import * as $ANY from '@google/genai';
+            ...
+        - pattern-inside: |
+            $ANY = require('@google/genai');
+            ...
       - pattern: "$MODEL.generateContent({...})"
-      - pattern-not: "$MODEL.generateContent({..., safetySettings: $S, ...})"
+      - pattern-not: "$MODEL.generateContent({..., config: {..., safetySettings: $S, ...}, ...})"

--- a/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-python.py
+++ b/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-python.py
@@ -1,12 +1,20 @@
-import google.generativeai as genai
 
-model = genai.GenerativeModel("gemini-pro")
+from google import genai
+from google.genai import types
+
+client = genai.Client()
 
 # ruleid: gemini-missing-safety-settings-python
-response = model.generate_content("Tell me about history")
+response = client.models.generate_content(
+    model="gemini-3-flash-preview",
+    contents="Tell me about history",
+)
 
 # ok: gemini-missing-safety-settings-python
-response = model.generate_content(
-    "Tell me about history",
-    safety_settings=safety_config
+response = client.model.generate_content(
+    model="gemini-3-flash-preview",
+    content="Tell me about history",
+    config={
+        "safety_settings": safety_config
+    }
 )

--- a/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-python.yaml
+++ b/ai/ai-best-practices/gemini-missing-safety-settings/gemini-missing-safety-settings-python.yaml
@@ -17,5 +17,18 @@ rules:
       references:
         - https://ai.google.dev/gemini-api/docs/safety-settings
     patterns:
+      - pattern-either:
+          - pattern-inside: |
+              from google import genai
+              ...
+          - pattern-inside: |
+              from google import genai as $ANY
+              ...
+          - pattern-inside: |
+              import google.genai
+              ...
+          - pattern-inside: |
+              import google.genai as $ANY
+              ...
       - pattern: $MODEL.generate_content(...)
-      - pattern-not: $MODEL.generate_content(..., safety_settings=$SETTINGS, ...)
+      - pattern-not: $MODEL.generate_content(..., config={..., "safety_settings":$SETTINGS, ...}, ...)


### PR DESCRIPTION
Hello together,

the Google SDK for Gemini has been replaced with new packages, the existing packages for python and javascript are deprecated and have been replaced with new ones.

Old:
- https://pypi.org/project/google-generativeai/
- https://www.npmjs.com/package/@google/generative-ai

New:
- https://www.npmjs.com/package/@google/genai
- https://pypi.org/project/google-genai/

---
The safety settings in the new sdks have moved to a config object when calling the gemini api. 
I edited the rules targeting deprecated package to match the new SDK. But I also tried to target only the specific SDK, so that the rules won't fire for other packages and creates false positives. I am a little bit unsure if this is desired or how you want to handle such cases. 
I can  also remove that if you want to.

Code examples from Google: https://ai.google.dev/gemini-api/docs/safety-settings?hl=de#code-examples

I hope this contribution helps.