### PR TITLE
Update disabled-cert-validation to detect requests.Session() usage

### DIFF
--- a/python/requests/security/disabled-cert-validation.py
+++ b/python/requests/security/disabled-cert-validation.py
@@ -15,3 +15,16 @@ r = req.get(some_url, stream=True, verify=False)
 r = requests.post(some_url, stream=True, verify=False)
 # ruleid:disabled-cert-validation
 r = requests.post(some_url, verify=False, stream=True)
+
+# ok:disabled-cert-validation
+session = requests.Session()
+# ok:disabled-cert-validation
+r = session.post(some_url, stream=True)
+
+session = requests.Session()
+# ruleid:disabled-cert-validation
+r = session.post(some_url, verify=False, json={"text": "hello"})
+
+s = requests.Session()
+# ruleid:disabled-cert-validation
+r = s.get(some_url, verify=False)

--- a/python/requests/security/disabled-cert-validation.yaml
+++ b/python/requests/security/disabled-cert-validation.yaml
@@ -32,6 +32,11 @@ rules:
   - pattern: requests.request(..., verify=False, ...)
   - pattern: requests.get(..., verify=False, ...)
   - pattern: requests.post(..., verify=False, ...)
+  - patterns:
+    - pattern-inside: |
+        $S = requests.Session(...)
+        ...
+    - pattern: $S.$METHOD(..., verify=False, ...)
   fix-regex:
     regex: verify(\s)*=(\s)*False
     replacement: verify=True


### PR DESCRIPTION
## Summary

Update `disabled-cert-validation` rule to detect `verify=False` on `requests.Session()` method calls, e.g.: `session.post(url, verify=False)`.

**Problem**: The rule only matched direct `requests.get(...)`, `requests.post(...)`, etc. calls with `verify=False`. When a `requests.Session()` was created and used with `verify=False`, it was not detected.

**Fix**: Added a `pattern-inside` + `$S.$METHOD(...)` pattern that matches any HTTP method call with `verify=False` on a session object initialized via `requests.Session()`.

## Test plan

- [x] `semgrep --test` passes
- [x] New test cases cover:
  - `ok:` `session.post(url, stream=True)` without `verify=False` (no false positive)
  - `ruleid:` `session.post(url, verify=False, json=...)` (true positive)
  - `ruleid:` `s.get(url, verify=False)` (true positive)
- [x] All existing test cases continue to pass (no regressions)
