### PR TITLE
Add String.formatted coverage to jdo-sqli (#3812)

### DIFF
--- a/java/lang/security/audit/sqli/jdo-sqli.java
+++ b/java/lang/security/audit/sqli/jdo-sqli.java
@@ -21,6 +21,8 @@ public class JdoSqlFilter {
         Query q = pm.newQuery(UserEntity.class);
         // ruleid: jdo-sqli
         q.setFilter("id == "+filterValue);
+        // ruleid: jdo-sqli
+        q.setFilter("id == %s".formatted(filterValue));
     }
 
     public void testJdoSafeFilter(String filterValue) {
@@ -46,6 +48,8 @@ public class JdoSqlFilter {
         Query q = pm.newQuery(UserEntity.class);
         // ruleid: jdo-sqli
         q.setGrouping(groupByField);
+        // ruleid: jdo-sqli
+        q.setGrouping("%s".formatted(groupByField));
     }
 
     public void testJdoSafeGrouping() {
@@ -87,14 +91,20 @@ public class JdoSql {
         PersistenceManager pm = getPM();
         // ruleid: jdo-sqli
         pm.newQuery(UserEntity.class,new ArrayList(),"id == "+ input);
+        // ruleid: jdo-sqli
+        pm.newQuery(UserEntity.class,new ArrayList(),"id == %s".formatted(input));
         // ok: jdo-sqli
         pm.newQuery(UserEntity.class,new ArrayList(),"id == 1");
         // ruleid: jdo-sqli
         pm.newQuery(UserEntity.class,"id == "+ input);
+        // ruleid: jdo-sqli
+        pm.newQuery(UserEntity.class,"id == %s".formatted(input));
         // ok: jdo-sqli
         pm.newQuery(UserEntity.class,"id == 1");
         // ruleid: jdo-sqli
         pm.newQuery((Extent) null,"id == "+input);
+        // ruleid: jdo-sqli
+        pm.newQuery((Extent) null,"id == %s".formatted(input));
         // ok: jdo-sqli
         pm.newQuery((Extent) null,"id == 1");
     }

--- a/java/lang/security/audit/sqli/jdo-sqli.yaml
+++ b/java/lang/security/audit/sqli/jdo-sqli.yaml
@@ -12,6 +12,9 @@ rules:
               String $SQL = String.format(...);
               ...
           - pattern-inside: |
+              String $SQL = $FMT.formatted(...);
+              ...
+          - pattern-inside: |
               $TYPE $FUNC(...,String $SQL,...) {
                 ...
               }
@@ -21,6 +24,8 @@ rules:
         - pattern: $Q.$METHOD($SQL,...)
       - pattern: |
           $Q.$METHOD(String.format(...),...);
+      - pattern: |
+          $Q.$METHOD($FMT.formatted(...),...);
       - pattern: |
           $Q.$METHOD($X + $Y,...);
     - pattern-either:
@@ -47,6 +52,9 @@ rules:
               String $SQL = String.format(...);
               ...
           - pattern-inside: |
+              String $SQL = $FMT.formatted(...);
+              ...
+          - pattern-inside: |
               $VAL $FUNC(...,String $SQL,...) {
                 ...
               }
@@ -56,6 +64,8 @@ rules:
         - pattern: $PM.newQuery(...,$SQL,...)
       - pattern: |
           $PM.newQuery(...,String.format(...),...);
+      - pattern: |
+          $PM.newQuery(...,$FMT.formatted(...),...);
       - pattern: |
           $PM.newQuery(...,$X + $Y,...);
     - pattern-either:


### PR DESCRIPTION
## Summary
- Extend `jdo-sqli` to detect dynamic JDO query strings built with Java `String.formatted(...)`.
- Add coverage in both sink branches:
  - `javax.jdo.Query` methods (`setFilter`, `setGrouping`)
  - `javax.jdo.PersistenceManager.newQuery(...)`
- Add regression tests for `formatted(...)` variants in existing Java test file.

Resolved:  #3812 