### PR TITLE
Fix rules-test-historical CI: use canonical semgrep/semgrep API path and fail loudly

### DIFF
--- a/scripts/historical-semgrep-version
+++ b/scripts/historical-semgrep-version
@@ -1,12 +1,46 @@
 #!/bin/bash
+set -euo pipefail
+
+# Fetch a recent-but-not-newest Semgrep release tag and pull the matching
+# Docker image, so we can validate/test rules against an older Semgrep.
+#
+# We reverse the releases list (so it is oldest-first), keep the last
+# HISTORICAL_VERSIONS (the most recent N releases), then take the first
+# RETRIES of those (the oldest within that window). Each candidate is tried
+# in turn until a Docker image successfully pulls.
+
 HISTORICAL_VERSIONS=10
 RETRIES=3
 
-versions=$(gh api --method GET /repos/returntocorp/semgrep/releases | jq 'reverse' | jq -r '.[].tag_name' | tail "-n${HISTORICAL_VERSIONS}" | head -n "${RETRIES}" | tr -d v)
+# The repo was renamed from returntocorp/semgrep to semgrep/semgrep. Use the
+# canonical path; the rename redirect does not work reliably with the
+# scoped GITHUB_TOKEN in workflows, which silently produced an empty
+# response and made the script fail with no diagnostics.
+api_path="/repos/semgrep/semgrep/releases"
 
-for version in $(echo "${versions}"); do
-  docker pull "returntocorp/semgrep:${version}"
-  if [[ "$?" == 0 ]]; then
+if ! releases_json="$(gh api --method GET "${api_path}" 2>&1)"; then
+  echo "Failed to fetch ${api_path} from GitHub:"
+  echo "${releases_json}"
+  exit 1
+fi
+
+versions="$(echo "${releases_json}" \
+  | jq -r 'reverse | .[].tag_name' \
+  | tail -n "${HISTORICAL_VERSIONS}" \
+  | head -n "${RETRIES}" \
+  | tr -d v)"
+
+if [[ -z "${versions}" ]]; then
+  echo "No candidate versions found in ${api_path} response (first 500 chars):"
+  echo "${releases_json}" | head -c 500
+  echo
+  exit 1
+fi
+
+echo "Candidate historical versions: $(echo ${versions})"
+
+for version in ${versions}; do
+  if docker pull "returntocorp/semgrep:${version}"; then
     echo "${version}"
     echo "SEMGREP_OLD_VERSION=${version}" >> "${GITHUB_ENV}"
     exit 0


### PR DESCRIPTION
## Summary

`scripts/historical-semgrep-version` has been failing on **every** PR since April 15, blocking the `rules-test-historical` check. The job dies with an unhelpful empty error:

```
Could not determine historical version, tried:
Process completed with exit code 1.
```

(See e.g. [run 25014250296](https://github.com/semgrep/semgrep-rules/actions/runs/25014250296/job/73257771165) on PR #3828.)

Two issues stack:

1. **Stale API path.** The script calls `gh api /repos/returntocorp/semgrep/releases`. The repo was renamed to `semgrep/semgrep`. A personal token transparently follows the rename, but the workflow's scoped `GITHUB_TOKEN` does not, so the API call returns nothing usable in CI.
2. **Silent pipeline.** The `gh api ... | jq ... | tail | head | tr` ran without `pipefail`, so the failed call left `versions` empty and the for-loop no-op'd straight into the unhelpful "tried:" print.

This PR:

- Switches to the canonical `/repos/semgrep/semgrep/releases` path.
- Adds `set -euo pipefail` and explicit `gh api` failure handling, dumping the API response on failure so the next breakage is diagnosable straight from the CI log.
- Echoes the candidate versions before iterating, and uses `if docker pull ...` instead of post-hoc `$?` checks.

The Docker image is still pulled from `returntocorp/semgrep`, which continues to be published alongside `semgrep/semgrep` (verified on Docker Hub through `1.161.0`).

## Test plan

- [x] `bash -n scripts/historical-semgrep-version` — syntax OK
- [x] Local dry-run of the version selection produces real candidates: `1.152.0 1.153.0 1.154.0`
- [ ] CI's `rules-test-historical` job goes green on this PR


Made with [Cursor](https://cursor.com)