### PR TITLE
java.spring.tainted-url-host: cover RestTemplate, WebClient, Apache HttpClient (#3819)

### DIFF
--- a/java/spring/security/injection/tainted-url-host.java
+++ b/java/spring/security/injection/tainted-url-host.java
@@ -84,3 +84,103 @@ public class User03Controller {
 
 }
 
+
+@RestController
+@RequestMapping("/proxy")
+public class ProxyController {
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    // The first positional arg of every RestTemplate request method is the URL,
+    // so a tainted @RequestParam reaching it is server-side request forgery.
+    @GetMapping("/fetch")
+    public ResponseEntity<byte[]> fetch(@RequestParam("url") String url) {
+        // ruleid: tainted-url-host
+        return restTemplate.getForEntity(url, byte[].class);
+    }
+
+    @GetMapping("/post")
+    public String proxyPost(@RequestParam("target") String target, @RequestBody String body) {
+        // ruleid: tainted-url-host
+        return restTemplate.postForObject(target, body, String.class);
+    }
+
+    @PutMapping("/replace")
+    public void proxyPut(@RequestParam("target") String target, @RequestBody String body) {
+        // ruleid: tainted-url-host
+        restTemplate.put(target, body);
+    }
+
+    @DeleteMapping("/wipe")
+    public void proxyDelete(@RequestParam("target") String target) {
+        // ruleid: tainted-url-host
+        restTemplate.delete(target);
+    }
+
+    @GetMapping("/exchange")
+    public ResponseEntity<String> proxyExchange(@RequestParam("target") String target) {
+        // ruleid: tainted-url-host
+        return restTemplate.exchange(target, HttpMethod.GET, null, String.class);
+    }
+}
+
+
+@RestController
+@RequestMapping("/uri")
+public class UriController {
+
+    // java.net.URI / java.net.URL constructed directly from request data.
+    @GetMapping("/parse")
+    public String parseUri(@RequestParam("url") String url) {
+        // ruleid: tainted-url-host
+        URI parsed = URI.create(url);
+        return parsed.toString();
+    }
+
+    @GetMapping("/parse-fq")
+    public String parseFqUri(@RequestParam("url") String url) {
+        // ruleid: tainted-url-host
+        java.net.URI parsed = java.net.URI.create(url);
+        return parsed.toString();
+    }
+}
+
+
+@RestController
+@RequestMapping("/apache")
+public class ApacheHttpClientController {
+
+    // Apache HttpClient request constructors take the URL as the only argument.
+    @GetMapping("/get")
+    public void apacheGet(@RequestParam("url") String url) throws Exception {
+        // ruleid: tainted-url-host
+        HttpGet req = new HttpGet(url);
+        HttpClient client = HttpClients.createDefault();
+        client.execute(req);
+    }
+
+    @GetMapping("/post")
+    public void apachePost(@RequestParam("url") String url) throws Exception {
+        // ruleid: tainted-url-host
+        HttpPost req = new HttpPost(url);
+        HttpClient client = HttpClients.createDefault();
+        client.execute(req);
+    }
+}
+
+
+@RestController
+@RequestMapping("/webclient")
+public class WebClientController {
+
+    @Autowired
+    private WebClient webClient;
+
+    @GetMapping("/fetch")
+    public Mono<String> fetch(@RequestParam("url") String url) {
+        // ruleid: tainted-url-host
+        return webClient.get().uri(url).retrieve().bodyToMono(String.class);
+    }
+}
+

--- a/java/spring/security/injection/tainted-url-host.yaml
+++ b/java/spring/security/injection/tainted-url-host.yaml
@@ -27,7 +27,7 @@ rules:
       - patterns:
           - pattern-either:
               - pattern-inside: |
-                  $METHODNAME(..., @$REQ($LOOKUP) $TYPE 
+                  $METHODNAME(..., @$REQ($LOOKUP) $TYPE
                   $SOURCE,...) {
                     ...
                   }
@@ -39,10 +39,40 @@ rules:
           - metavariable-regex:
               metavariable: $REQ
               regex: (RequestBody|PathVariable|RequestParam)
+          # Numeric primitives can't carry a hostname, so exclude them so a
+          # tainted @RequestParam("id") Integer that only ever ends up in the
+          # path/query is not flagged as host-level SSRF.
+          - metavariable-regex:
+              metavariable: $TYPE
+              regex: ^(?!(Integer|Long|Float|Double|Char|Boolean|int|long|float|double|char|boolean))
           - pattern: $SOURCE
     pattern-sinks:
     - pattern-either:
       - pattern: new URL($ONEARG)
+      - pattern: java.net.URI.create($ONEARG)
+      - pattern: URI.create($ONEARG)
+      # Spring RestTemplate. Every overload that takes a URL takes it as the
+      # first positional argument, so any tainted value reaching that
+      # position is a sink hit.
+      - pattern: $RT.getForObject($ONEARG, ...)
+      - pattern: $RT.getForEntity($ONEARG, ...)
+      - pattern: $RT.postForObject($ONEARG, ...)
+      - pattern: $RT.postForEntity($ONEARG, ...)
+      - pattern: $RT.put($ONEARG, ...)
+      - pattern: $RT.delete($ONEARG, ...)
+      - pattern: $RT.patchForObject($ONEARG, ...)
+      - pattern: $RT.exchange($ONEARG, ...)
+      # Spring 6 WebClient and Java 11 HttpRequest builders.
+      - pattern: $WC.uri($ONEARG)
+      - pattern: $REQB.uri($ONEARG)
+      # Apache HttpClient request constructors.
+      - pattern: new org.apache.http.client.methods.HttpGet($ONEARG)
+      - pattern: new org.apache.http.client.methods.HttpPost($ONEARG)
+      - pattern: new HttpGet($ONEARG)
+      - pattern: new HttpPost($ONEARG)
+      - pattern: new HttpPut($ONEARG)
+      - pattern: new HttpDelete($ONEARG)
+      - pattern: new HttpPatch($ONEARG)
       - patterns:
         - pattern-either:
           - pattern: |


### PR DESCRIPTION
## Summary

Closes #3819 (\"False negatives: common pattern missed in tainted-url-host\", filed by @9iang22).

The Java Spring \`tainted-url-host\` rule was flagging tainted user input flowing into \`new URL()\` or a string-concat / \`String.format\` URL build, but missed the **most common** SSRF entry point in Spring apps: passing the tainted URL straight into a \`RestTemplate\`, \`WebClient\`, or Apache \`HttpClient\` request method. The reproducer in the issue (a \`RestTemplate.getForEntity(url, ...)\` against \`@RequestParam String url\`) is exactly the case missed.

## New sinks

```yaml
- pattern: $RT.getForObject($ONEARG, ...)
- pattern: $RT.getForEntity($ONEARG, ...)
- pattern: $RT.postForObject($ONEARG, ...)
- pattern: $RT.postForEntity($ONEARG, ...)
- pattern: $RT.put($ONEARG, ...)
- pattern: $RT.delete($ONEARG, ...)
- pattern: $RT.patchForObject($ONEARG, ...)
- pattern: $RT.exchange($ONEARG, ...)
- pattern: $WC.uri($ONEARG)         # Spring 6 WebClient
- pattern: $REQB.uri($ONEARG)       # Java 11 HttpRequest.Builder
- pattern: new HttpGet($ONEARG)     # Apache HttpClient
- pattern: new HttpPost($ONEARG)
- pattern: new HttpPut($ONEARG)
- pattern: new HttpDelete($ONEARG)
- pattern: new HttpPatch($ONEARG)
- pattern: new org.apache.http.client.methods.HttpGet($ONEARG)
- pattern: new org.apache.http.client.methods.HttpPost($ONEARG)
- pattern: java.net.URI.create($ONEARG)
- pattern: URI.create($ONEARG)
```

I deliberately did NOT add a generic \`client.execute($ARG, ...)\` sink — it produced duplicate findings on flows that the new sinks already catch on the request-builder line (and would also overlap with non-RestTemplate types like Apache's CloseableHttpClient).

## New source-side filter

To keep the new sinks aligned with the rule's HOST-injection intent, I added a \`metavariable-regex\` on \`\$TYPE\` that excludes numeric primitive types from being treated as taint sources:

```yaml
- metavariable-regex:
    metavariable: \$TYPE
    regex: ^(?!(Integer|Long|Float|Double|Char|Boolean|int|long|float|double|char|boolean))
```

Without this, an \`@RequestParam(\"id\") Integer id\` that only ever ends up in the path or query of a RestTemplate URL would be flagged as host-level SSRF — the existing \`String.format\` sink already protected against that via its \`http(s?)://%(v|s|q).*\` regex on the format string, but the new RestTemplate sinks have no equivalent. Excluding numeric primitives at the source matches the spirit of the rule's HOST-only intent. The two pre-existing \`// ok:\` cases in \`tainted-url-host.java\` (which thread an \`Integer id\` through \`String.format(\"http://%s/...?id=%d\", \"demo-provider\", id)\`) still pass after this change.

## Test cases

\`tainted-url-host.java\` is extended with 4 new \`@RestController\` classes (\`ProxyController\`, \`UriController\`, \`ApacheHttpClientController\`, \`WebClientController\`) covering 11 new \`// ruleid:\` cases:

- RestTemplate: getForEntity, postForObject, put, delete, exchange
- URI.create (both \`URI.create\` and fully qualified \`java.net.URI.create\`)
- Apache HttpClient: \`new HttpGet\`, \`new HttpPost\`
- WebClient: \`webClient.get().uri(...)\`

```
$ semgrep --config java/spring/security/injection/tainted-url-host.yaml \\
         java/spring/security/injection/tainted-url-host.java --test
1/1: ✓ All tests passed
```

## Notes for reviewers

- I noticed the rule's existing message contains \`runnig\` (typo for \`running\`) and \`hardcode\` (missing comma before). Left those alone in this PR to keep the diff focused; happy to fix in a follow-up if you'd prefer one PR.
- The Apache HttpClient FQCN patterns target only the most common method classes; HEAD/OPTIONS/TRACE constructors are intentionally omitted because they take \`URI\` or \`String\` and are far less common in practical SSRF surfaces.