### PR TITLE
Add rule: unguarded pickle deserialization in MLflow (GHSA-cxjq-35gw-4m9f)

### DIFF
--- a/python/mlflow/security/tests/unguarded-pickle-deserialization.py
+++ b/python/mlflow/security/tests/unguarded-pickle-deserialization.py
@@ -1,0 +1,38 @@
+import pickle
+import cloudpickle
+from mlflow.exceptions import MlflowException
+from mlflow.environment_variables import MLFLOW_ALLOW_PICKLE_DESERIALIZATION
+
+def load_model_v1(path):
+    with open(path, "rb") as f:
+        # ruleid: python.mlflow.security.unguarded-pickle-deserialization
+        return pickle.load(f)
+
+def deserialize_bytes(data: bytes):
+    # ruleid: python.mlflow.security.unguarded-pickle-deserialization
+    return pickle.loads(data)
+
+def load_cloudpickle_model(path):
+    with open(path, "rb") as f:
+        # ruleid: python.mlflow.security.unguarded-pickle-deserialization
+        return cloudpickle.load(f)
+
+def load_model_safe_v1(path):
+    if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+        raise MlflowException("Disabled.")
+    with open(path, "rb") as f:
+        # ok: python.mlflow.security.unguarded-pickle-deserialization
+        return pickle.load(f)
+
+def load_cloudpickle_safe(path):
+    if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+        raise MlflowException("Disabled.")
+    with open(path, "rb") as f:
+        # ok: python.mlflow.security.unguarded-pickle-deserialization
+        return cloudpickle.load(f)
+
+def safe_loads(data: bytes):
+    if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+        raise MlflowException("Disabled.")
+    # ok: python.mlflow.security.unguarded-pickle-deserialization
+    return pickle.loads(data)

--- a/python/mlflow/security/unguarded-pickle-deserialization.yaml
+++ b/python/mlflow/security/unguarded-pickle-deserialization.yaml
@@ -1,0 +1,59 @@
+rules:
+  - id: python.mlflow.security.unguarded-pickle-deserialization
+    metadata:
+      author: Kartik Nair
+      category: security
+      confidence: MEDIUM
+      cwe:
+        - "CWE-502: Deserialization of Untrusted Data"
+      ghsa: GHSA-cxjq-35gw-4m9f
+      impact: HIGH
+      likelihood: MEDIUM
+      references:
+        - https://github.com/advisories/GHSA-cxjq-35gw-4m9f
+        - https://cwe.mitre.org/data/definitions/502.html
+      subcategory:
+        - vuln
+      technology:
+        - mlflow
+        - python
+    message: >
+      Unsafe pickle/cloudpickle deserialization detected without the
+      MLFLOW_ALLOW_PICKLE_DESERIALIZATION guard. Deserializing untrusted
+      pickle data allows arbitrary code execution (CWE-502).
+      Related advisory: GHSA-cxjq-35gw-4m9f
+    severity: ERROR
+    languages:
+      - python
+    patterns:
+      - pattern-either:
+          - pattern: pickle.load(...)
+          - pattern: pickle.loads(...)
+          - pattern: cloudpickle.load(...)
+      - pattern-inside: |
+          def $FUNC(...):
+              ...
+      - pattern-not-inside: |
+          def $FUNC(...):
+              ...
+              if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+                  ...
+              ...
+      - pattern-not-inside: |
+          def $FUNC(...):
+              ...
+              if MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get() == False:
+                  ...
+              ...
+      - pattern-not-inside: |
+          def $FUNC(...):
+              ...
+              if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION:
+                  ...
+              ...
+    fix: |
+      if not MLFLOW_ALLOW_PICKLE_DESERIALIZATION.get():
+          raise MlflowException(
+              "Deserialization of untrusted pickle data is disabled. "
+              "Set MLFLOW_ALLOW_PICKLE_DESERIALIZATION=true to opt in.",
+          )


### PR DESCRIPTION
## Summary
Adds a Semgrep rule to detect unguarded pickle/cloudpickle deserialization 
in MLflow codebases that bypass the MLFLOW_ALLOW_PICKLE_DESERIALIZATION guard.

## Background
MLflow added MLFLOW_ALLOW_PICKLE_DESERIALIZATION as a security guard — every 
pickle load in the codebase should check it before proceeding. This rule 
detects functions that call pickle.load, pickle.loads, or cloudpickle.load 
without the guard.

This rule was written following discovery of GHSA-cxjq-35gw-4m9f — an 
incomplete fix where MLflow added the guard to one class but missed 
_load_from_pickle() in the LangChain integration.

## Rule details
- Detects: pickle.load, pickle.loads, cloudpickle.load without guard
- Language: Python
- Severity: ERROR
- CWE-502: Deserialization of Untrusted Data
- Advisory: GHSA-cxjq-35gw-4m9f

## Testing
1/1 tests passing via semgrep --test