### PR TITLE
Add sqlite3-sqli: detect SQL injection via string formatting in Python sqlite3

### DIFF
--- a/python/lang/security/audit/sqli/sqlite3-sqli.py
+++ b/python/lang/security/audit/sqli/sqlite3-sqli.py
@@ -1,0 +1,25 @@
+import sqlite3
+
+conn = sqlite3.connect("example.db")
+cur = conn.cursor()
+
+user_id = input("Enter ID: ")
+name = input("Enter name: ")
+
+# ruleid: sqlite3-sqli
+cur.execute("SELECT * FROM users WHERE id = " + user_id)
+
+# ruleid: sqlite3-sqli
+cur.execute("SELECT * FROM users WHERE name = '%s'" % name)
+
+# ruleid: sqlite3-sqli
+cur.execute(f"SELECT * FROM users WHERE name = '{name}'")
+
+# ruleid: sqlite3-sqli
+cur.execute("SELECT * FROM users WHERE name = '{}'".format(name))
+
+# ok: sqlite3-sqli
+cur.execute("SELECT * FROM users WHERE id = ?", (user_id,))
+
+# ok: sqlite3-sqli
+cur.execute("SELECT * FROM users WHERE name = ?", (name,))

--- a/python/lang/security/audit/sqli/sqlite3-sqli.yaml
+++ b/python/lang/security/audit/sqli/sqlite3-sqli.yaml
@@ -1,0 +1,84 @@
+rules:
+- id: sqlite3-sqli
+  languages:
+  - python
+  message: >-
+    Detected string concatenation with a non-literal variable in a sqlite3
+    Python SQL statement. This could lead to SQL injection if the variable
+    is user-controlled and not properly sanitized. In order to prevent SQL
+    injection, use parameterized queries instead.
+    For example: 'cur.execute("SELECT * FROM table WHERE id=?", (user_id,))'
+  metadata:
+    cwe:
+    - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command\
+      \ ('SQL Injection')"
+    references:
+    - https://docs.python.org/3/library/sqlite3.html#sqlite3-placeholders
+    category: security
+    technology:
+    - sqlite3
+    owasp:
+    - A01:2017 - Injection
+    - A03:2021 - Injection
+    - A05:2025 - Injection
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - audit
+    likelihood: LOW
+    impact: HIGH
+    confidence: LOW
+  patterns:
+  - pattern-either:
+    - patterns:
+      - pattern: $CUR.$METHOD(..., $QUERY, ...)
+      - pattern-either:
+        - pattern-inside: |
+            $QUERY = $X + $Y
+            ...
+        - pattern-inside: |
+            $QUERY += $X
+            ...
+        - pattern-inside: |
+            $QUERY = '...'.format(...)
+            ...
+        - pattern-inside: |
+            $QUERY = '...' % (...)
+            ...
+        - pattern-inside: |
+            $QUERY = f'...{$USERINPUT}...'
+            ...
+      - pattern-not-inside: |
+          $QUERY += "..."
+          ...
+      - pattern-not-inside: |
+          $QUERY = "..." + "..."
+          ...
+      - pattern-not-inside: |
+          $QUERY = '...'.format()
+          ...
+      - pattern-not-inside: |
+          $QUERY = '...' % ()
+          ...
+    - pattern: $CUR.$METHOD(..., $X + $Y, ...)
+    - pattern: $CUR.$METHOD(..., '...'.format(...), ...)
+    - pattern: $CUR.$METHOD(..., '...' % (...), ...)
+    - pattern: $CUR.$METHOD(..., f'...{$USERINPUT}...', ...)
+  - pattern-either:
+    - pattern-inside: |
+        $CONN = sqlite3.connect(...)
+        ...
+        $CUR = $CONN.cursor(...)
+        ...
+    - pattern-inside: |
+        $CONN = sqlite3.connect(...)
+        ...
+        with $CONN:
+          ...
+  - pattern-not: $CUR.$METHOD(..., "..." + "...", ...)
+  - pattern-not: $CUR.$METHOD(..., '...'.format(), ...)
+  - pattern-not: $CUR.$METHOD(..., '...'%(), ...)
+  - metavariable-regex:
+      metavariable: $METHOD
+      regex: ^(execute|executemany|executescript)$
+  severity: WARNING


### PR DESCRIPTION
## Summary

Added a new Semgrep rule to detect SQL injection vulnerabilities in Python 
code using the built-in `sqlite3` module.

## What this rule detects

Detects string concatenation, %-formatting, f-strings, and .format() usage 
inside `sqlite3` cursor methods (`execute`, `executemany`, `executescript`).

## Why this matters

The `sqlite3` module is Python's standard library database interface and is 
widely used in tutorials, small apps, and beginner projects. Unlike psycopg2, 
asyncpg, aiopg, and pg8000 — which already have dedicated SQLi rules — sqlite3 
had no coverage.

## Test cases

- ✅ 4 true positives detected (string concat, %, f-string, .format)
- ✅ 2 true negatives ignored (parameterized queries with `?`)

## References

- https://docs.python.org/3/library/sqlite3.html#sqlite3-placeholders
- https://cwe.mitre.org/data/definitions/89.html