### PR TITLE
Add lgpd-cpf-exposure: detect CPF PII exposure violating Brazilian LGPD

### DIFF
--- a/python/lang/security/audit/lgpd/lgpd-cpf-exposure.py
+++ b/python/lang/security/audit/lgpd/lgpd-cpf-exposure.py
@@ -1,0 +1,30 @@
+import logging
+
+def get_cpf_from_db():
+    return "123.456.789-00"
+
+cpf_usuario = get_cpf_from_db()
+
+# ruleid: lgpd-cpf-hardcoded
+cpf = "123.456.789-00"
+
+# ruleid: lgpd-cpf-hardcoded
+cpf_fixo = "123.456.789-00"
+
+# ruleid: lgpd-cpf-logged
+logging.info(f"Processando CPF: {cpf_usuario}")
+
+# ruleid: lgpd-cpf-logged
+logging.debug("CPF: " + cpf_usuario)
+
+# ruleid: lgpd-cpf-logged
+print(f"CPF do usuário: {cpf_usuario}")
+
+# ruleid: lgpd-cpf-logged
+print("CPF: " + cpf_usuario)
+
+# ok: lgpd-cpf-logged
+logging.info("Processando usuário ID: %s", user_id)
+
+# ok: lgpd-cpf-hardcoded
+cpf_mascarado = "***.***.789-**"

--- a/python/lang/security/audit/lgpd/lgpd-cpf-exposure.yaml
+++ b/python/lang/security/audit/lgpd/lgpd-cpf-exposure.yaml
@@ -1,0 +1,65 @@
+rules:
+- id: lgpd-cpf-logged
+  languages:
+  - python
+  message: >-
+    Possível exposição de CPF em logs. Sob a LGPD (Lei Geral de Proteção de
+    Dados - Lei nº 13.709/2018), CPF é dado pessoal sensível e não deve ser
+    registrado em logs sem anonimização ou mascaramento. Considere mascarar
+    o CPF antes de logar, por exemplo: '***.***.789-**'.
+  metadata:
+    cwe:
+    - "CWE-532: Insertion of Sensitive Information into Log File"
+    references:
+    - https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm
+    - https://www.gov.br/anpd/pt-br
+    category: security
+    technology:
+    - python
+    owasp:
+    - A09:2021 - Security Logging and Monitoring Failures
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+  severity: WARNING
+  pattern-either:
+  - pattern: logging.$METHOD(..., $X + $CPF, ...)
+  - pattern: logging.$METHOD(f"...{$CPF}...")
+  - pattern: logging.$METHOD("...".format(..., $CPF, ...))
+  - pattern: print($CPF)
+  - pattern: print(f"...{$CPF}...")
+  - pattern: print("..." + $CPF)
+  - pattern: print("...".format(..., $CPF, ...))
+
+- id: lgpd-cpf-hardcoded
+  languages:
+  - python
+  message: >-
+    CPF hardcoded detectado no código-fonte. Sob a LGPD (Lei nº 13.709/2018),
+    dados pessoais como CPF não devem ser incluídos diretamente no código.
+    Remova o CPF do código e utilize variáveis de ambiente ou banco de dados.
+  metadata:
+    cwe:
+    - "CWE-312: Cleartext Storage of Sensitive Information"
+    references:
+    - https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm
+    category: security
+    technology:
+    - python
+    owasp:
+    - A02:2021 - Cryptographic Failures
+    subcategory:
+    - audit
+    likelihood: HIGH
+    impact: HIGH
+    confidence: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+  severity: ERROR
+  patterns:
+  - pattern: $X = "$CPF"
+  - metavariable-regex:
+      metavariable: $CPF
+      regex: '^\d{3}\.\d{3}\.\d{3}-\d{2}$'


### PR DESCRIPTION
## Summary

Added Semgrep rules to detect exposure of CPF (Cadastro de Pessoas Físicas),
Brazil's national ID number, which is classified as personal data under the
LGPD (Lei Geral de Proteção de Dados - Lei nº 13.709/2018).

This is the first LGPD-specific ruleset in semgrep-rules.

## Rules added

- `lgpd-cpf-hardcoded`: Detects CPF numbers hardcoded directly in source
  code using regex validation of the XXX.XXX.XXX-XX format (ERROR severity)
- `lgpd-cpf-logged`: Detects CPF variables being exposed via logging or
  print statements without masking (WARNING severity)

## Why this matters

Brazil's LGPD went into effect in 2020 and applies to any company processing
personal data of Brazilian residents. The CPF is explicitly classified as
personal data under Art. 5. Exposing CPF in logs or source code can result
in fines of up to 2% of revenue (capped at R$50M per violation).

There are currently no LGPD-specific rules in semgrep-rules, leaving
Brazilian developers without automated compliance checking.

## Test cases

- ✅ CPF hardcoded as string literal detected
- ✅ CPF logged via logging.info/debug detected
- ✅ CPF exposed via print() detected
- ✅ Masked CPF (***.***.789-**) not flagged
- ✅ Non-CPF variables in logs not flagged

## References

- https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm
- https://www.gov.br/anpd/pt-br
- https://cwe.mitre.org/data/definitions/532.html
- https://cwe.mitre.org/data/definitions/312.html