### PR TITLE
python/fastapi: add subprocess-shell-injection rule for command injection via shell=True

### DIFF
--- a/python/fastapi/security/injection/command/subprocess-shell-injection.yaml
+++ b/python/fastapi/security/injection/command/subprocess-shell-injection.yaml
@@ -1,0 +1,61 @@
+rules:
+  - id: subprocess-shell-injection
+    languages:
+      - python
+    severity: ERROR
+    message: >
+      Detected user-controlled input from a FastAPI route passed to a subprocess
+      call with `shell=True`. This allows an attacker to inject arbitrary OS
+      commands. Pass arguments as a list and remove `shell=True`, or use
+      `shlex.quote()` to sanitize the input before use.
+    metadata:
+      cwe:
+        - "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+      owasp:
+        - A01:2017 - Injection
+        - A03:2021 - Injection
+      references:
+        - https://owasp.org/www-community/attacks/Command_Injection
+        - https://docs.python.org/3/library/subprocess.html#security-considerations
+      category: security
+      technology:
+        - fastapi
+      cwe2022-top25: true
+      cwe2021-top25: true
+      subcategory:
+        - vuln
+      likelihood: HIGH
+      impact: HIGH
+      confidence: HIGH
+    pattern-either:
+      # subprocess.run / call / check_call / check_output with shell=True and f-string
+      - patterns:
+          - pattern: subprocess.$FUNC(<... shell=True ...>, ...)
+          - pattern-either:
+              - pattern-inside: |
+                  @$APP.$METHOD($ROUTE)
+                  async def $HANDLER(..., $INPUT: $TYPE, ...):
+                    ...
+                    subprocess.$FUNC(<... $INPUT ...>, shell=True, ...)
+              - pattern-inside: |
+                  @$APP.$METHOD($ROUTE)
+                  def $HANDLER(..., $INPUT: $TYPE, ...):
+                    ...
+                    subprocess.$FUNC(<... $INPUT ...>, shell=True, ...)
+          - pattern-not: subprocess.$FUNC([...], shell=True, ...)
+
+      # subprocess.Popen with shell=True and route param
+      - patterns:
+          - pattern: subprocess.Popen(<... shell=True ...>, ...)
+          - pattern-either:
+              - pattern-inside: |
+                  @$APP.$METHOD($ROUTE)
+                  async def $HANDLER(..., $INPUT: $TYPE, ...):
+                    ...
+                    subprocess.Popen(<... $INPUT ...>, shell=True, ...)
+              - pattern-inside: |
+                  @$APP.$METHOD($ROUTE)
+                  def $HANDLER(..., $INPUT: $TYPE, ...):
+                    ...
+                    subprocess.Popen(<... $INPUT ...>, shell=True, ...)
+          - pattern-not: subprocess.Popen([...], shell=True, ...)

--- a/python/fastapi/security/injection/command/subprocess-shell-injection_test.py
+++ b/python/fastapi/security/injection/command/subprocess-shell-injection_test.py
@@ -1,0 +1,49 @@
+import subprocess
+from fastapi import FastAPI, Query
+from typing import Annotated
+
+app = FastAPI()
+
+
+# ruleid: subprocess-shell-injection
+@app.get("/ping")
+async def ping(host: str):
+    subprocess.run(f"ping -c 1 {host}", shell=True)
+
+
+# ruleid: subprocess-shell-injection
+@app.get("/run")
+def run_command(cmd: str = Query(...)):
+    subprocess.call("ls " + cmd, shell=True)
+
+
+# ruleid: subprocess-shell-injection
+@app.post("/check")
+async def check_host(target: str):
+    result = subprocess.check_output(f"nmap {target}", shell=True)
+    return {"output": result}
+
+
+# ruleid: subprocess-shell-injection
+@app.get("/popen")
+def open_proc(filename: str):
+    proc = subprocess.Popen(f"cat {filename}", shell=True)
+    return {"pid": proc.pid}
+
+
+# ok: subprocess-shell-injection
+@app.get("/safe-list")
+async def safe_ping(host: str):
+    subprocess.run(["ping", "-c", "1", host], shell=False)
+
+
+# ok: subprocess-shell-injection
+@app.get("/safe-no-shell")
+def safe_run(filename: str):
+    subprocess.run(["cat", filename])
+
+
+# ok: subprocess-shell-injection
+@app.get("/hardcoded")
+def hardcoded():
+    subprocess.run("uptime", shell=True)

--- a/python/lang/security/audit/lgpd/lgpd-cpf-exposure.py
+++ b/python/lang/security/audit/lgpd/lgpd-cpf-exposure.py
@@ -1,0 +1,30 @@
+import logging
+
+def get_cpf_from_db():
+    return "123.456.789-00"
+
+cpf_usuario = get_cpf_from_db()
+
+# ruleid: lgpd-cpf-hardcoded
+cpf = "123.456.789-00"
+
+# ruleid: lgpd-cpf-hardcoded
+cpf_fixo = "123.456.789-00"
+
+# ruleid: lgpd-cpf-logged
+logging.info(f"Processando CPF: {cpf_usuario}")
+
+# ruleid: lgpd-cpf-logged
+logging.debug("CPF: " + cpf_usuario)
+
+# ruleid: lgpd-cpf-logged
+print(f"CPF do usuário: {cpf_usuario}")
+
+# ruleid: lgpd-cpf-logged
+print("CPF: " + cpf_usuario)
+
+# ok: lgpd-cpf-logged
+logging.info("Processando usuário ID: %s", user_id)
+
+# ok: lgpd-cpf-hardcoded
+cpf_mascarado = "***.***.789-**"

--- a/python/lang/security/audit/lgpd/lgpd-cpf-exposure.yaml
+++ b/python/lang/security/audit/lgpd/lgpd-cpf-exposure.yaml
@@ -1,0 +1,65 @@
+rules:
+- id: lgpd-cpf-logged
+  languages:
+  - python
+  message: >-
+    Possível exposição de CPF em logs. Sob a LGPD (Lei Geral de Proteção de
+    Dados - Lei nº 13.709/2018), CPF é dado pessoal sensível e não deve ser
+    registrado em logs sem anonimização ou mascaramento. Considere mascarar
+    o CPF antes de logar, por exemplo: '***.***.789-**'.
+  metadata:
+    cwe:
+    - "CWE-532: Insertion of Sensitive Information into Log File"
+    references:
+    - https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm
+    - https://www.gov.br/anpd/pt-br
+    category: security
+    technology:
+    - python
+    owasp:
+    - A09:2021 - Security Logging and Monitoring Failures
+    subcategory:
+    - audit
+    likelihood: MEDIUM
+    impact: MEDIUM
+    confidence: LOW
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+  severity: WARNING
+  pattern-either:
+  - pattern: logging.$METHOD(..., $X + $CPF, ...)
+  - pattern: logging.$METHOD(f"...{$CPF}...")
+  - pattern: logging.$METHOD("...".format(..., $CPF, ...))
+  - pattern: print($CPF)
+  - pattern: print(f"...{$CPF}...")
+  - pattern: print("..." + $CPF)
+  - pattern: print("...".format(..., $CPF, ...))
+
+- id: lgpd-cpf-hardcoded
+  languages:
+  - python
+  message: >-
+    CPF hardcoded detectado no código-fonte. Sob a LGPD (Lei nº 13.709/2018),
+    dados pessoais como CPF não devem ser incluídos diretamente no código.
+    Remova o CPF do código e utilize variáveis de ambiente ou banco de dados.
+  metadata:
+    cwe:
+    - "CWE-312: Cleartext Storage of Sensitive Information"
+    references:
+    - https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm
+    category: security
+    technology:
+    - python
+    owasp:
+    - A02:2021 - Cryptographic Failures
+    subcategory:
+    - audit
+    likelihood: HIGH
+    impact: HIGH
+    confidence: HIGH
+    license: Commons Clause License Condition v1.0[LGPL-2.1-only]
+  severity: ERROR
+  patterns:
+  - pattern: $X = "$CPF"
+  - metavariable-regex:
+      metavariable: $CPF
+      regex: '^\d{3}\.\d{3}\.\d{3}-\d{2}$'


### PR DESCRIPTION
## Summary

Adds a new Semgrep rule to detect command injection vulnerabilities in Python FastAPI applications via `subprocess` calls with `shell=True` and user-controlled input from route parameters.

## What this rule detects

When a FastAPI route parameter (path, query, or body) is passed directly into any of the following subprocess functions with `shell=True`:
- `subprocess.run`
- `subprocess.call`
- `subprocess.check_call`
- `subprocess.check_output`
- `subprocess.Popen`

## Why FastAPI specifically

Rules for Django and Flask already exist in this repo. FastAPI has no command injection coverage despite being one of the most widely adopted Python web frameworks today, especially in ML/AI projects where developers may not have a security background.

## True positives (ruleid)

- f-string interpolation of route param into shell command
- string concatenation of query param into shell command
- `check_output` with route param and `shell=True`
- `Popen` with route param and `shell=True`

## False positives avoided (ok)

- Safe list-based argument passing: `["ping", "-c", "1", host]`
- Calls without `shell=True`
- Hardcoded commands with `shell=True` (no user input)