### PR TITLE
Add oauth-state-unsigned-base64 rule for unsigned OAuth state forgery

### DIFF
--- a/javascript/lang/security/oauth-state-unsigned-base64.js
+++ b/javascript/lang/security/oauth-state-unsigned-base64.js
@@ -1,0 +1,33 @@
+const crypto = require("node:crypto");
+
+// --- vulnerable ---
+
+function callbackBad(req) {
+  const state = req.query.state;
+  // ruleid: oauth-state-unsigned-base64
+  const decoded = JSON.parse(Buffer.from(state, "base64").toString("utf-8"));
+  return decoded.organization_id;
+}
+
+function callbackBadBrowser(req) {
+  const state = req.query.state;
+  // ruleid: oauth-state-unsigned-base64
+  const decoded = JSON.parse(atob(state));
+  return decoded.organization_id;
+}
+
+// --- safe: HMAC-verified before deserialization ---
+
+const SECRET = process.env.OAUTH_STATE_SECRET;
+
+function callbackGood(req) {
+  const raw = req.query.state;
+  const [body, sig] = raw.split(".");
+  const expected = crypto.createHmac("sha256", SECRET).update(body).digest("hex");
+  if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+    return null;
+  }
+  // ok: oauth-state-unsigned-base64
+  const decoded = JSON.parse(Buffer.from(body, "base64").toString("utf-8"));
+  return decoded.organization_id;
+}

--- a/javascript/lang/security/oauth-state-unsigned-base64.js
+++ b/javascript/lang/security/oauth-state-unsigned-base64.js
@@ -1,33 +1,76 @@
 const crypto = require("node:crypto");
 
-// --- vulnerable ---
+// --- vulnerable: state from query, deserialized without verification ---
 
-function callbackBad(req) {
+function callbackBadExpress(req) {
+  // ruleid: oauth-state-unsigned-base64
+  const decoded = JSON.parse(Buffer.from(req.query.state, "base64").toString("utf-8"));
+  return decoded.organization_id;
+}
+
+function callbackBadExpressIndirect(req) {
   const state = req.query.state;
   // ruleid: oauth-state-unsigned-base64
   const decoded = JSON.parse(Buffer.from(state, "base64").toString("utf-8"));
   return decoded.organization_id;
 }
 
-function callbackBadBrowser(req) {
+function callbackBadNextRouteHandler(req) {
+  const state = new URL(req.url).searchParams.get("state");
+  // ruleid: oauth-state-unsigned-base64
+  const decoded = JSON.parse(Buffer.from(state, "base64").toString());
+  return decoded.organization_id;
+}
+
+function callbackBadBrowserAtob(req) {
   const state = req.query.state;
   // ruleid: oauth-state-unsigned-base64
   const decoded = JSON.parse(atob(state));
   return decoded.organization_id;
 }
 
-// --- safe: HMAC-verified before deserialization ---
+// --- false-positive guard: unrelated timingSafeEqual must NOT suppress ---
+
+function callbackBadWithUnrelatedTimingSafeEqual(req, expectedApiKey) {
+  const apiKey = req.headers["x-api-key"];
+  if (!crypto.timingSafeEqual(Buffer.from(apiKey), Buffer.from(expectedApiKey))) {
+    return null;
+  }
+  // ruleid: oauth-state-unsigned-base64
+  const decoded = JSON.parse(Buffer.from(req.query.state, "base64").toString("utf-8"));
+  return decoded.organization_id;
+}
+
+// --- false-positive guard: ordinary base64-JSON parsing of non-state input ---
+
+function decodeConfig(configBlob) {
+  // ok: oauth-state-unsigned-base64
+  return JSON.parse(Buffer.from(configBlob, "base64").toString("utf-8"));
+}
+
+// --- safe: state value is HMAC-verified before deserialization ---
 
 const SECRET = process.env.OAUTH_STATE_SECRET;
 
 function callbackGood(req) {
-  const raw = req.query.state;
-  const [body, sig] = raw.split(".");
-  const expected = crypto.createHmac("sha256", SECRET).update(body).digest("hex");
-  if (!crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+  const state = req.query.state;
+  const expected = crypto.createHmac("sha256", SECRET).update(state).digest();
+  const provided = Buffer.from(req.query.sig, "hex");
+  if (!crypto.timingSafeEqual(Buffer.from(state), expected) || !provided) {
     return null;
   }
   // ok: oauth-state-unsigned-base64
-  const decoded = JSON.parse(Buffer.from(body, "base64").toString("utf-8"));
+  const decoded = JSON.parse(Buffer.from(state, "base64").toString("utf-8"));
   return decoded.organization_id;
+}
+
+// --- safe: state delivered as signed JWT, verified before use ---
+
+const jwt = require("jsonwebtoken");
+
+function callbackGoodJwt(req) {
+  const state = req.query.state;
+  const payload = jwt.verify(state, SECRET);
+  // ok: oauth-state-unsigned-base64
+  return JSON.parse(Buffer.from(payload.body, "base64").toString("utf-8")).organization_id;
 }

--- a/javascript/lang/security/oauth-state-unsigned-base64.yaml
+++ b/javascript/lang/security/oauth-state-unsigned-base64.yaml
@@ -1,13 +1,15 @@
 rules:
 - id: oauth-state-unsigned-base64
+  mode: taint
   message: >-
     OAuth `state` parameter is being deserialized from base64-encoded
-    JSON without an adjacent HMAC verification. An unauthenticated
+    JSON without HMAC verification of the same value. An unauthenticated
     attacker can forge `state` values to inject arbitrary identifiers
     (e.g. `organization_id`, `tenant_id`) into the OAuth callback and
     bind their own third-party account into a victim's tenant. Sign
-    `state` with an HMAC on the authorization endpoint and verify the
-    signature on the callback before deserializing.
+    `state` with an HMAC (or use a signed/encrypted token) on the
+    authorization endpoint and verify the signature on the callback
+    before deserializing.
   metadata:
     cwe:
     - 'CWE-345: Insufficient Verification of Data Authenticity'
@@ -31,19 +33,25 @@ rules:
   - javascript
   - typescript
   severity: ERROR
-  patterns:
-  - pattern-either:
-    - pattern: JSON.parse(Buffer.from($STATE, "base64").toString(...))
-    - pattern: JSON.parse(atob($STATE))
-  - pattern-not-inside: |
-      {
-        ...
-        $H = createHmac(...);
-        ...
-      }
-  - pattern-not-inside: |
-      {
-        ...
-        timingSafeEqual(...);
-        ...
-      }
+  pattern-sources:
+  - patterns:
+    - pattern-either:
+      - pattern: $REQ.query.state
+      - pattern: $REQ.body.state
+      - pattern: $REQ.query["state"]
+      - pattern: $REQ.body["state"]
+      - pattern: $X.searchParams.get("state")
+      - pattern: $X.searchParams.get('state')
+  pattern-sinks:
+  - patterns:
+    - pattern-either:
+      - pattern: JSON.parse(Buffer.from($X, "base64").toString(...))
+      - pattern: JSON.parse(Buffer.from($X, "base64").toString())
+      - pattern: JSON.parse(atob($X))
+  pattern-sanitizers:
+  - patterns:
+    - pattern-either:
+      - pattern: crypto.timingSafeEqual(...)
+      - pattern: timingSafeEqual(...)
+      - pattern: jwt.verify(...)
+      - pattern: $JWT.verify(...)

--- a/javascript/lang/security/oauth-state-unsigned-base64.yaml
+++ b/javascript/lang/security/oauth-state-unsigned-base64.yaml
@@ -1,0 +1,49 @@
+rules:
+- id: oauth-state-unsigned-base64
+  message: >-
+    OAuth `state` parameter is being deserialized from base64-encoded
+    JSON without an adjacent HMAC verification. An unauthenticated
+    attacker can forge `state` values to inject arbitrary identifiers
+    (e.g. `organization_id`, `tenant_id`) into the OAuth callback and
+    bind their own third-party account into a victim's tenant. Sign
+    `state` with an HMAC on the authorization endpoint and verify the
+    signature on the callback before deserializing.
+  metadata:
+    cwe:
+    - 'CWE-345: Insufficient Verification of Data Authenticity'
+    - 'CWE-352: Cross-Site Request Forgery (CSRF)'
+    owasp:
+    - A01:2021 - Broken Access Control
+    - A01:2025 - Broken Access Control
+    references:
+    - https://datatracker.ietf.org/doc/html/rfc6749#section-10.12
+    - https://shippedwithbugs.com/writeups/outrank
+    category: security
+    technology:
+    - oauth
+    - javascript
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: MEDIUM
+  languages:
+  - javascript
+  - typescript
+  severity: ERROR
+  patterns:
+  - pattern-either:
+    - pattern: JSON.parse(Buffer.from($STATE, "base64").toString(...))
+    - pattern: JSON.parse(atob($STATE))
+  - pattern-not-inside: |
+      {
+        ...
+        $H = createHmac(...);
+        ...
+      }
+  - pattern-not-inside: |
+      {
+        ...
+        timingSafeEqual(...);
+        ...
+      }


### PR DESCRIPTION
## Summary

Adds a new rule under `javascript/lang/security/` that detects OAuth `state` parameters being deserialized from base64-encoded JSON without an adjacent HMAC verification.

When an OAuth flow uses `state` to round-trip identifiers (such as `organization_id` or `tenant_id`) across the authorization redirect, the `state` must be integrity-protected. Otherwise an attacker who knows or guesses a victim's identifiers can construct a `state` value from scratch and inject it into the callback — binding their own third-party account into the victim's tenant.

This pattern is most commonly observed in Next.js / Node SaaS apps that hand-roll OAuth handlers (rather than going through `passport` / `next-auth` / `iron-session`, which sign `state` by default).

## Real-world context

This exact pattern was identified in a 2026 vulnerability disclosure against an AI SEO SaaS where:

1. `/api/integrations/notion/auth` accepted an `organization_id` in the body and returned a Notion OAuth URL with `state = base64(JSON.stringify({ organization_id, ... }))` — no HMAC.
2. `/api/integrations/notion/callback` decoded `state` directly via `JSON.parse(Buffer.from(state, "base64").toString())` and used the embedded `organization_id` to persist a Notion access token — with no session check and no signature verification.

Result: an unauthenticated attacker could bind their own Notion workspace into any victim org by constructing the `state` themselves.

Full writeup: https://shippedwithbugs.com/writeups/outrank

## Detection

The rule matches:

- `JSON.parse(Buffer.from($STATE, "base64").toString(...))` (Node)
- `JSON.parse(atob($STATE))` (browser / edge runtime)

and is suppressed when the enclosing scope contains a sibling `createHmac(...)` or `timingSafeEqual(...)` call — i.e. the developer is verifying the signature before deserializing.

## Files

- `javascript/lang/security/oauth-state-unsigned-base64.yaml` — the rule
- `javascript/lang/security/oauth-state-unsigned-base64.js` — two vulnerable cases and one safe case

## Notes

- Severity set to `ERROR` because exploitation is unauthenticated and the consequence is cross-tenant account binding.
- Placed under `javascript/lang/security/` since the pattern is framework-agnostic (any Node/edge handler that base64-decodes `state` without HMAC).
- Happy to refine the `pattern-not-inside` shape if maintainers prefer a tighter scope (e.g. JWT-verify or named state-validation helpers).

References:
- RFC 6749 §10.12 — CSRF in OAuth `state`: https://datatracker.ietf.org/doc/html/rfc6749#section-10.12
- Writeup with real-world impact analysis: https://shippedwithbugs.com/writeups/outrank