### PR TITLE
fix(jjwt-none-alg): scope signWith check to same builder chain

### DIFF
--- a/java/jjwt/security/jwt-none-alg.java
+++ b/java/jjwt/security/jwt-none-alg.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.security.Keys;
 
 public class App
 {
+    private static boolean shouldSign = true;
 
     private static void bad1() {
         // ruleid: jjwt-none-alg
@@ -23,6 +24,22 @@ public class App
                 .setSubject("Bob")
                 .signWith(key)
                 .compact();
+    }
+
+    private static void bad2_conditional() {
+        String jws;
+        if (shouldSign) {
+            Key key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
+            jws = Jwts.builder()
+                    .setSubject("Bob")
+                    .signWith(key)
+                    .compact();
+        } else {
+            // ruleid: jjwt-none-alg
+            jws = Jwts.builder()
+                    .setSubject("Bob")
+                    .compact();
+        }
     }
 
     public static void main( String[] args )

--- a/java/jjwt/security/jwt-none-alg.yaml
+++ b/java/jjwt/security/jwt-none-alg.yaml
@@ -34,9 +34,5 @@ rules:
   patterns:
   - pattern: |
       io.jsonwebtoken.Jwts.builder();
-  - pattern-not-inside: |-
-      $RETURNTYPE $FUNC(...) {
-        ...
-        $JWTS.signWith(...);
-        ...
-      }
+  - pattern-not-inside: |
+      io.jsonwebtoken.Jwts.builder().....signWith(...);


### PR DESCRIPTION
Problem: The rule's pattern-not-inside checks for `signWith()` at the method scope. This means a `builder()` call in one branch gets incorrectly treated as safe if `signWith()` exists in another branch of the same method which is producing a false negative.

Proposed Fix: Replaced the method-scoped pattern-not-inside with a chain-scoped deep ellipsis pattern `(Jwts.builder().....signWith(...))` that only excludes the match when `signWith()` is chained on the same `builder()` call.

Also added a regression test (`bad2_conditional`) covering the conditional branch case.