### PR TITLE
fix: asyncpg SQLi rule query-argument matching

### DIFF
--- a/python/lang/security/audit/sqli/asyncpg-sqli.py
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.py
@@ -69,6 +69,10 @@ def bad11(conn: asyncpg.Connection):
     # ruleid: asyncpg-sqli
     cur = conn.fetch(common.bad_query_1.format(user_input))
 
+def bad12(conn: asyncpg.Connection, user_input):
+    # ruleid: asyncpg-sqli
+    cur = conn.fetch(query=f'SELECT * FROM {user_input}')
+
 def ok1(user_input):
     con = await asyncpg.connect(user='postgres')
     # ok: asyncpg-sqli
@@ -130,3 +134,12 @@ def ok11(user_input):
     # ok: asyncpg-sqli
     stmt = await con.prepare('SELECT ($1::int, $2::text)')
     print(stmt.get_parameters())
+
+async def ok12(conn: asyncpg.Connection, task_id, row, e):
+    # ok: asyncpg-sqli
+    await conn.execute(
+        "UPDATE atlassian.scheduled_tasks SET status = 'failed', attempts = $2, last_error = $3 WHERE id = $1",
+        task_id,
+        row["attempts"] + 1,
+        str(e),
+    )

--- a/python/lang/security/audit/sqli/asyncpg-sqli.yaml
+++ b/python/lang/security/audit/sqli/asyncpg-sqli.yaml
@@ -34,7 +34,9 @@ rules:
   patterns:
   - pattern-either:
     - patterns:
-      - pattern: $CONN.$METHOD(...,$QUERY,...)
+      - pattern-either:
+        - pattern: $CONN.$METHOD($QUERY, ...)
+        - pattern: $CONN.$METHOD(query=$QUERY, ...)
       - pattern-either:
         - pattern-inside: |
             $QUERY = $X + $Y
@@ -63,11 +65,16 @@ rules:
       - pattern-not-inside: |
           $QUERY = '...' % ()
           ...
-    - pattern: $CONN.$METHOD(..., $X + $Y, ...)
-    - pattern: $CONN.$METHOD(..., $Y.format(...), ...)
-    - pattern: $CONN.$METHOD(..., '...'.format(...), ...)
-    - pattern: $CONN.$METHOD(..., '...' % (...), ...)
-    - pattern: $CONN.$METHOD(..., f'...{$USERINPUT}...', ...)
+    - pattern: $CONN.$METHOD($X + $Y, ...)
+    - pattern: $CONN.$METHOD(query=$X + $Y, ...)
+    - pattern: $CONN.$METHOD($Y.format(...), ...)
+    - pattern: $CONN.$METHOD(query=$Y.format(...), ...)
+    - pattern: $CONN.$METHOD('...'.format(...), ...)
+    - pattern: $CONN.$METHOD(query='...'.format(...), ...)
+    - pattern: $CONN.$METHOD('...' % (...), ...)
+    - pattern: $CONN.$METHOD(query='...' % (...), ...)
+    - pattern: $CONN.$METHOD(f'...{$USERINPUT}...', ...)
+    - pattern: $CONN.$METHOD(query=f'...{$USERINPUT}...', ...)
   - pattern-either:
     - pattern-inside: |
         $CONN = await asyncpg.connect(...)
@@ -87,9 +94,12 @@ rules:
     - pattern-inside: |
         def $FUNCNAME(..., $CONN: asyncpg.Connection, ...):
             ...
-  - pattern-not: $CONN.$METHOD(..., "..." + "...", ...)
-  - pattern-not: $CONN.$METHOD(..., '...'.format(), ...)
-  - pattern-not: $CONN.$METHOD(..., '...'%(), ...)
+  - pattern-not: $CONN.$METHOD("..." + "...", ...)
+  - pattern-not: $CONN.$METHOD(query="..." + "...", ...)
+  - pattern-not: $CONN.$METHOD('...'.format(), ...)
+  - pattern-not: $CONN.$METHOD(query='...'.format(), ...)
+  - pattern-not: $CONN.$METHOD('...'%(), ...)
+  - pattern-not: $CONN.$METHOD(query='...'%(), ...)
   - metavariable-regex:
       metavariable: $METHOD
       regex: ^(fetch|fetchrow|fetchval|execute|executemany|prepare|cursor|copyfromquery)$


### PR DESCRIPTION
Updates `python.lang.security.audit.sqli.asyncpg-sqli` so dynamic SQL patterns only match the asyncpg query argument, not later bound parameter arguments.

Previously, patterns like:

```yaml
$CONN.$METHOD(..., $X + $Y, ...)
```

could match safe parameter expressions such as `row["attempts"] + 1` in:

```python
await conn.execute("UPDATE ... attempts = $2 WHERE id = $1", task_id, row["attempts"] + 1)
```

This caused false positives on correctly parameterized asyncpg queries.

## Changes

- Restrict inline dynamic SQL patterns to the first positional query argument.
- Add matching support for `query=...` keyword usage.
- Add a regression `ok` test for safe asyncpg parameter interpolation.
- Add a positive test for dynamic SQL passed via `query=f"...{user_input}..."`.

## Test plan

- `uvx --from semgrep semgrep test --config python/lang/security/audit/sqli/asyncpg-sqli.yaml python/lang/security/audit/sqli/asyncpg-sqli.py`
- `uvx --from semgrep semgrep validate python`