### PR TITLE
feat: add MyBatis-Plus SQL injection detection rules

### DIFF
--- a/java/mybatis/security/mybatis-plus-apply-user-input.java
+++ b/java/mybatis/security/mybatis-plus-apply-user-input.java
@@ -1,0 +1,45 @@
+package testcode.mybatis;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+
+public class MyBatisPlusApplyTest {
+
+    public void badCases() {
+        QueryWrapper<User> wrapper = new QueryWrapper<>();
+        String dateFunc = "DATE_FORMAT(create_time,'%Y-%m-%d')";
+
+        // ruleid:mybatis-plus-apply-user-input
+        wrapper.apply(dateFunc);
+
+        // ruleid:mybatis-plus-apply-user-input
+        wrapper.apply("status = " + getStatus());
+
+        String customSql = "id IN (SELECT id FROM other_table)";
+        // ruleid:mybatis-plus-apply-user-input
+        wrapper.apply(customSql);
+
+        // ruleid:mybatis-plus-apply-user-input
+        new QueryWrapper<User>().apply(getDynamicCondition());
+    }
+
+    public void goodCases() {
+        QueryWrapper<User> wrapper = new QueryWrapper<>();
+
+        // ok:mybatis-plus-apply-user-input
+        wrapper.apply("DATE_FORMAT(create_time,'%Y-%m-%d') = '2024-01-01'");
+
+        // ok:mybatis-plus-apply-user-input
+        wrapper.apply("status = 1");
+
+        // ok:mybatis-plus-apply-user-input
+        new QueryWrapper<User>().apply("1 = 1");
+    }
+
+    private String getStatus() { return "ACTIVE"; }
+    private String getDynamicCondition() { return "deleted = 0"; }
+}
+
+class User {
+    private Long id;
+    private String name;
+}

--- a/java/mybatis/security/mybatis-plus-apply-user-input.yaml
+++ b/java/mybatis/security/mybatis-plus-apply-user-input.yaml
@@ -1,0 +1,34 @@
+rules:
+  - id: mybatis-plus-apply-user-input
+    languages:
+      - java
+    severity: ERROR
+    message: >-
+      MyBatis-Plus QueryWrapper apply() method received a non-literal argument.
+      The apply() method concatenates raw SQL fragments into the query without
+      parameterization. If the argument contains user-controllable input, it can
+      lead to SQL injection. Use eq(), ne(), like(), in() and other safe
+      condition-building methods instead, or validate and escape inputs before
+      passing them to apply().
+    metadata:
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      category: security
+      technology:
+        - mybatis-plus
+      owasp:
+        - A01:2017 - Injection
+        - A03:2021 - Injection
+      references:
+        - https://baomidou.com/guides/wrapper/#apply
+        - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+      subcategory:
+        - vuln
+      likelihood: MEDIUM
+      impact: HIGH
+      confidence: HIGH
+      vulnerability_class:
+        - SQL Injection
+    patterns:
+      - pattern: $X.apply(...)
+      - pattern-not-regex: '\.apply\s*\(\s*"[^"]*"\s*\)'

--- a/java/mybatis/security/mybatis-plus-dynamic-sql-concat.java
+++ b/java/mybatis/security/mybatis-plus-dynamic-sql-concat.java
@@ -1,0 +1,45 @@
+package testcode.mybatis;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+
+public class MyBatisPlusDynamicSqlConcatTest {
+
+    public void badCases() {
+        QueryWrapper<User> wrapper = new QueryWrapper<>();
+        String columnName = "user_name";
+        String orderCol = "create_time";
+
+        // ruleid:mybatis-plus-dynamic-sql-concat
+        wrapper.eq(columnName + " = ", "test");
+
+        // ruleid:mybatis-plus-dynamic-sql-concat
+        wrapper.orderByAsc(orderCol + " ASC");
+
+        // ruleid:mybatis-plus-dynamic-sql-concat
+        wrapper.groupBy(orderCol + ", status");
+
+        // ruleid:mybatis-plus-dynamic-sql-concat
+        wrapper.orderByDesc("user" + columnName);
+    }
+
+    public void goodCases() {
+        QueryWrapper<User> wrapper = new QueryWrapper<>();
+
+        // ok:mybatis-plus-dynamic-sql-concat
+        wrapper.eq("user_name", "admin");
+
+        // ok:mybatis-plus-dynamic-sql-concat
+        wrapper.orderByAsc("create_time");
+
+        // ok:mybatis-plus-dynamic-sql-concat
+        wrapper.groupBy("status", "type");
+
+        // ok:mybatis-plus-dynamic-sql-concat
+        wrapper.orderByDesc("id");
+    }
+}
+
+class User {
+    private Long id;
+    private String name;
+}

--- a/java/mybatis/security/mybatis-plus-dynamic-sql-concat.yaml
+++ b/java/mybatis/security/mybatis-plus-dynamic-sql-concat.yaml
@@ -1,0 +1,47 @@
+rules:
+  - id: mybatis-plus-dynamic-sql-concat
+    languages:
+      - java
+    severity: WARNING
+    message: >-
+      MyBatis-Plus QueryWrapper condition method received a dynamically
+      concatenated string argument for column/table names. If the concatenated
+      content originates from user input, it may allow SQL injection via
+      column name manipulation. Use hardcoded column names or validate
+      dynamic identifiers against a whitelist before use.
+    metadata:
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      category: security
+      technology:
+        - mybatis-plus
+      owasp:
+        - A01:2017 - Injection
+        - A03:2021 - Injection
+      references:
+        - https://baomidou.com/guides/wrapper/
+        - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+      subcategory:
+        - vuln
+      likelihood: LOW
+      impact: MEDIUM
+      confidence: MEDIUM
+      vulnerability_class:
+        - SQL Injection
+    patterns:
+      - pattern-either:
+          - pattern: $W.eq($S + ..., ...)
+          - pattern: $W.ne($S + ..., ...)
+          - pattern: $W.like($S + ..., ...)
+          - pattern: $W.in($S + ..., ...)
+          - pattern: $W.notIn($S + ..., ...)
+          - pattern: $W.between($S + ..., ...)
+          - pattern: $W.notBetween($S + ..., ...)
+          - pattern: $W.gt($S + ..., ...)
+          - pattern: $W.ge($S + ..., ...)
+          - pattern: $W.lt($S + ..., ...)
+          - pattern: $W.le($S + ..., ...)
+          - pattern: $W.orderByAsc($S + ...)
+          - pattern: $W.orderByDesc($S + ...)
+          - pattern: $W.groupBy($S + ...)
+          - pattern: $W.having($S + ..., ...)

--- a/java/mybatis/security/mybatis-plus-last-user-input.java
+++ b/java/mybatis/security/mybatis-plus-last-user-input.java
@@ -1,0 +1,43 @@
+package testcode.mybatis;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+
+public class MyBatisPlusLastTest {
+
+    public void badCases() {
+        QueryWrapper<User> wrapper = new QueryWrapper<>();
+        String sortField = "create_time";
+        String limit = "0,10";
+
+        // ruleid:mybatis-plus-last-user-input
+        wrapper.last("limit " + limit);
+
+        // ruleid:mybatis-plus-last-user-input
+        wrapper.last(sortField + " DESC");
+
+        // ruleid:mybatis-plus-last-user-input
+        new QueryWrapper<User>().last("order by " + sortField);
+
+        String orderBy = "id ASC";
+        // ruleid:mybatis-plus-last-user-input
+        wrapper.last(orderBy);
+    }
+
+    public void goodCases() {
+        QueryWrapper<User> wrapper = new QueryWrapper<>();
+
+        // ok:mybatis-plus-last-user-input
+        wrapper.last("limit 10");
+
+        // ok:mybatis-plus-last-user-input
+        wrapper.last("ORDER BY create_time DESC");
+
+        // ok:mybatis-plus-last-user-input
+        new QueryWrapper<User>().last("LIMIT 1");
+    }
+}
+
+class User {
+    private Long id;
+    private String name;
+}

--- a/java/mybatis/security/mybatis-plus-last-user-input.yaml
+++ b/java/mybatis/security/mybatis-plus-last-user-input.yaml
@@ -1,0 +1,33 @@
+rules:
+  - id: mybatis-plus-last-user-input
+    languages:
+      - java
+    severity: ERROR
+    message: >-
+      MyBatis-Plus QueryWrapper last() method received a non-literal argument.
+      The last() method appends raw SQL fragments to the end of the query without
+      parameterization. If the argument contains user-controllable input, it can
+      lead to SQL injection. Use orderBy() or orderByAsc()/orderByDesc() for
+      dynamic sorting, or ensure last() only receives hardcoded constants.
+    metadata:
+      cwe:
+        - "CWE-89: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
+      category: security
+      technology:
+        - mybatis-plus
+      owasp:
+        - A01:2017 - Injection
+        - A03:2021 - Injection
+      references:
+        - https://baomidou.com/guides/wrapper/#last
+        - https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html
+      subcategory:
+        - vuln
+      likelihood: MEDIUM
+      impact: HIGH
+      confidence: HIGH
+      vulnerability_class:
+        - SQL Injection
+    patterns:
+      - pattern: $X.last(...)
+      - pattern-not-regex: '\.last\s*\(\s*"[^"]*"\s*\)'


### PR DESCRIPTION
  ## Summary
  
  Add 3 new security rules targeting MyBatis-Plus framework APIs. These  fill a gap in the Java security rule set — no existing rules cover  MyBatis-Plus specific methods like `last()`, `apply()`, and wrapper  condition string concatenation.

  ## Rules Added
  
  | Rule | What it detects | Severity |
  |------|----------------|----------|
  | `mybatis-plus-last-user-input` | Non-literal arguments to `last()` | ERROR |
  | `mybatis-plus-apply-user-input` | Non-literal arguments to `apply()` | ERROR |
  | `mybatis-plus-dynamic-sql-concat` | String concatenation in wrapper conditions | WARNING |

  ## Why these matter

  MyBatis-Plus is a popular MyBatis extension in the Java ecosystem  (17k+ GitHub stars). Its `last()` and `apply()` methods append raw SQL  fragments without parameterization, making them common SQL injection  vectors when misused. These rules detect unsafe usage patterns.

  ## Test Coverage

  Each rule includes test files with both true positive and true  negative cases (12 findings verified).

  ## Metadata

  All rules include CWE-89, OWASP Top 10 mappings, and reference links  to the official MyBatis-Plus documentation.
