### PR TITLE
Poetry and Ruby cooldown

### DIFF
--- a/package_managers/poetry/poetry-missing-solver-min-release-age.test.toml
+++ b/package_managers/poetry/poetry-missing-solver-min-release-age.test.toml
@@ -1,0 +1,63 @@
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = 0
+
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = 3
+
+---
+# ok: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = 7
+
+---
+# ok: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = 30
+
+---
+# ok: poetry-missing-solver-min-release-age
+[virtualenvs]
+path = ".venv"
+
+---
+# ok: poetry-missing-solver-min-release-age
+[solver.sources]
+min-release-age = 0
+
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+# min-release-age = 7
+
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+lazy-wheel = true
+
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = 6
+
+---
+# ok: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = 7  # inline comment
+
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = "7d"
+
+---
+# ruleid: poetry-missing-solver-min-release-age
+[solver]
+min-release-age = false

--- a/package_managers/poetry/poetry-missing-solver-min-release-age.yaml
+++ b/package_managers/poetry/poetry-missing-solver-min-release-age.yaml
@@ -1,0 +1,40 @@
+---
+rules:
+  - id: poetry-missing-solver-min-release-age
+    message: >-
+      This poetry.toml does not set a dependency cooldown via `solver.min-release-age`.
+      Without a cooldown, Poetry may resolve newly published package versions that have
+      not yet been vetted by the community. Supply chain attacks frequently involve
+      publishing a malicious version of a popular package and waiting for it to be pulled
+      in — most are detected and removed within days. Set `min-release-age = 7` under
+      `[solver]` to require that package versions are at least 7 days old before they
+      are considered during dependency resolution.
+      Added in: v2.4.0
+    languages:
+      - generic
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/poetry.toml"
+        - "**/config.toml"
+    pattern-either:
+      - pattern-regex: '(?m)^\[solver\]\n(?:^(?!min-release-age|\[|---).*\n)*(?=^\[|^---|\z)'
+      - pattern-regex: "(?ms)^\\[solver\\](?:[^\\[]*?)min-release-age\\s*=\\s*(?P<TARGET>\"[^\"]*\"|[0-6](?:\\s|#|$)|false)"
+    metadata:
+      category: security
+      technology:
+        - poetry
+        - python
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - "A08:2021 - Software and Data Integrity Failures"
+      confidence: MEDIUM
+      likelihood: LOW
+      impact: MEDIUM
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://python-poetry.org/docs/configuration/#solvermin-release-age

--- a/package_managers/renovate/renovate-missing-minimum-release-age.test.json
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.test.json
@@ -192,6 +192,11 @@
       "matchPackageNames": ["webpack"],
       // ruleid: renovate-missing-minimum-release-age
       "minimumReleaseAge": "7 days "
+    },
+    {
+      "matchPackageNames": ["webpack"],
+      // ok: renovate-missing-minimum-release-age
+      "minimumReleaseAge": false
     }
   ]
 }

--- a/package_managers/renovate/renovate-missing-minimum-release-age.yaml
+++ b/package_managers/renovate/renovate-missing-minimum-release-age.yaml
@@ -21,6 +21,12 @@ rules:
                 "minimumReleaseAge": $AGE,
                 ...
               }
+          - pattern-not: |
+              {
+                ...,
+                "minimumReleaseAge": false,
+                ...
+              }
       # Branch 2: Present but too low
       - patterns:
           - pattern-inside: |
@@ -50,17 +56,18 @@ rules:
       Add `"minimumReleaseAge": "7 days"` within a `packageRules`
       entry to wait 7 days before proposing updates to newly
       published package versions.
+      Set `"minimumReleaseAge": false` to set an exception for minimal release age for the package rule.
       Added in: v42
-      Reference: https://docs.renovatebot.com/configuration-options/#minimumreleaseage
     languages:
       - json
     severity: MEDIUM
     paths:
       include:
         - "**/renovate.json"
+        - "**/renovate.json5"
         - "**/.renovaterc"
         - "**/.renovaterc.json"
-        - "**/renovate.json5"
+        - "**/.renovaterc.json5"
     metadata:
       category: security
       technology:

--- a/package_managers/ruby/bundler-gemfile-missing-cooldown.test.rb
+++ b/package_managers/ruby/bundler-gemfile-missing-cooldown.test.rb
@@ -1,0 +1,75 @@
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org"
+
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 6
+
+# ok: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 0
+
+# ok: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 7
+
+# ok: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 30
+
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", group: :development
+
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org" do
+  gem "rails"
+end
+
+# Block form — multiple gems, no cooldown
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org" do
+  gem "rails"
+  gem "rack"
+  gem "puma"
+end
+
+# Block form — private registry, no cooldown
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://gems.internal.company.com" do
+  gem "internal-lib"
+end
+
+# Block form — cooldown too low
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 3 do
+  gem "rails"
+end
+
+# Block form — safe cooldown
+# ok: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 7 do
+  gem "rails"
+end
+
+# Block form — explicit bypass (internal registry)
+# ok: bundler-gemfile-missing-cooldown
+source "https://gems.internal.company.com", cooldown: 0 do
+  gem "internal-lib"
+end
+
+# ok: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 7
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://gems.company.com"
+
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 1
+
+# ruleid: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: 3
+
+# If no source, cannot cooldown the package
+# ok: bundler-gemfile-missing-cooldown
+gem "private-gem", source: "https://gems.internal.company.com"
+
+# ok: bundler-gemfile-missing-cooldown
+source MY_GEM_SERVER_URL
+
+# ok: bundler-gemfile-missing-cooldown
+source "https://rubygems.org", cooldown: ENV["GEM_COOLDOWN"].to_i

--- a/package_managers/ruby/bundler-gemfile-missing-cooldown.yaml
+++ b/package_managers/ruby/bundler-gemfile-missing-cooldown.yaml
@@ -1,0 +1,54 @@
+---
+rules:
+  - id: bundler-gemfile-missing-cooldown
+    message: >-
+      A Gemfile `source` declaration without a `cooldown` (or with a cooldown
+      below 7 days) allows Bundler to resolve newly published gem versions
+      immediately, before the community has had time to detect malicious
+      releases. The May 2026 RubyGems supply-chain attack demonstrated that
+      threat actors can push compromised gem versions and have them automatically
+      pulled into builds within minutes. Add `cooldown: 7` to each public source
+      declaration so Bundler ignores gem versions published within the last 7
+      days during dependency resolution (e.g. `source "https://rubygems.org", cooldown: 7`).
+      If you operate an internal or private registry where the supply-chain risk is lower,
+      use `cooldown: 0` as an explicit bypass. Note: this feature requires
+      Bundler >= 4.0.13. Cooldown only applies during `bundle update` and
+      `bundle add`; `bundle install` with an existing lockfile is unaffected.
+    languages:
+      - ruby
+    severity: MEDIUM
+    paths:
+      include:
+        - "**/Gemfile"
+        - "**/gems.rb"
+      exclude:
+        - "**/vendor/**"
+        - "**/.bundle/**"
+    pattern-either:
+      - patterns:
+          - pattern: source "...", ...
+          - pattern-not: "source \"...\", ..., cooldown: $N, ..."
+      - patterns:
+          - pattern: "source \"...\", ..., cooldown: $N, ..."
+          - metavariable-comparison:
+              metavariable: $N
+              comparison: "$N > 0 and $N < 7"
+          - focus-metavariable: $N
+    metadata:
+      category: security
+      technology:
+        - bundler
+        - ruby
+      cwe:
+        - "CWE-829: Inclusion of Functionality from Untrusted Control Sphere"
+      owasp:
+        - "A08:2021 - Software and Data Integrity Failures"
+      confidence: MEDIUM
+      likelihood: LOW
+      impact: MEDIUM
+      subcategory:
+        - audit
+      vulnerability_class:
+        - Insecure Configuration
+      references:
+        - https://blog.rubygems.org/2026/06/03/cooldown-let-new-gems-be-vetted.html


### PR DESCRIPTION
Continuation from:
https://github.com/semgrep/semgrep-rules/pull/3805

### Poetry

Adds Poetry cooldown.  Poetry doesn't seem to look at `pyproject.toml`. I haven't actually fully tested that, but according to their documentation and looking where the setting is populated when you use `poetry config`, `poetry.toml` and `config.toml` are the spots to check.

This one's pretty simple as Poetry only allows an `int`, no `7 day` shenanigans.

### Ruby Bundler

Pretty straight forward.  Bundler doesn't have a separate field for setting exceptions, so have to go the Renovate route of allowing an in place exception.  

### Renovate

Also updated the Renovate rule to allow to set to `false` to disable minimum package age. Renovate doesn't have another field to set exclusions for packages, so the only mechanism is on the rule itself.