### PR TITLE
fix(django): stop django-no-csrf-token false positive on nested if blocks

### DIFF
--- a/python/django/security/django-no-csrf-token.html
+++ b/python/django/security/django-no-csrf-token.html
@@ -97,3 +97,36 @@
       </div>
   </div>
 </div>
+
+<!-- https://github.com/semgrep/semgrep-rules/issues/3816 -->
+<!-- csrf_token is present but the form body has a nested {% if %} wrapping a -->
+<!-- multi-line element with a {{ ... }} interpolation, followed by a sibling block. -->
+<form method="post">
+<!-- ok: django-no-csrf-token -->
+    {% csrf_token %}
+    <div>
+        {% if x %}
+            <div>
+                {{ y }}
+            </div>
+        {% endif %}
+    </div>
+    <div>
+        <button type="submit">Go</button>
+    </div>
+</form>
+
+<!-- Same nested-if shape but with NO csrf_token: must still be flagged. -->
+<!-- ruleid: django-no-csrf-token -->
+<form method="post">
+    <div>
+        {% if x %}
+            <div>
+                {{ y }}
+            </div>
+        {% endif %}
+    </div>
+    <div>
+        <button type="submit">Go</button>
+    </div>
+</form>

--- a/python/django/security/django-no-csrf-token.yaml
+++ b/python/django/security/django-no-csrf-token.yaml
@@ -12,7 +12,13 @@ rules:
       - metavariable-regex:
           metavariable: $METHOD
           regex: (?i)(post|put|delete|patch)
-      - pattern-not-inside: "<form...>...{% csrf_token %}...</form>"
+      # Exempt forms that contain {% csrf_token %} anywhere in the body. The
+      # previous "<form...>...{% csrf_token %}...</form>" generic ellipsis missed
+      # the token when the form body had a nested multi-line {% if %} block, so a
+      # form with a valid token was still flagged (issue #3816). The regex below
+      # matches an opening <form> tag followed by {% csrf_token %} before any
+      # other form boundary, so nested blocks no longer break the exemption.
+      - pattern-not-regex: '(?s)<form\b(?:(?!</?form\b).)*?\{%\s*csrf_token\s*%\}'
       - pattern-not-inside: "<form...>...{{ $VAR.csrf_token }}...</form>"
     message: Manually-created forms in django templates should specify a csrf_token to prevent CSRF attacks.
     languages: [generic]


### PR DESCRIPTION
## Link to an issue, if relevant

Fixes #3816

## What this changes

`python.django.security.django-no-csrf-token` fires on Django templates that
**do** contain `{% csrf_token %}` when the form body has a nested multi-line
`{% if %}...{% endif %}` block with a `{{ ... }}` interpolation followed by a
sibling block. This is a CWE-352 false positive: the CSRF token is present, but
the rule reports the form as unprotected anyway.

The rule runs in `generic` mode and exempted forms via a token-ellipsis pattern:

```yaml
pattern-not-inside: "<form...>...{% csrf_token %}...</form>"
```

In generic mode that ellipsis does not always reach `{% csrf_token %}` through a
form body shaped like the reporter's markup, so the exemption silently fails and
the form is flagged. The reporter's own bisection confirms it: collapsing the
nested element onto one line makes the finding disappear.

## The fix

Replace the brittle ellipsis exemption with a dotall regex that matches an
opening `<form>` tag followed by `{% csrf_token %}` before any other form
boundary:

```yaml
pattern-not-regex: '(?s)<form\b(?:(?!</?form\b).)*?\{%\s*csrf_token\s*%\}'
```

The negative lookahead on `</?form\b` keeps the exemption from leaking across
sibling or nested forms, so a form that has no token of its own is still
flagged even when a later form in the same file does have one. The
`{{ $VAR.csrf_token }}` exemption is left in place.

## Tests

Added two cases to `django-no-csrf-token.html`:

- the reporter's exact nested-`{% if %}` form with `{% csrf_token %}` present,
  marked `ok:` (true negative);
- the same nested-if shape with no token, marked `ruleid:` (true positive),
  guarding against the regex over-suppressing.

`semgrep --test --config python/django/security/django-no-csrf-token.yaml python/django/security/django-no-csrf-token.html`
passes: all existing positives/negatives plus the two new cases. Before the
change the new `ok:` case fails (the rule reports the `{% csrf_token %}` line).
