### PR TITLE
fix(secrets): tighten heroku API key regex to remove false positives

### DIFF
--- a/generic/secrets/security/detected-heroku-api-key.txt
+++ b/generic/secrets/security/detected-heroku-api-key.txt
@@ -3,3 +3,11 @@ HEROKU_API_KEY = A6264401-E60A-48A9-941F-6446E78EC164
 
 # ruleid: detected-heroku-api-key
 heroku_api_key = a6264401-e60a-48a9-941f-6446e78ec164
+
+# A heroku URL on the same line as an unrelated UUID elsewhere is not a key.
+# ok: detected-heroku-api-key
+s = '"url":"https://data-api.heroku.com/dataclips/zzjmfvodnuesahmgggrggsbgxeqm.json.gz","latest_result_checksum":"9426d595c8188285c92e3115bf196526","creator_id":"99511235-ea18-409e-b0a6-880ff97d3a82"'
+
+# A heroku word far from an unrelated UUID is not a key.
+# ok: detected-heroku-api-key
+heroku app log shows request 99511235-ea18-409e-b0a6-880ff97d3a82 completed

--- a/generic/secrets/security/detected-heroku-api-key.yaml
+++ b/generic/secrets/security/detected-heroku-api-key.yaml
@@ -1,7 +1,7 @@
 rules:
 - id: detected-heroku-api-key
   pattern-regex: |-
-    [hH][eE][rR][oO][kK][uU].*[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}
+    (?i)heroku[0-9a-z\-_\t .]{0,20}[\s'"]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)['"\s=\x60]{0,5}[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}
   languages: [regex]
   message: Heroku API Key detected
   severity: ERROR


### PR DESCRIPTION
## Link to an issue, if relevant

Fixes #3733

### What this changes

`detected-heroku-api-key` matched any line that contained the word `heroku`
followed, anywhere on the line, by a UUID. The pattern was:

```
[hH][eE][rR][oO][kK][uU].*[0-9A-Fa-f]{8}-...-[0-9A-Fa-f]{12}
```

The unbounded `.*` is the problem: `heroku` and the UUID only have to share a
line, not be related. The reporter hit this with archived dataclip metadata,
where a `data-api.heroku.com` URL and an unrelated `creator_id` UUID appear in
the same JSON line:

```
"url":"https://data-api.heroku.com/dataclips/...json.gz",...,"creator_id":"99511235-ea18-409e-b0a6-880ff97d3a82"
```

### The fix

Replace the unbounded `.*` with a bounded key/value assignment context, so the
UUID has to be the assigned value of a `heroku`-prefixed key rather than just
somewhere on the line. This reuses the same proximity window and operator set
already used by the sibling `gitleaks/heroku-api-key` rule:

```
(?i)heroku[0-9a-z\-_\t .]{0,20}[\s'"]{0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)['"\s=\x60]{0,5}[0-9A-Fa-f]{8}-...-[0-9A-Fa-f]{12}
```

True positives (`HEROKU_API_KEY = <uuid>`) still match. The false-positive JSON
line, and a `heroku` word sitting far from an unrelated UUID, no longer match.

### Tests

`detected-heroku-api-key.txt` keeps the two existing `# ruleid:` true positives
and adds two `# ok:` true negatives: the exact repro from the issue and a
distant-UUID case.

```
semgrep --test --config detected-heroku-api-key.yaml detected-heroku-api-key.txt
1/1: All tests passed
```

(Before the regex change, the two `# ok:` lines were reported as findings.)

### Note on the HRKU- format

A commenter noted that the auth tokens Heroku writes to `.netrc` look like
`HRKU-[0-9A-Za-z]{60}`, which is unrelated to the UUID shape this rule keys on.
Adding `HRKU-` detection would be a separate enhancement; this PR is scoped to
removing the false positive in the existing UUID-based rule without dropping its
current true positives.
