### PR TITLE
fix(java.rmi): stop flagging RMI params of safe scalar array types

### DIFF
--- a/java/rmi/security/server-dangerous-object-deserialization.java
+++ b/java/rmi/security/server-dangerous-object-deserialization.java
@@ -36,6 +36,13 @@ public interface IBSidesServiceOK extends Remote {
    void poke(Integer attende) throws RemoteException;
 }
 
+// ok:server-dangerous-object-deserialization
+public interface IBSidesServiceArrayOK extends Remote {
+   boolean registerTicket(String[] ticketIDs) throws RemoteException;
+   void vistTalk(String talkID) throws RemoteException;
+   void poke(int[] attendees) throws RemoteException;
+}
+
 public class BSidesServer {
     public static void main(String[] args) {
         try {

--- a/java/rmi/security/server-dangerous-object-deserialization.yaml
+++ b/java/rmi/security/server-dangerous-object-deserialization.yaml
@@ -70,3 +70,31 @@ rules:
         - pattern-not: short
         - pattern-not: Short
         - pattern-not: java.lang.Short
+        # Arrays of the scalar types above carry no deserialization gadget
+        # either, so exclude their array forms for consistency.
+        - pattern-not: String[]
+        - pattern-not: java.lang.String[]
+        - pattern-not: boolean[]
+        - pattern-not: Boolean[]
+        - pattern-not: java.lang.Boolean[]
+        - pattern-not: byte[]
+        - pattern-not: Byte[]
+        - pattern-not: java.lang.Byte[]
+        - pattern-not: char[]
+        - pattern-not: Character[]
+        - pattern-not: java.lang.Character[]
+        - pattern-not: double[]
+        - pattern-not: Double[]
+        - pattern-not: java.lang.Double[]
+        - pattern-not: float[]
+        - pattern-not: Float[]
+        - pattern-not: java.lang.Float[]
+        - pattern-not: int[]
+        - pattern-not: Integer[]
+        - pattern-not: java.lang.Integer[]
+        - pattern-not: long[]
+        - pattern-not: Long[]
+        - pattern-not: java.lang.Long[]
+        - pattern-not: short[]
+        - pattern-not: Short[]
+        - pattern-not: java.lang.Short[]


### PR DESCRIPTION
Fixes #3737

## What this changes

The `java.rmi.security.server-dangerous-object-deserialization` rule already trusts scalar parameter types (`String`, `int`, `Integer`, `boolean`, ...) and excludes them from the insecure-deserialization warning via a list of `pattern-not` entries on `$PARAMTYPE`. It does not exclude the **array forms** of those same types, so an RMI interface method that takes a parameter like `String[]` or `int[]` is still flagged.

As the issue points out, an array of a safe scalar carries no deserialization gadget. That is the same reasoning the rule already applies to the scalars themselves, so the array forms are excluded here for consistency:

```java
public interface IBSidesServiceOK extends Remote {
   boolean registerTicket(String[] ticketIDs) throws RemoteException; // no longer flagged
   void poke(int[] attendees) throws RemoteException;                 // no longer flagged
}
```

## Changes

- `server-dangerous-object-deserialization.yaml`: add the array forms (`String[]`, `int[]`, `Integer[]`, `java.lang.String[]`, ...) of the existing scalar exclusion list as `pattern-not` entries.
- `server-dangerous-object-deserialization.java`: add an `// ok:` interface that takes `String[]` and `int[]` params, and keep the existing `// ruleid:` cases for the genuinely dangerous `Object` / `StringBuilder` params.

## Testing

`semgrep --test` passes. Before the change the new array `// ok:` case is reported as a false positive; after it is clean, and the `Object` / `StringBuilder` `// ruleid:` cases still match.

## A note for reviewers

This mirrors the existing scalar-trust decision rather than introducing new judgment, but the call about which array types are safe to deserialize is ultimately yours. If you would rather scope this more narrowly (for example only the primitive arrays, or only `String[]`), I am happy to adjust the exclusion list to match your preference.
