### PR TITLE
fix(java): weak-random misses stored Random instances

### DIFF
--- a/java/lang/security/audit/crypto/weak-random.java
+++ b/java/lang/security/audit/crypto/weak-random.java
@@ -29,10 +29,29 @@ public class BenchmarkTest00023 extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
+    private static final java.util.Random rng = new java.util.Random();
+
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         doPost(request, response);
+    }
+
+    public int storedInstanceRandom() {
+        // ruleid: weak-random
+        return rng.nextInt();
+    }
+
+    public int localInstanceRandom() {
+        java.util.Random localRng = new java.util.Random();
+        // ruleid: weak-random
+        return localRng.nextInt();
+    }
+
+    public int secureRandomInstance() {
+        java.security.SecureRandom secureRng = new java.security.SecureRandom();
+        // ok: weak-random
+        return secureRng.nextInt();
     }
 
     @Override

--- a/java/lang/security/audit/crypto/weak-random.yaml
+++ b/java/lang/security/audit/crypto/weak-random.yaml
@@ -27,5 +27,10 @@ rules:
   pattern-either:
   - pattern: |
       new java.util.Random(...).$FUNC(...)
+  - patterns:
+    - pattern: $RNG.$FUNC(...)
+    - metavariable-type:
+        metavariable: $RNG
+        type: java.util.Random
   - pattern: |
       java.lang.Math.random(...)


### PR DESCRIPTION
Fixes #3732

## Problem

The `java.lang.security.audit.crypto.weak-random` rule only matched the inline form:

```java
new java.util.Random().nextInt();
```

It missed the very common stored-instance case reported in #3732, where a `java.util.Random` is assigned to a field or local variable and used later:

```java
private static final java.util.Random rng = new java.util.Random();

public int next() {
    return rng.nextInt();   // not detected before this change
}
```

## Fix

I added one branch to the existing `pattern-either` that matches `$RNG.$FUNC(...)` and constrains `$RNG` to the `java.util.Random` type with `metavariable-type`:

```yaml
- patterns:
  - pattern: $RNG.$FUNC(...)
  - metavariable-type:
      metavariable: $RNG
      type: java.util.Random
```

The type guard is the important part. Without it, a bare `$RNG.$FUNC(...)` would flag `.nextInt()` (and similar method names) on completely unrelated types. Typing `$RNG` to `java.util.Random` keeps the new match scoped to actual `Random` instances, so there are no new false positives on, for example, `Scanner.nextInt()`. It also leaves `SecureRandom`-typed variables clean, consistent with the existing `// ok:` SecureRandom case.

I considered the broader pattern suggested in the issue (match `new java.util.Random(...)` on its own). That over-matches: a `Random` instance can be constructed without ever producing a value (or used only as a seed source for a `SecureRandom`), so flagging the constructor in isolation would add noise. Matching the actual call on a `Random`-typed receiver is the precise fix for the reported false negative.

## Tests

Added to `java/lang/security/audit/crypto/weak-random.java`:

- a stored field-instance `// ruleid:` case (`rng.nextInt()`),
- a local-variable instance `// ruleid:` case,
- a `SecureRandom` `// ok:` case to confirm the type guard does not over-match.

`semgrep --test` passes:

```
$ semgrep --test --config java/lang/security/audit/crypto/weak-random.yaml \
    java/lang/security/audit/crypto/weak-random.java
1/1: ✓ All tests passed
```
