### PR TITLE
fix: correct YAML metadata syntax errors in apex, generic, rust rules

### DIFF
--- a/apex/lang/security/ncino/dml/ApexCSRFConstructor.yaml
+++ b/apex/lang/security/ncino/dml/ApexCSRFConstructor.yaml
@@ -10,9 +10,9 @@ rules:
       owasp:
       - A01:2021 - Broken Access Control
       - A01:2025 - Broken Access Control
-      cwe2020-top25': true
-      cwe2021-top25': true
-      cwe2022-top25': true
+      'cwe2020-top25': true
+      'cwe2021-top25': true
+      'cwe2022-top25': true
       impact: HIGH
       likelihood: MEDIUM
       confidence: HIGH

--- a/apex/lang/security/ncino/dml/ApexCSRFStaticConstructor.yaml
+++ b/apex/lang/security/ncino/dml/ApexCSRFStaticConstructor.yaml
@@ -10,9 +10,9 @@ rules:
       owasp:
       - A01:2021 - Broken Access Control
       - A01:2025 - Broken Access Control
-      cwe2020-top25': true
-      cwe2021-top25': true
-      cwe2022-top25': true
+      'cwe2020-top25': true
+      'cwe2021-top25': true
+      'cwe2022-top25': true
       impact: HIGH
       likelihood: MEDIUM
       confidence: HIGH

--- a/generic/visualforce/security/ncino/html/UseSRIForCDNs.yaml
+++ b/generic/visualforce/security/ncino/html/UseSRIForCDNs.yaml
@@ -18,9 +18,9 @@ rules:
       owasp:
       - A07:2021 - Identification and Authentication Failures
       - A07:2025 - Authentication Failures
-      cwe2020-top25': true
-      cwe2021-top25': true
-      cwe2022-top25': true
+      'cwe2020-top25': true
+      'cwe2021-top25': true
+      'cwe2022-top25': true
       impact: MEDIUM
       likelihood: MEDIUM
       confidence: MEDIUM

--- a/rust/lang/security/args-os.yml
+++ b/rust/lang/security/args-os.yml
@@ -16,6 +16,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: LOW
-      subcategory: audit
+      subcategory:
+        - audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/args.yml
+++ b/rust/lang/security/args.yml
@@ -16,6 +16,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: LOW
-      subcategory: audit
+      subcategory:
+        - audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/current-exe.yml
+++ b/rust/lang/security/current-exe.yml
@@ -16,6 +16,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: LOW
-      subcategory: audit
+      subcategory:
+        - audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/insecure-hashes.yml
+++ b/rust/lang/security/insecure-hashes.yml
@@ -20,6 +20,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: MEDIUM
-      subcategory: audit
+      subcategory:
+        - audit
     languages: [rust]
     severity: WARNING

--- a/rust/lang/security/reqwest-accept-invalid.yml
+++ b/rust/lang/security/reqwest-accept-invalid.yml
@@ -15,6 +15,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: MEDIUM
-      subcategory: vuln
+      subcategory:
+        - vuln
     languages: [rust]
     severity: WARNING

--- a/rust/lang/security/reqwest-set-sensitive.yml
+++ b/rust/lang/security/reqwest-set-sensitive.yml
@@ -39,6 +39,7 @@ rules:
       confidence: MEDIUM
       likelihood: LOW
       impact: LOW
-      subcategory: audit
+      subcategory:
+        - audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/rustls-dangerous.yml
+++ b/rust/lang/security/rustls-dangerous.yml
@@ -19,6 +19,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: MEDIUM
-      subcategory: vuln
+      subcategory:
+        - vuln
     languages: [rust]
     severity: WARNING

--- a/rust/lang/security/ssl-verify-none.yml
+++ b/rust/lang/security/ssl-verify-none.yml
@@ -12,6 +12,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: MEDIUM
-      subcategory: vuln
+      subcategory:
+        - vuln
     languages: [rust]
     severity: WARNING

--- a/rust/lang/security/temp-dir.yml
+++ b/rust/lang/security/temp-dir.yml
@@ -18,6 +18,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: LOW
-      subcategory: audit
+      subcategory:
+        - audit
     languages: [rust]
     severity: INFO

--- a/rust/lang/security/unsafe-usage.yml
+++ b/rust/lang/security/unsafe-usage.yml
@@ -12,6 +12,7 @@ rules:
       confidence: HIGH
       likelihood: LOW
       impact: LOW
-      subcategory: audit
+      subcategory:
+        - audit
     languages: [rust]
     severity: INFO


### PR DESCRIPTION
- Fix malformed field names missing opening quotes in 2 apex rules
- Fix malformed field names missing opening quotes in 1 generic rule
- Fix scalar subcategory values that should be lists in 10 rust rules