### PR TITLE
Fix command-injection-process-builder false negative on fluent ProcessBuilder().command()

### DIFF
--- a/java/lang/security/audit/command-injection-process-builder.java
+++ b/java/lang/security/audit/command-injection-process-builder.java
@@ -47,5 +47,25 @@ public class TestExecutor {
       return "foo";
     }
 
+    public String fluentTest1(String userInput) {
+      // ruleid: command-injection-process-builder
+      new ProcessBuilder().command(userInput);
+      return "foo";
+    }
+
+    public String fluentTest2(String command) {
+      try {
+        // ruleid: command-injection-process-builder
+        new ProcessBuilder().redirectErrorStream(true).command("/bin/bash", "-c", command).start();
+      } catch (Exception e) {}
+      return "foo";
+    }
+
+    public String fluentOkTest() {
+      // ok: command-injection-process-builder
+      new ProcessBuilder().command("bash", "-c", "ls");
+      return "foo";
+    }
+
 
 }

--- a/java/lang/security/audit/command-injection-process-builder.yaml
+++ b/java/lang/security/audit/command-injection-process-builder.yaml
@@ -41,6 +41,48 @@ rules:
     - pattern-not: |
         $PB.command(Arrays.asList("...",...),...)
   - patterns:
+    - pattern: |
+        $PB.command($CMD,...)
+    - metavariable-pattern:
+        metavariable: $PB
+        patterns:
+        - pattern: |
+            <... new ProcessBuilder(...) ...>
+    - pattern-not: |
+        $PB.command("...",...)
+    - pattern-not: |
+        $PB.command(new String[]{"...",...},...)
+    - pattern-not: |
+        $PB.command(Arrays.asList("...",...),...)
+  - patterns:
+    - pattern-either:
+      - pattern: |
+          $PB.command("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$ARG,...)
+      - pattern: |
+          $PB.command("cmd","/c",$ARG,...)
+      - pattern: |
+          $PB.command(Arrays.asList("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$ARG,...),...)
+      - pattern: |
+          $PB.command(Arrays.asList("cmd","/c",$ARG,...),...)
+      - pattern: |
+          $PB.command(new String[]{"=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$ARG,...},...)
+      - pattern: |
+          $PB.command(new String[]{"cmd","/c",$ARG,...},...)
+    - metavariable-pattern:
+        metavariable: $PB
+        patterns:
+        - pattern: |
+            <... new ProcessBuilder(...) ...>
+    - pattern-not-inside: |
+        $ARG = "...";
+        ...
+    - pattern-not: |
+        $PB.command("...","...","...",...)
+    - pattern-not: |
+        $PB.command(new String[]{"...","...","...",...},...)
+    - pattern-not: |
+        $PB.command(Arrays.asList("...","...","...",...),...)
+  - patterns:
     - pattern-either:
       - pattern: |
           new ProcessBuilder("=~/(sh|bash|ksh|csh|tcsh|zsh)/","-c",$ARG,...)


### PR DESCRIPTION
## What

`command-injection-process-builder` (Java) has a false negative on the fluent / chained form of `ProcessBuilder`. The two `$PB.command(...)` branches both require:

```yaml
pattern-inside: |
  $TYPE $PB = new ProcessBuilder(...);
  ...
```

so they only fire when the builder is first assigned to a local variable. The common fluent shape, where the builder is never stored in a variable, is missed:

```java
new ProcessBuilder().command(userInput);
new ProcessBuilder().redirectErrorStream(true).command("/bin/bash", "-c", command).start();
```

Neither of those is flagged today, even though they are semantically identical to the cases the rule already catches.

## Fix

Adds two branches that match `.command(...)` when the receiver is a chain that begins with `new ProcessBuilder(...)`, instead of requiring a prior variable assignment. The receiver is matched with a `metavariable-pattern` deep-expression match (`<... new ProcessBuilder(...) ...>`) so intermediate fluent calls such as `.redirectErrorStream(true)` between the constructor and `.command(...)` do not break the match.

The new branches reuse the exact same scalar-literal guards as the existing variable-form branches:

- the generic branch keeps the `pattern-not` guards for `command("...")`, `command(new String[]{"..."})`, and `command(Arrays.asList("..."))`, so fully literal commands stay safe.
- the shell branch keeps the `$ARG = "..."` `pattern-not-inside` guard and the three-literal `pattern-not` guards, matching the existing shell branch.

Because `<... new ProcessBuilder(...) ...>` only matches receivers that actually contain a `new ProcessBuilder`, a plain local variable (the pre-existing `$PB` form) is not re-matched, so there is no overlap or double counting with the existing branches.

## Tests

Added to `command-injection-process-builder.java`:

- `// ruleid:` `new ProcessBuilder().command(userInput);` (fluent, variable command)
- `// ruleid:` `new ProcessBuilder().redirectErrorStream(true).command("/bin/bash", "-c", command).start();` (fluent shell with an intermediate chained method)
- `// ok:` `new ProcessBuilder().command("bash", "-c", "ls");` (fluent, fully literal, stays safe)

`semgrep --test --config command-injection-process-builder.yaml command-injection-process-builder.java` passes (all prior `ruleid` / `ok` cases still pass, the new fluent cases are caught, and the literal fluent case is correctly not flagged). I also checked that an unrelated `.command()` call on a non-`ProcessBuilder` object is not flagged.

Fixes #3743

Also addresses #3814 (same fluent-chain gap; case 1 of that issue, `new ProcessBuilder().command(userInput)`, is now caught). The non-first-argument / dynamic-position variants noted in #3814 are a separate concern and are not in scope here.
