### PR TITLE
feat(dev3/gh-workflows): add dev3 to release workflows

### DIFF
--- a/.github/workflows/update-semgrep-staging-dev.yml
+++ b/.github/workflows/update-semgrep-staging-dev.yml
@@ -14,5 +14,8 @@ jobs:
     - name: update dev2.semgrep.dev
       run: curl --fail -X POST -L https://dev2.semgrep.dev/api/admin/update-registry?rule_type=sast
       continue-on-error: true
+    - name: update dev3.semgrep.dev
+      run: curl --fail -X POST -L https://dev3.semgrep.dev/api/admin/update-registry?rule_type=sast
+      continue-on-error: true
     - name: update staging.semgrep.dev
       run: curl --fail -X POST -L https://staging.semgrep.dev/api/admin/update-registry?rule_type=sast


### PR DESCRIPTION
Uploads semgrep-rules to dev3 the same way we do for dev2, non-blocking to prod on error. 