### PR TITLE
Add fastapi pickle deserialization

### DIFF
--- a/python/fastapi/security/fastapi-pickle-deserialization.py
+++ b/python/fastapi/security/fastapi-pickle-deserialization.py
@@ -1,0 +1,57 @@
+import pickle
+import _pickle
+from fastapi import FastAPI, Request
+import json
+
+app = FastAPI()
+
+
+# TRUE POSITIVES — rule must fire
+@app.post("/load")
+async def load_data(request: Request):
+    body = await request.body()
+    # ruleid: fastapi-pickle-deserialization
+    obj = pickle.loads(body)
+    return {"result": str(obj)}
+
+
+@app.post("/load-indirect")
+async def load_indirect(request: Request):
+    raw = await request.body()
+    # ruleid: fastapi-pickle-deserialization
+    result = pickle.loads(raw)
+    return {"ok": True}
+
+
+@app.post("/load-cpickle")
+async def load_cpickle(request: Request):
+    body = await request.body()
+    # ruleid: fastapi-pickle-deserialization
+    return _pickle.loads(body)
+
+
+@app.post("/load-json-source")
+async def load_json_source(request: Request):
+    body = await request.json()
+    # ruleid: fastapi-pickle-deserialization
+    return pickle.loads(body)
+
+
+# SAFE CASES — rule must NOT fire
+@app.post("/load-safe-json")
+async def load_safe(request: Request):
+    body = await request.json()
+    # ok: fastapi-pickle-deserialization
+    return {"data": body}
+
+
+def load_from_trusted_file():
+    with open("/var/app/model.pkl", "rb") as f:
+        # ok: fastapi-pickle-deserialization
+        return pickle.load(f)
+
+
+def load_hardcoded():
+    data = b'\x80\x04\x95\x11\x00\x00\x00\x00\x00\x00\x00\x8c\x07example\x94.'
+    # ok: fastapi-pickle-deserialization
+    return pickle.loads(data)

--- a/python/fastapi/security/fastapi-pickle-deserialization.yaml
+++ b/python/fastapi/security/fastapi-pickle-deserialization.yaml
@@ -55,5 +55,7 @@ rules:
     likelihood: MEDIUM
     impact: HIGH
     confidence: HIGH
+    vulnerability_class:
+    - Insecure Deserialization
   languages: [python]
-  severity: ERROR
+  severity: HIGH

--- a/python/fastapi/security/fastapi-pickle-deserialization.yaml
+++ b/python/fastapi/security/fastapi-pickle-deserialization.yaml
@@ -1,0 +1,59 @@
+rules:
+- id: fastapi-pickle-deserialization
+  mode: taint
+  pattern-sources:
+    - patterns:
+      - pattern-either:
+        - pattern: await $REQUEST.body()
+        - pattern: await $REQUEST.json()
+        - pattern: await $REQUEST.stream()
+        - patterns:
+          - pattern-inside: |
+              @$APP.$METHOD(...)
+              async def $FUNC($REQ: Request, ...):
+                ...
+          - pattern: await $REQ.body()
+        - patterns:
+          - pattern-inside: |
+              async def $FUNC($REQ: Request, ...):
+                ...
+          - pattern: await $REQ.body()
+  pattern-sinks:
+    - patterns:
+      - pattern-either:
+        - pattern: pickle.loads($DATA)
+        - pattern: pickle.load($DATA)
+        - pattern: _pickle.loads($DATA)
+        - pattern: _pickle.load($DATA)
+      - focus-metavariable: $DATA
+  message: >-
+    Detected `pickle.loads()` called with data sourced from a FastAPI request.
+    Deserializing untrusted data with `pickle` is unsafe because a crafted
+    payload can execute arbitrary Python code on the server during unpickling.
+    An attacker who controls the request body can achieve full remote code
+    execution (RCE). Replace `pickle` with a safe serialization format such
+    as `json.loads()`, or if binary serialization is required, use `msgpack`
+    with strict schema validation. Never deserialize `pickle` data from an
+    untrusted client.
+  metadata:
+    owasp:
+    - A08:2017 - Insecure Deserialization
+    - A08:2021 - Software and Data Integrity Failures
+    cwe:
+    - "CWE-502: Deserialization of Untrusted Data"
+    references:
+    - https://docs.python.org/3/library/pickle.html
+    - https://owasp.org/www-community/vulnerabilities/Deserialization_of_untrusted_data
+    category: security
+    technology:
+    - python
+    - fastapi
+    cwe2022-top25: true
+    cwe2021-top25: true
+    subcategory:
+    - vuln
+    likelihood: MEDIUM
+    impact: HIGH
+    confidence: HIGH
+  languages: [python]
+  severity: ERROR


### PR DESCRIPTION
Description:
## Summary

Adds a taint-mode rule detecting `pickle.loads()` and `pickle.load()` called
with data sourced from a FastAPI HTTP request (`request.body()`, `request.json()`,
`request.stream()`). This proves attacker-controlled data reaches the unsafe sink,
making it a confirmed vulnerability rather than an audit finding.

## Rule details

- **Rule ID:** `python.fastapi.security.fastapi-pickle-deserialization`
- **Language:** Python
- **Framework:** FastAPI
- **Severity:** `HIGH`
- **Subcategory:** `vuln`
- **Confidence:** `HIGH`

## Why this fills a gap

The existing `avoid-pickle` rule is a low-confidence audit rule that flags any
`pickle` call. This rule uses taint mode to track HTTP request data directly to
`pickle.loads()`, making it `confidence: HIGH` and `subcategory: vuln`. The
`python/fastapi/security/` folder previously had only one rule.

## Vulnerability

**[CWE-502: Deserialization of Untrusted Data](https://cwe.mitre.org/data/definitions/502.html)**
**[OWASP A08:2021 – Software and Data Integrity Failures](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/)**

Deserializing untrusted data with `pickle` allows a crafted payload to execute
arbitrary Python code on the server during unpickling, leading to full RCE.

## Vulnerable code (true positive)

```python
@app.post("/load")
async def load_data(request: Request):
    body = await request.body()
    # ruleid: fastapi-pickle-deserialization
    obj = pickle.loads(body)  # attacker controls body → RCE
    return {"result": str(obj)}

Safe code (true negative)

@app.post("/load-safe")
async def load_safe(request: Request):
    body = await request.json()
    # ok: fastapi-pickle-deserialization
    return {"data": body}  # safe deserializer, no pickle

Test results

semgrep --validate → 0 errors, 1 rule found
semgrep --test     → 1/1 passed (4 true positives, 3 true negatives)

Known limitations

- Does not cover aliased imports (from pickle import loads as deserialize)
- Does not cover shelve, marshal, or jsonpickle — candidates for follow-up rules
- Taint does not track inter-procedural data flow (across function boundaries)
