### PR TITLE
Add subprocess shell=True coverage for common APIs

### DIFF
--- a/python/lang/security/audit/subprocess-shell-true.fixed.py
+++ b/python/lang/security/audit/subprocess-shell-true.fixed.py
@@ -18,3 +18,12 @@ subprocess.call("grep -R {} .".format(sys.argv[1]), shell=False, cwd="/home/user
 
 # ruleid:subprocess-shell-true
 subprocess.run("grep -R {} .".format(sys.argv[1]), shell=False)
+
+# ruleid:subprocess-shell-true
+subprocess.check_output("grep -R {} .".format(sys.argv[1]), shell=False)
+
+# ruleid:subprocess-shell-true
+subprocess.check_call("grep -R {} .".format(sys.argv[1]), shell=False)
+
+# ruleid:subprocess-shell-true
+subprocess.Popen("grep -R {} .".format(sys.argv[1]), shell=False)

--- a/python/lang/security/audit/subprocess-shell-true.py
+++ b/python/lang/security/audit/subprocess-shell-true.py
@@ -18,3 +18,9 @@ subprocess.call("grep -R {} .".format(sys.argv[1]), shell=True, cwd="/home/user"
 
 # ruleid:subprocess-shell-true
 subprocess.run("grep -R {} .".format(sys.argv[1]), shell=True)
+
+# ruleid:subprocess-shell-true
+subprocess.check_output("grep -R {} .".format(sys.argv[1]), shell=True)
+
+# ruleid:subprocess-shell-true
+subprocess.Popen("grep -R {} .".format(sys.argv[1]), shell=True)

--- a/python/lang/security/audit/subprocess-shell-true.py
+++ b/python/lang/security/audit/subprocess-shell-true.py
@@ -23,4 +23,7 @@ subprocess.run("grep -R {} .".format(sys.argv[1]), shell=True)
 subprocess.check_output("grep -R {} .".format(sys.argv[1]), shell=True)
 
 # ruleid:subprocess-shell-true
+subprocess.check_call("grep -R {} .".format(sys.argv[1]), shell=True)
+
+# ruleid:subprocess-shell-true
 subprocess.Popen("grep -R {} .".format(sys.argv[1]), shell=True)


### PR DESCRIPTION
This PR adds test coverage for `subprocess.check_output`, `subprocess.check_call`, and `subprocess.Popen` when `shell=True` is used with dynamically formatted command strings.
These examples improve coverage for command-injection-prone `subprocess` APIs covered by the `subprocess-shell-true` rule.