### PR TITLE
feat: add TypeScript rules for mcp-command-injection and mcp-ssrf

### DIFF
--- a/ai/ai-best-practices/mcp-command-injection/mcp-command-injection-typescript.ts
+++ b/ai/ai-best-practices/mcp-command-injection/mcp-command-injection-typescript.ts
@@ -1,0 +1,65 @@
+import { exec, execSync, execFile } from 'child_process';
+import * as cp from 'child_process';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+
+// --- TRUE POSITIVES ---
+
+server.tool('run-command', { command: z.string() }, async (args) => {
+    // ruleid: mcp-command-injection-typescript
+    exec(args.command, (err, stdout) => { console.log(stdout); });
+    return { content: [{ type: 'text' as const, text: 'done' }] };
+});
+
+server.tool('run-sync', { command: z.string() }, async ({ command }) => {
+    // ruleid: mcp-command-injection-typescript
+    const result = execSync(command);
+    return { content: [{ type: 'text' as const, text: result.toString() }] };
+});
+
+server.tool('eval-input', 'Evaluate an expression', { code: z.string() }, async ({ code }) => {
+    // ruleid: mcp-command-injection-typescript
+    const result = eval(code);
+    return { content: [{ type: 'text' as const, text: String(result) }] };
+});
+
+server.tool('cp-run', { cmd: z.string() }, async ({ cmd }) => {
+    // ruleid: mcp-command-injection-typescript
+    cp.exec(cmd);
+    return { content: [{ type: 'text' as const, text: 'done' }] };
+});
+
+// v2 registerTool API
+server.registerTool(
+    'run-v2',
+    { description: 'Run a command', inputSchema: z.object({ command: z.string() }) },
+    async ({ command }) => {
+        // ruleid: mcp-command-injection-typescript
+        execSync(command);
+        return { content: [{ type: 'text' as const, text: 'done' }] };
+    }
+);
+
+// --- TRUE NEGATIVES ---
+
+server.tool('list-files', {}, async () => {
+    // ok: mcp-command-injection-typescript
+    // Hardcoded string literal — not user-controlled
+    exec('ls -la /tmp', (err, stdout) => { console.log(stdout); });
+    return { content: [{ type: 'text' as const, text: 'done' }] };
+});
+
+server.tool('safe-run', { filename: z.string() }, async ({ filename }) => {
+    // ok: mcp-command-injection-typescript
+    // execFile does not invoke a shell — safe API
+    execFile('cat', [filename]);
+    return { content: [{ type: 'text' as const, text: 'done' }] };
+});
+
+// exec outside any MCP handler — not in scope for this rule
+function unrelatedFunction(cmd: string) {
+    // ok: mcp-command-injection-typescript
+    exec(cmd);
+}

--- a/ai/ai-best-practices/mcp-command-injection/mcp-command-injection-typescript.yaml
+++ b/ai/ai-best-practices/mcp-command-injection/mcp-command-injection-typescript.yaml
@@ -1,0 +1,41 @@
+rules:
+  - id: mcp-command-injection-typescript
+    languages: [javascript, typescript]
+    severity: ERROR
+    message: >-
+      A child_process execution function is called with a dynamic argument inside
+      an MCP tool handler. Tool arguments flow from LLM/user input and may carry
+      injected shell commands. Use execFile() with an explicit argument array
+      instead of exec() or execSync(), or sanitize input strictly before executing
+      shell commands.
+    metadata:
+      cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')"
+      category: security
+      confidence: MEDIUM
+      subcategory: [vuln]
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [mcp]
+      references:
+        - https://modelcontextprotocol.io/specification/draft/basic/security_best_practices
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              $SERVER.tool($NAME, ..., async (...) => {
+                ...
+              })
+          - pattern-inside: |
+              $SERVER.registerTool($NAME, ..., async (...) => {
+                ...
+              })
+      - pattern-either:
+          - pattern: exec($CMD, ...)
+          - pattern: execSync($CMD)
+          - pattern: $CP.exec($CMD, ...)
+          - pattern: $CP.execSync($CMD)
+          - pattern: eval($CMD)
+      - pattern-not: exec("...", ...)
+      - pattern-not: execSync("...")
+      - pattern-not: $CP.exec("...", ...)
+      - pattern-not: $CP.execSync("...")
+      - pattern-not: eval("...")

--- a/ai/ai-best-practices/mcp-ssrf/mcp-ssrf-typescript.ts
+++ b/ai/ai-best-practices/mcp-ssrf/mcp-ssrf-typescript.ts
@@ -1,0 +1,65 @@
+import axios from 'axios';
+import * as https from 'https';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+
+// --- TRUE POSITIVES ---
+
+server.tool('fetch-url', { url: z.string() }, async ({ url }) => {
+    // ruleid: mcp-ssrf-typescript
+    const response = await fetch(url);
+    return { content: [{ type: 'text' as const, text: await response.text() }] };
+});
+
+server.tool('get-data', { endpoint: z.string() }, async ({ endpoint }) => {
+    // ruleid: mcp-ssrf-typescript
+    const response = await axios.get(endpoint);
+    return { content: [{ type: 'text' as const, text: JSON.stringify(response.data) }] };
+});
+
+server.tool('post-data', { url: z.string(), body: z.string() }, async ({ url, body }) => {
+    // ruleid: mcp-ssrf-typescript
+    const response = await axios.post(url, { data: body });
+    return { content: [{ type: 'text' as const, text: JSON.stringify(response.data) }] };
+});
+
+server.tool('https-get', { url: z.string() }, async ({ url }) => {
+    // ruleid: mcp-ssrf-typescript
+    https.get(url, (res) => { /* ... */ });
+    return { content: [{ type: 'text' as const, text: 'requested' }] };
+});
+
+// v2 registerTool API
+server.registerTool(
+    'fetch-v2',
+    { description: 'Fetch a URL', inputSchema: z.object({ url: z.string() }) },
+    async ({ url }) => {
+        // ruleid: mcp-ssrf-typescript
+        const response = await fetch(url);
+        return { content: [{ type: 'text' as const, text: await response.text() }] };
+    }
+);
+
+// --- TRUE NEGATIVES ---
+
+server.tool('fetch-fixed', {}, async () => {
+    // ok: mcp-ssrf-typescript
+    // Hardcoded URL — not user-controlled, not SSRF
+    const response = await fetch('https://api.example.com/data');
+    return { content: [{ type: 'text' as const, text: await response.text() }] };
+});
+
+server.tool('get-fixed', {}, async () => {
+    // ok: mcp-ssrf-typescript
+    const response = await axios.get('https://api.example.com/items');
+    return { content: [{ type: 'text' as const, text: JSON.stringify(response.data) }] };
+});
+
+// fetch outside any MCP handler — not in scope for this rule
+async function unrelatedFetch(url: string) {
+    // ok: mcp-ssrf-typescript
+    const response = await fetch(url);
+    return response.text();
+}

--- a/ai/ai-best-practices/mcp-ssrf/mcp-ssrf-typescript.yaml
+++ b/ai/ai-best-practices/mcp-ssrf/mcp-ssrf-typescript.yaml
@@ -1,0 +1,47 @@
+rules:
+  - id: mcp-ssrf-typescript
+    languages: [javascript, typescript]
+    severity: ERROR
+    message: >-
+      An HTTP request is made with a dynamic URL inside an MCP tool handler.
+      Tool arguments flow from LLM/user input and may redirect requests to
+      internal network resources (SSRF). Validate and restrict URLs with an
+      allowlist before making requests — parse with new URL() and check the
+      hostname against an allowlist of permitted external origins.
+    metadata:
+      cwe: "CWE-918: Server-Side Request Forgery (SSRF)"
+      category: security
+      confidence: MEDIUM
+      subcategory: [vuln]
+      likelihood: MEDIUM
+      impact: HIGH
+      technology: [mcp]
+      references:
+        - https://modelcontextprotocol.io/specification/draft/basic/security_best_practices
+    patterns:
+      - pattern-either:
+          - pattern-inside: |
+              $SERVER.tool($NAME, ..., async (...) => {
+                ...
+              })
+          - pattern-inside: |
+              $SERVER.registerTool($NAME, ..., async (...) => {
+                ...
+              })
+      - pattern-either:
+          - pattern: fetch($URL, ...)
+          - pattern: axios.get($URL, ...)
+          - pattern: axios.post($URL, ...)
+          - pattern: axios.put($URL, ...)
+          - pattern: axios.delete($URL, ...)
+          - pattern: axios($URL, ...)
+          - pattern: $HTTPS.get($URL, ...)
+          - pattern: $HTTPS.request($URL, ...)
+      - pattern-not: fetch("...", ...)
+      - pattern-not: axios.get("...", ...)
+      - pattern-not: axios.post("...", ...)
+      - pattern-not: axios.put("...", ...)
+      - pattern-not: axios.delete("...", ...)
+      - pattern-not: axios("...", ...)
+      - pattern-not: $HTTPS.get("...", ...)
+      - pattern-not: $HTTPS.request("...", ...)


### PR DESCRIPTION
## Link to issue

Closes #3873

## What this adds

TypeScript variants of two existing Python-only MCP security rules. The official MCP SDK (`@modelcontextprotocol/sdk`) is TypeScript-first — most real-world MCP servers are written in TypeScript — but all five MCP rules in `ai/ai-best-practices/` currently fire only on Python.

This PR adds the two highest-severity rules:

- `mcp-command-injection-typescript` (CWE-78, ERROR) — flags `exec()`/`execSync()`/`eval()` with a dynamic argument inside `server.tool()` or `server.registerTool()` callbacks
- `mcp-ssrf-typescript` (CWE-918, ERROR) — flags `fetch()`/`axios.get/post/put/delete()`/`https.get()` with a dynamic URL inside MCP tool handler callbacks

Both rules cover MCP SDK v1 (`server.tool`) and v2 (`server.registerTool`) APIs. Structural patterns at MEDIUM confidence — the callback parameter taint approach was considered but structural patterns are more reliable across CI without local engine testing.

## Test results (local)

```
semgrep --test ai/ai-best-practices/mcp-command-injection/  →  2/2 ✓
semgrep --test ai/ai-best-practices/mcp-ssrf/              →  2/2 ✓
```

Each rule fires on 5 true-positive cases and correctly excludes all true-negative cases (hardcoded string literals, `execFile` with explicit args, calls outside any MCP handler).